### PR TITLE
Remove unnecessary logging

### DIFF
--- a/examples/pxScene2d/external/.gitignore
+++ b/examples/pxScene2d/external/.gitignore
@@ -13,8 +13,10 @@ libpng-1.6.28/config.log
 libpng-1.6.28/Makefile
 libpng-1.6.28/config.status
 zlib-1.2.8/example
+zlib-1.2.8/example64
 zlib-1.2.8/examplesh
 zlib-1.2.8/minigzip
+zlib-1.2.8/minigzip64
 zlib-1.2.8/minigzipsh
 libpng-1.6.28/.libs
 libpng-1.6.28/libpng16-config

--- a/examples/pxScene2d/src/browser.js
+++ b/examples/pxScene2d/src/browser.js
@@ -6,7 +6,7 @@ px.import({ scene:      'px:scene.1.js',
              keys:      'px:tools.keys.js',
              EditBox: 'browser:editbox.js'
 }).then( function importsAreReady(imports)
-{  
+{
   var url   = "";
   var helpShown = false;
 
@@ -26,7 +26,7 @@ px.import({ scene:      'px:scene.1.js',
   var contentBG = scene.create({t:"rect",  parent: bg, x:10, y:60, fillColor: 0xffffffff, a: 0.05, draw: false});
   var content   = scene.create({t:"scene", parent: bg, x:10, y:60, clip:true});
   var spinner   = scene.create({t:"image", url:"browser/images/spinningball2.png",cx:50,cy:50,y:-80,parent:bg,sx:0.3,sy:0.3,a:0.0});
-   
+
   var inputBox = new imports.EditBox( { parent: bg, url: "browser/images/input2.png", x: 10, y: 10, w: 800, h: 35, pts: 24 });
   var helpBox   = null;
 
@@ -63,7 +63,7 @@ px.import({ scene:      'px:scene.1.js',
     {
         u = "about.js";
     }
-    else        
+    else
     if (u.indexOf(':') == -1)
     {
       u = 'http://www.pxscene.org/examples/px-reference/gallery/' + u;
@@ -97,12 +97,11 @@ px.import({ scene:      'px:scene.1.js',
       content.ready.then(
         function(o)
         {
-          console.log(o);
           contentBG.draw = true;
           content.focus = true;
 
           inputBox.textColor = urlSucceededColor;
-                         
+
           inputBox.hideCursor();
           inputBox.cancelLater( function() { spinner.a = 0;} );
         },
@@ -114,7 +113,7 @@ px.import({ scene:      'px:scene.1.js',
 
           content.focus = false;
           inputBox.focus = true;
-                         
+
           inputBox.showCursor();
           inputBox.cancelLater( function() { spinner.a = 0;} );
         }
@@ -128,7 +127,7 @@ px.import({ scene:      'px:scene.1.js',
   {
     inputBox.focus = false;
     content.focus=true;
-  });  
+  });
 
   function updateSize(w,h)
   {
@@ -142,7 +141,7 @@ px.import({ scene:      'px:scene.1.js',
     content.h   = h - 70;
 
     contentBG.w = w - 20;
-    contentBG.h = h - 70;  
+    contentBG.h = h - 70;
 
     inputBox.w  = w - 20;
 
@@ -192,7 +191,6 @@ px.import({ scene:      'px:scene.1.js',
   scene.root.on("onKeyDown", function(e)
   {
     var code = e.keyCode; var flags = e.flags;
-   // console.log("onKeyDown browser.js  >> code: " + code + " key:" + keys.name(code) + " flags: " + flags);
 
     if( keys.is_CTRL_ALT( flags ) ) // CTRL-ALT keys !!
     {
@@ -220,7 +218,7 @@ px.import({ scene:      'px:scene.1.js',
       if(e.keyCode == keys.K)  //  CTRL-ALT-K
       {
         helpShown ? hideHelp(0) : showHelp(4500); // Hide / Show
-      
+
         e.stopPropagation();
     }
     }
@@ -242,7 +240,7 @@ px.import({ scene:      'px:scene.1.js',
   scene.on("onResize", function(e) { updateSize(e.w,e.h); });
 
   Promise.all([inputBox, bg, spinner, content, fontRes])
-      .catch( (err) => 
+      .catch( (err) =>
       {
           console.log(">>> Loading Assets ... err = " + err);
       })

--- a/examples/pxScene2d/src/browser/editbox.js
+++ b/examples/pxScene2d/src/browser/editbox.js
@@ -13,13 +13,13 @@ px.import({ scene: 'px:scene.1.js',
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
-// EXAMPLE:  
+// EXAMPLE:
 //
 //   var inputBox  = new EditBox( {    url:"images/input2.png",    <<<<< 9 slice Image for Background frame
-//                                  insets: {l: 10, r: 10, t: 10, b: 10}, 
-//                                  parent: bg, 
-//                                       x: 10, 
-//                                       y: 10, 
+//                                  insets: {l: 10, r: 10, t: 10, b: 10},
+//                                  parent: bg,
+//                                       x: 10,
+//                                       y: 10,
 //                                       w: 800,
 //                                       h: 35,
 //                                     pts: 24 });
@@ -70,32 +70,32 @@ px.import({ scene: 'px:scene.1.js',
             get: function () { return this._keepFocus;    },
         });
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        this._showFocus = false; // Highlight focus 
+        this._showFocus = false; // Highlight focus
         Object.defineProperty(this, "showFocus",
         {
             set: function (val) { this._showFocus = val; },
             get: function () { return this._showFocus;   },
-        });    
+        });
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         Object.defineProperty(this, "interactive",
         {
-            set: function (val) {    textInput.interactive = val; 
-                                      textView.interactive = val; 
-                                 
+            set: function (val) {    textInput.interactive = val;
+                                      textView.interactive = val;
+
                                  console.log(">>> interactive = " + val);
 
                                  },
 
             get: function () { return textInput.interactive ;      },
-        });        
+        });
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         Object.defineProperty(this, "text",
         {
-            set: function (val) { 
-                textInput.text = val;                                   
+            set: function (val) {
+                textInput.text = val;
                 prompt.a = (textInput.text.length > 0) ? 0 : 1; // show/hide placeholder
             },
-            get: function () { 
+            get: function () {
                   // Remove Leading/Trailing whitespace...
                   var txt = textInput.text.trim();
                   return txt; },
@@ -103,20 +103,20 @@ px.import({ scene: 'px:scene.1.js',
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         Object.defineProperty(this, "prompt",
         {
-            set: function (val) { 
-                prompt.text = val;                                                   
+            set: function (val) {
+                prompt.text = val;
             },
-            get: function () { 
+            get: function () {
                   // Remove Leading/Trailing whitespace...
                   var txt = prompt.text.trim();
                   return txt; },
-        });        
+        });
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         Object.defineProperty(this, "textColor",
         {
             set: function (val) { textInput.textColor = val;  },
             get: function ()    { return textInput.textColor; },
-        });        
+        });
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         this._enableCopy = true;
         Object.defineProperty(this, "enableCopy",
@@ -136,7 +136,7 @@ px.import({ scene: 'px:scene.1.js',
         // PUBLIC methods
         //
         this.moveToHome     = moveToHome;
-        this.moveToEnd      = moveToEnd;        
+        this.moveToEnd      = moveToEnd;
         this.selectAll      = selectAll;
         this.clearSelection = clearSelection;
         this.hideCursor     = hideCursor;
@@ -170,7 +170,7 @@ px.import({ scene: 'px:scene.1.js',
 
         var default_insets = {l: 10, r: 10, t: 10, b: 10};
 
-                                                 // set -OR- (default)   
+                                                 // set -OR- (default)
                     this._x =               "x" in params ? params.x               : 0;
                     this._y =               "y" in params ? params.y               : 0;
                     this._w =               "w" in params ? params.w               : 200;
@@ -195,7 +195,7 @@ px.import({ scene: 'px:scene.1.js',
 
         var inputBg = scene.create({
             t: "image9", resource: inputRes, a: 0.9, x: 0, y: 0, w: this._w, h: this._h,// insets: insets,
-            insetLeft: insets.l, insetRight: insets.r, insetTop: insets.t, insetBottom: insets.b, 
+            insetLeft: insets.l, insetRight: insets.r, insetTop: insets.t, insetBottom: insets.b,
             parent: clipRect, stretchX: ss, stretchY: ss
         });
 
@@ -221,7 +221,7 @@ px.import({ scene: 'px:scene.1.js',
                 prompt.interactive    = false;
                 selection.interactive = false;
                 cursor.interactive    = false;
-                
+
                 textInputBG.interactive = false;
 
                 onSize(self.w, self.h);
@@ -253,14 +253,14 @@ px.import({ scene: 'px:scene.1.js',
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         container.on("onMouseDown", function (e) {
-     
+
             textInput.focus = true;
         });
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         clipRect.on("onMouseDown", function (e) {
-                    
+
             if(textInput.text.length > 0)
             {
                 var now = new Date().getTime();
@@ -278,11 +278,11 @@ px.import({ scene: 'px:scene.1.js',
                 buttonDownTime = now;
             }
         });
-        
+
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        
+
         textView.on("onMouseDown", function (e) {
-     
+
             textInput.focus = true;
 
             buttonDown = true;
@@ -301,7 +301,7 @@ px.import({ scene: 'px:scene.1.js',
             {
                 selection_chars = cursor_pos - selection_start;
                 makeSelection(selection_start, selection_chars);
-            }           
+            }
             else
             {
                 selection.w = 0;
@@ -314,7 +314,7 @@ px.import({ scene: 'px:scene.1.js',
                 selection_start = cursor_pos;
             }
         });
- 
+
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         textInput.on("onMouseUp", function (e) {
@@ -326,9 +326,7 @@ px.import({ scene: 'px:scene.1.js',
 
         textView.on("onMouseEnter", function (e) {
 
-//             console.log(">>> textView.onMouseEnter   showFocus:" + showFocus );
-
-            if(showFocus)
+            if(this.showFocus)
             {
                 textInputBG.a = 0.5;
             }
@@ -338,16 +336,14 @@ px.import({ scene: 'px:scene.1.js',
 
         textView.on("onMouseLeave", function (e) {
 
-//            console.log(">>> textView.onMouseLeave   showFocus:" + showFocus + " keepFocus:  " + keepFocus);
-
-            if(showFocus)
+            if(this.showFocus)
             {
                 textInputBG.a = 0.25;
             }
 
             buttonDown = false;
 
-            if(keepFocus === false)
+            if(this.keepFocus === false)
             {
                 hideCursor();
                 clearSelection();
@@ -464,7 +460,7 @@ px.import({ scene: 'px:scene.1.js',
                         prompt.a = (textInput.text.length > 0) ? 0 : 1; // show/hide placeholder
                     }
                     break;
-                    
+
                 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
                 case keys.ENTER:   // bubble up !!
                     break;
@@ -480,7 +476,7 @@ px.import({ scene: 'px:scene.1.js',
                     break;
                 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
                 case keys.END:
-                    if (self._enableCopy && keys.is_SHIFT(e.flags)) 
+                    if (self._enableCopy && keys.is_SHIFT(e.flags))
                     {
                         selectToEnd(); // <<  SHIFT KEY + END
                     }
@@ -538,12 +534,12 @@ px.import({ scene: 'px:scene.1.js',
                         break;
                     }
 
-                    if (keys.is_CTRL(e.flags) || keys.is_CMD(e.flags)) 
+                    if (keys.is_CTRL(e.flags) || keys.is_CMD(e.flags))
                     {
                         moveToEnd(); // <<  CTRL KEY + RIGHT
                     }
                     else
-                    if (self._enableCopy && (keys.is_CTRL_SHIFT(e.flags) || keys.is_CMD_SHIFT(e.flags)) ) 
+                    if (self._enableCopy && (keys.is_CTRL_SHIFT(e.flags) || keys.is_CMD_SHIFT(e.flags)) )
                     {
                         selectToEnd(); // <<  CTRL + SHIFT KEY + RIGHT
                     }
@@ -566,17 +562,17 @@ px.import({ scene: 'px:scene.1.js',
                         {
                             clearSelection();
                         }
-                        cursor_pos++; 
+                        cursor_pos++;
                     }
                     break;
                 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-                case keys.A:   // << CTRL + A 
+                case keys.A:   // << CTRL + A
                     if (self._enableCopy && (keys.is_CTRL(e.flags) || keys.is_CMD(e.flags)) )  // ctrl Pressed also
                     {
-                        // Select All                        
+                        // Select All
                         cursor_pos = 0;
                         selection_x = textInput.x;
-                         
+
                         selection_start = 0;
                         selection_chars = textInput.text.length + 1;
 
@@ -668,10 +664,10 @@ px.import({ scene: 'px:scene.1.js',
             {
                 var mi = lo + ((hi - lo) >> 1);
 
-                snip    = array.slice(0, mi ); 
+                snip    = array.slice(0, mi );
                 metrics = fontRes.measureText(pts, snip);
 
-                if (metrics.w > x) // Test 
+                if (metrics.w > x) // Test
                 {
                     hi = mi;
                 }
@@ -697,7 +693,7 @@ px.import({ scene: 'px:scene.1.js',
             if (x <= full_w)
             {
                if(textInput.text.length > 0)
-                { 
+                {
                     var ans   = binarySearch(textInput.text, x);
 
                     var index = ans[0]; // position index
@@ -724,13 +720,13 @@ px.import({ scene: 'px:scene.1.js',
 //                        console.log(" Choose LHS");
                         index--;
                         return_x = lhs_w;
-                    }            
+                    }
                     else
                     {
 //                        console.log(" Choose RHS");
-                        return_x = rhs_w;                    
+                        return_x = rhs_w;
                     }
-                    
+
                     return [index, return_x];  // return tuple [pos,x]
                 }
             }
@@ -748,7 +744,7 @@ px.import({ scene: 'px:scene.1.js',
             var return_y = textInput.y;
 
             console.log("cursorToPoint() >>> xy: (" + return_x + "," + return_y + ")");
-        
+
             return [return_x, return_y]; // return tuple [x,y]
         }
 
@@ -762,30 +758,30 @@ px.import({ scene: 'px:scene.1.js',
 
             var clip_w    = clipRect.w - cw; // allow a little room for cursor
             var scrollBit = Math.abs(scrollBy - lastScroll);
-            
+
             lastScroll = scrollBy;
 
             // Cursor beyond 'clipRect' bounds... slide `textInput` into view
             //
-            if( cursor.x > clip_w ) // Need to Scroll ? 
+            if( cursor.x > clip_w ) // Need to Scroll ?
             {
                 if (scrollLeft)
-                {              
+                {
                     if( scrollOffset < (clip_w - cw - 20) )
-                    {  
-                        scrollOffset += scrollBit;  // Move Cursor Offset to the RIGHT 
+                    {
+                        scrollOffset += scrollBit;  // Move Cursor Offset to the RIGHT
                     }
                 }
                 else
                 if (scrollRight)
-                {                
-                    if( scrollOffset > cw) 
-                    {  
-                        scrollOffset -= scrollBit;  // Move Cursor Offset to the LEFT 
+                {
+                    if( scrollOffset > cw)
+                    {
+                        scrollOffset -= scrollBit;  // Move Cursor Offset to the LEFT
                     }
-                }   
+                }
                 textView.x = scrollBy - scrollOffset;
-            }       
+            }
             else
             {
                 textView.x  = 0;
@@ -799,7 +795,7 @@ px.import({ scene: 'px:scene.1.js',
             var s       = textInput.text.slice();
             var snip    = s.slice(0, pos); // measure characters to the left of cursor
             var metrics = fontRes.measureText(pts, snip);
-          
+
             cursor.x = metrics.w - cursorW2; // offset to cursor
 
             if(cursor.x < 0)
@@ -862,7 +858,7 @@ px.import({ scene: 'px:scene.1.js',
 //            console.log("makeSelection(start, length) >>>  s: " + start + "  e: " + end + " selection_text = [" + selection_text + "]");
 
             selection.x = selection_x - cursorW2;
-            selection.w = metrics.w   + cursorW2; 
+            selection.w = metrics.w   + cursorW2;
 
             if (length < 0) // selecting towards LEFT
             {
@@ -881,7 +877,7 @@ px.import({ scene: 'px:scene.1.js',
         {
             cursor.a = 0;
         }
-        
+
         function showCursor()
         {
             cursor.a = 1;
@@ -890,7 +886,7 @@ px.import({ scene: 'px:scene.1.js',
 
         function moveToHome() {
             cursor_pos = 0;
-            
+
             updateCursor(cursor_pos);
             clearSelection();
         }
@@ -904,7 +900,7 @@ px.import({ scene: 'px:scene.1.js',
 //            textInput.text += " "; // HACK - for text redraw
         }
 
-        function selectAll() 
+        function selectAll()
         {
             moveToHome();
             selectToEnd();
@@ -1014,7 +1010,7 @@ px.import({ scene: 'px:scene.1.js',
         });
         // - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    }//class 
+    }//class
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -2967,7 +2967,6 @@ void pxScriptView::runScript()
 // escape url end
 
   #ifdef ENABLE_RT_NODE
-  rtLogWarn("pxScriptView::pxScriptView is just now creating a context for mUrl=%s\n",mUrl.cString());
   mCtx = script.createContext();
 
   if (mCtx)
@@ -2988,7 +2987,6 @@ void pxScriptView::runScript()
     char buffer[MAX_URL_SIZE + 50];
     memset(buffer, 0, sizeof(buffer));
     snprintf(buffer, sizeof(buffer), "loadUrl(\"%s\");", mUrl.cString());
-    rtLogWarn("pxScriptView::runScript calling runScript with %s\n",mUrl.cString());
 #ifdef WIN32 // process \\ to /
 		unsigned int bufferLen = strlen(buffer);
 		char * newBuffer = (char*)malloc(sizeof(char)*(bufferLen + 1));

--- a/examples/pxScene2d/src/rcvrcore/SceneModuleLoader.js
+++ b/examples/pxScene2d/src/rcvrcore/SceneModuleLoader.js
@@ -24,10 +24,9 @@ SceneModuleLoader.prototype.loadScenePackage = function(scene, fileSpec) {
   return new Promise(function (resolve, reject) {
     scene.loadArchive(fileSpec.fileUri)
       .ready.then(function(a) {
-          console.error("http status code:", a.loadStatus.httpStatusCode);
           if (a.loadStatus.httpStatusCode && a.loadStatus.httpStatusCode != 200)
           {
-            console.error("http status is not 200 rejecting");
+            console.error("http status is not 200 - rejecting");
             reject(a.loadStatus);
           }
           else

--- a/examples/pxScene2d/src/shell.js
+++ b/examples/pxScene2d/src/shell.js
@@ -74,8 +74,6 @@ if (false)
 	  var code  = e.keyCode;
     var flags = e.flags;
 
-    console.log("SHELL: onPreKeyDown:", code, " key: ", keys.name(code), ", ", flags);
-
     if( keys.is_CTRL_ALT( flags ) )
     {
       if(code == keys.Y)  // ctrl-alt-y
@@ -155,11 +153,8 @@ if (false)
 
   scene.root.on("onPreKeyUp", function(e)
   {
-    console.log("in onPreKeyUp", e.keyCode, e.flags);
 	  var code  = e.keyCode;
     var flags = e.flags;
-
-    console.log("onKeyUp:", code, ", ", flags);
 
     // eat the ones we handle here
          if (code == keys.Y && keys.is_CTRL_ALT( flags ) )       e.stopPropagation(); // ctrl-alt-y
@@ -175,7 +170,6 @@ if (false)
     scene.root.on("onKeyDown", function(e)
     {
       var code = e.keyCode; var flags = e.flags;
-      console.log("onKeyDown shell:", code, ", ", flags);
 
       if( keys.is_CTRL_ALT( flags ) )
       {
@@ -199,12 +193,9 @@ if (false)
 
   scene.root.on("onPreChar", function(e)
   {
-    console.log("in onchar");
 	  var c = e.charCode;
-    console.log("onChar:", c);
 	  // TODO eating some "undesired" chars for now... need to redo this
     if (c<32) {
-      console.log("stop onChar");
       e.stopPropagation();
     }
   });

--- a/src/pxWindowUtil.cpp
+++ b/src/pxWindowUtil.cpp
@@ -23,6 +23,7 @@
 #include "pxWindowUtil.h"
 #include "pxCore.h"
 #include "pxKeycodes.h"
+#include "rtLog.h"
 #include <stdio.h>
 
 uint32_t keycodeFromNative(uint32_t nativeKeycode)
@@ -348,7 +349,7 @@ uint32_t keycodeFromNative(uint32_t nativeKeycode)
     break;
   default:
     //TODO move rtLog support to pxCore so we can use here
-    printf("pxWindowUtils: Unhandled keycode %d\n", nativeKeycode);
+    rtLogWarn("Unhandled keycode %d", nativeKeycode);
     break;
   }
   return commonKeycode;

--- a/src/rtNode.cpp
+++ b/src/rtNode.cpp
@@ -796,6 +796,7 @@ void rtNode::initializeNode()
 
 
 #ifdef ENABLE_NODE_V_6_9
+  rtLogInfo("rtNode::rtNode() calling init");
 #ifdef ENABLE_DEBUG_MODE
   init();
 #else
@@ -922,6 +923,7 @@ void rtNode::init(int argc, char** argv)
 
   if(node_is_initialized == false)
   {
+    rtLogInfo("About to init");
 #ifdef ENABLE_DEBUG_MODE
     Init(&g_argc, const_cast<const char**>(g_argv), &exec_argc, &exec_argv);
 #else
@@ -932,6 +934,7 @@ void rtNode::init(int argc, char** argv)
 //    V8::InitializePlatform(mPlatform);
 
 #ifdef ENABLE_NODE_V_6_9
+    rtLogInfo("using node version 6.9");
    V8::InitializeICU();
 #ifdef ENABLE_DEBUG_MODE
    V8::InitializeExternalStartupData(g_argv[0]);
@@ -953,6 +956,7 @@ void rtNode::init(int argc, char** argv)
 #else
     V8::Initialize();
 #endif // ENABLE_NODE_V_6_9
+    rtLogInfo("rtNode::init() node_is_initialized = %d", node_is_initialized);
     node_is_initialized = true;
 
     Locker                locker(mIsolate);
@@ -962,6 +966,7 @@ void rtNode::init(int argc, char** argv)
     Local<Context> ctx = Context::New(mIsolate);
     ctx->SetEmbedderData(HandleMap::kContextIdIndex, Integer::New(mIsolate, 99));
     mContext.Reset(mIsolate, ctx);
+    rtLogInfo("DONE in rtNode::init()");
   }
 }
 
@@ -980,7 +985,7 @@ void rtNode::term()
   {
 // JRJRJR  Causing crash???  ask Hugh
 
-    rtLogWarn("\n++++++++++++++++++ DISPOSE\n\n");
+    rtLogInfo("\n++++++++++++++++++ DISPOSE\n\n");
     node_isolate->Dispose();
     node_isolate = NULL;
     mIsolate     = NULL;

--- a/src/rtNode.cpp
+++ b/src/rtNode.cpp
@@ -796,7 +796,6 @@ void rtNode::initializeNode()
 
 
 #ifdef ENABLE_NODE_V_6_9
-  rtLogWarn("rtNode::rtNode() calling init \n");
 #ifdef ENABLE_DEBUG_MODE
   init();
 #else
@@ -923,7 +922,6 @@ void rtNode::init(int argc, char** argv)
 
   if(node_is_initialized == false)
   {
-    rtLogWarn("About to Init\n");
 #ifdef ENABLE_DEBUG_MODE
     Init(&g_argc, const_cast<const char**>(g_argv), &exec_argc, &exec_argv);
 #else
@@ -934,7 +932,6 @@ void rtNode::init(int argc, char** argv)
 //    V8::InitializePlatform(mPlatform);
 
 #ifdef ENABLE_NODE_V_6_9
-   rtLogWarn("using node version 6.9\n");
    V8::InitializeICU();
 #ifdef ENABLE_DEBUG_MODE
    V8::InitializeExternalStartupData(g_argv[0]);
@@ -956,7 +953,6 @@ void rtNode::init(int argc, char** argv)
 #else
     V8::Initialize();
 #endif // ENABLE_NODE_V_6_9
-    rtLogWarn("rtNode::init() node_is_initialized=%d\n",node_is_initialized);
     node_is_initialized = true;
 
     Locker                locker(mIsolate);
@@ -966,7 +962,6 @@ void rtNode::init(int argc, char** argv)
     Local<Context> ctx = Context::New(mIsolate);
     ctx->SetEmbedderData(HandleMap::kContextIdIndex, Integer::New(mIsolate, 99));
     mContext.Reset(mIsolate, ctx);
-    rtLogWarn("DONE in rtNode::init()\n");
   }
 }
 


### PR DESCRIPTION
Logging from both c++ and javascript was flooding the console and making
the output difficult to use.  This change removes many of the log
messages that were at fault, particularly rtLogWarn calls that remarked
about normal instantiation.