### PR TITLE
Enable compiling with llvm toolchain

### DIFF
--- a/remote/rapidjson/rapidjson.h
+++ b/remote/rapidjson/rapidjson.h
@@ -498,8 +498,12 @@ RAPIDJSON_NAMESPACE_END
 
 #ifndef RAPIDJSON_HAS_CXX11_RVALUE_REFS
 #if defined(__clang__)
-#define RAPIDJSON_HAS_CXX11_RVALUE_REFS __has_feature(cxx_rvalue_references) && \
+#if __has_feature(cxx_rvalue_references) && \
     (defined(_LIBCPP_VERSION) || defined(__GLIBCXX__) && __GLIBCXX__ >= 20080306)
+#define RAPIDJSON_HAS_CXX11_RVALUE_REFS (1)
+#else
+#define RAPIDJSON_HAS_CXX11_RVALUE_REFS (0)
+#endif
 #elif (defined(RAPIDJSON_GNUC) && (RAPIDJSON_GNUC >= RAPIDJSON_VERSION_CODE(4,3,0)) && defined(__GXX_EXPERIMENTAL_CXX0X__)) || \
       (defined(_MSC_VER) && _MSC_VER >= 1600)
 

--- a/remote/rapidjson/rapidjson.h
+++ b/remote/rapidjson/rapidjson.h
@@ -498,12 +498,14 @@ RAPIDJSON_NAMESPACE_END
 
 #ifndef RAPIDJSON_HAS_CXX11_RVALUE_REFS
 #if defined(__clang__)
+/* MODIFIED CODE BEGIN */
 #if __has_feature(cxx_rvalue_references) && \
     (defined(_LIBCPP_VERSION) || defined(__GLIBCXX__) && __GLIBCXX__ >= 20080306)
 #define RAPIDJSON_HAS_CXX11_RVALUE_REFS (1)
 #else
 #define RAPIDJSON_HAS_CXX11_RVALUE_REFS (0)
 #endif
+/* MODIFIED CODE END */
 #elif (defined(RAPIDJSON_GNUC) && (RAPIDJSON_GNUC >= RAPIDJSON_VERSION_CODE(4,3,0)) && defined(__GXX_EXPERIMENTAL_CXX0X__)) || \
       (defined(_MSC_VER) && _MSC_VER >= 1600)
 

--- a/src/rtNode.h
+++ b/src/rtNode.h
@@ -35,7 +35,9 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #ifndef PX_PLATFORM_MAC
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Werror"
+#endif
 #endif
 
 #pragma GCC diagnostic ignored "-Wall"


### PR DESCRIPTION
Rapidjson's RAPIDJSON_HAS_CXX11_RVALUE_REFS define statement was bad.
Rapidjson has fixed this in later versions.

When not compiled on a mac platform, the `#pragma gcc` statement caused
the clang build to fail.  This statement is now ignored under llvm's
toolchaein