### PR TITLE
pxImage and pxImageA changes for issues discovered while adding tests

### DIFF
--- a/examples/pxScene2d/src/pxImage.cpp
+++ b/examples/pxScene2d/src/pxImage.cpp
@@ -105,7 +105,7 @@ rtError pxImage::setResource(rtObjectRef o)
   else 
   {
     rtLogError("Object passed as resource is not an imageResource!\n");
-     pxObject::onTextureReady();
+    pxObject::onTextureReady();
     mReady.send("reject",this);
     return RT_ERROR; 
   }

--- a/examples/pxScene2d/src/pxImage.cpp
+++ b/examples/pxScene2d/src/pxImage.cpp
@@ -105,6 +105,8 @@ rtError pxImage::setResource(rtObjectRef o)
   else 
   {
     rtLogError("Object passed as resource is not an imageResource!\n");
+     pxObject::onTextureReady();
+    mReady.send("reject",this);
     return RT_ERROR; 
   }
 

--- a/examples/pxScene2d/src/pxImageA.cpp
+++ b/examples/pxScene2d/src/pxImageA.cpp
@@ -250,6 +250,8 @@ rtError pxImageA::setResource(rtObjectRef o)
   else
   {
     rtLogError("Object passed as resource is not an imageAResource!\n");
+    pxObject::onTextureReady();
+    mReady.send("reject",this);
     return RT_ERROR;
   }
 

--- a/examples/pxScene2d/src/pxImageA.cpp
+++ b/examples/pxScene2d/src/pxImageA.cpp
@@ -72,37 +72,28 @@ rtError pxImageA::url(rtString &s) const
 
 rtError pxImageA::setUrl(const char *s)
 {
- // url = s;
- // pxObject::createNewPromise();
 
-
-
-  //if (url)
- // {
-    rtImageAResource* resourceObj = getImageAResource();
-    if( resourceObj != NULL && resourceObj->getUrl().length() > 0 && resourceObj->getUrl().compare(s))
+  rtImageAResource* resourceObj = getImageAResource();
+  if( resourceObj != NULL && resourceObj->getUrl().length() > 0 && resourceObj->getUrl().compare(s))
+  {
+    if(mImageLoaded || ((rtPromise*)mReady.getPtr())->status())
     {
-      if(mImageLoaded || ((rtPromise*)mReady.getPtr())->status())
-      {
-        mCurFrame = 0;
-        mCachedFrame = UINT32_MAX;
-        mFrameTime = -1;
-        mPlays = 0;
-        mImageWidth = 0;
-        mImageHeight = 0;
-        mImageLoaded = false;
-        pxObject::createNewPromise();
-      }
+      mCurFrame = 0;
+      mCachedFrame = UINT32_MAX;
+      mFrameTime = -1;
+      mPlays = 0;
+      mImageWidth = 0;
+      mImageHeight = 0;
+      mImageLoaded = false;
+      pxObject::createNewPromise();
     }
-    mResource = pxImageManager::getImageA(s);
+  }
+  mResource = pxImageManager::getImageA(s);
 
-    if(getImageAResource() != NULL && getImageAResource()->getUrl().length() > 0 && !mImageLoaded) {
-      mListenerAdded = true;
-      getImageAResource()->addListener(this);
-    }
- // }
- // else
- //   mReady.send("resolve", this);
+  if(getImageAResource() != NULL && getImageAResource()->getUrl().length() > 0 && !mImageLoaded) {
+    mListenerAdded = true;
+    getImageAResource()->addListener(this);
+  }
 
   return RT_OK;
 }

--- a/examples/pxScene2d/src/pxImageA.cpp
+++ b/examples/pxScene2d/src/pxImageA.cpp
@@ -59,29 +59,37 @@ void pxImageA::onInit()
 
 rtError pxImageA::url(rtString &s) const
 {
-  s = mURL;
+  if (getImageAResource() != NULL)
+  {
+    s = getImageAResource()->getUrl();
+  }
+  else
+  {
+    s = "";
+  }
   return RT_OK;
 }
 
 rtError pxImageA::setUrl(const char *s)
 {
-  mURL = s;
-  pxObject::createNewPromise();
+ // url = s;
+ // pxObject::createNewPromise();
 
-  mCurFrame = 0;
-  mCachedFrame = UINT32_MAX;
-  mFrameTime = -1;
-  mPlays = 0;
-  mImageWidth = 0;
-  mImageHeight = 0;
 
-  if (mURL)
-  {
+
+  //if (url)
+ // {
     rtImageAResource* resourceObj = getImageAResource();
     if( resourceObj != NULL && resourceObj->getUrl().length() > 0 && resourceObj->getUrl().compare(s))
     {
       if(mImageLoaded || ((rtPromise*)mReady.getPtr())->status())
       {
+        mCurFrame = 0;
+        mCachedFrame = UINT32_MAX;
+        mFrameTime = -1;
+        mPlays = 0;
+        mImageWidth = 0;
+        mImageHeight = 0;
         mImageLoaded = false;
         pxObject::createNewPromise();
       }
@@ -92,9 +100,9 @@ rtError pxImageA::setUrl(const char *s)
       mListenerAdded = true;
       getImageAResource()->addListener(this);
     }
-  }
-  else
-    mReady.send("resolve", this);
+ // }
+ // else
+ //   mReady.send("resolve", this);
 
   return RT_OK;
 }

--- a/examples/pxScene2d/src/pxImageA.h
+++ b/examples/pxScene2d/src/pxImageA.h
@@ -72,7 +72,6 @@ protected:
   pxTextureRef mTexture;
 
   double mFrameTime;
-  rtString mURL;
   pxConstantsStretch::constants mStretchX;
   pxConstantsStretch::constants mStretchY;
 

--- a/tests/pxScene2d/testRunner/tests.json
+++ b/tests/pxScene2d/testRunner/tests.json
@@ -19,5 +19,9 @@
       {"url":"../tests/test_pxAnimate.js", "title":"test_pxAnimate","useBaseURI":"true"},
       {"url":"../tests/test_pxResource.js", "title":"test_pxResource","useBaseURI":"true"},
       {"url":"../tests/test_pxWayland.js", "title":"test_pxWayland","useBaseURI":"true"},
-      {"url":"../tests/test_pxScene2d.js", "title":"test_pxScene2d","useBaseURI":"true"}
+      {"url":"../tests/test_pxScene2d.js", "title":"test_pxScene2d","useBaseURI":"true"},
+      {"url":"../tests/test_pxImage.js", "title":"test_pxImage","useBaseURI":"true"},
+      {"url":"../tests/test_pxImageA_2.js", "title":"test_pxImageA_2","useBaseURI":"true"},
+      {"url":"../tests/test_pxImage9.js", "title":"test_pxImage9","useBaseURI":"true"}
+
 ]


### PR DESCRIPTION
Reject promise if trying to assign an incompatible resource obj to 'resource' property.  Make url for pxImageA come from resource rather than separate property.