### PR TITLE
Fixing a build error in unit tests caused by keyword redefinition

### DIFF
--- a/tests/pxScene2d/test_api.cpp
+++ b/tests/pxScene2d/test_api.cpp
@@ -1,5 +1,7 @@
 #define ENABLE_RT_NODE
 
+#include <sstream>
+
 #define private public
 #define protected public
 

--- a/tests/pxScene2d/test_imagecache.cpp
+++ b/tests/pxScene2d/test_imagecache.cpp
@@ -1,5 +1,6 @@
 
 #include <list>
+#include <sstream>
 
 #define private public
 #define protected public

--- a/tests/pxScene2d/test_jsfiles.cpp
+++ b/tests/pxScene2d/test_jsfiles.cpp
@@ -1,5 +1,7 @@
 #define ENABLE_RT_NODE
 
+#include <sstream>
+
 #define private public
 #define protected public
 #include <pxCore.h>

--- a/tests/pxScene2d/test_memoryleak.cpp
+++ b/tests/pxScene2d/test_memoryleak.cpp
@@ -1,5 +1,6 @@
 #define ENABLE_RT_NODE
 
+#include <sstream>
 
 #define private public
 #define protected public

--- a/tests/pxScene2d/test_pxAnimate.cpp
+++ b/tests/pxScene2d/test_pxAnimate.cpp
@@ -1,4 +1,5 @@
 #include <list>
+#include <sstream>
 
 #define private public
 #define protected public

--- a/tests/pxScene2d/test_pxImage.cpp
+++ b/tests/pxScene2d/test_pxImage.cpp
@@ -1,3 +1,5 @@
+#include <sstream>
+
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"  // Brings in Google Mock.
 #define private public

--- a/tests/pxScene2d/test_pxUtil.cpp
+++ b/tests/pxScene2d/test_pxUtil.cpp
@@ -1,4 +1,5 @@
 #include <list>
+#include <sstream>
 
 #define private public
 #define protected public

--- a/tests/pxScene2d/test_rtError.cpp
+++ b/tests/pxScene2d/test_rtError.cpp
@@ -1,3 +1,4 @@
+#include <sstream>
 
 #define private public
 #define protected public

--- a/tests/pxScene2d/test_rtFile.cpp
+++ b/tests/pxScene2d/test_rtFile.cpp
@@ -1,3 +1,4 @@
+#include <sstream>
 
 #define private public
 #define protected public

--- a/tests/pxScene2d/test_rtString.cpp
+++ b/tests/pxScene2d/test_rtString.cpp
@@ -1,3 +1,4 @@
+#include <sstream>
 
 #define private public
 #define protected public

--- a/tests/pxScene2d/test_rtZip.cpp
+++ b/tests/pxScene2d/test_rtZip.cpp
@@ -1,3 +1,4 @@
+#include <sstream>
 
 #define private public
 #define protected public


### PR DESCRIPTION
https://github.com/johnrobinsn/pxCore/issues/401