### PR TITLE
Change address for ci results server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ after_script:
 - ./ci/after_script.sh
 - if [ "$TRAVIS_EVENT_TYPE" != "pull_request" ]; then  rm -rf /tmp/pxscene-build.pem; fi
 addons:
-  ssh_known_hosts: 96.118.6.151
+  ssh_known_hosts: 96.118.159.200
 notifications:
   slack:
     secure: gQ7GjheuN4j98co71p1gO0QaIAX3xHnDE2JRTT5UopsPbhczBC3A6RlVhXBrIc9mDyt2AO/pTBOl68BGtwtb4NVhZo2fqCcoq4wk2U2bAH3OnQu5KE9fJxm1KdJi0WiFVy1pURQql1fUH800YqF1LOWbc9m8aexgcvtD6ghDFLCDStgqfNgRzSEbZ8YBP98FjkEHj/jjeqwdUaH0Aezv0n82Laev99KDveCTVMoKXcbyfBQK0ty3OFAg6nBrMWPx0RVDVOVFPjjXDFgC5UfS9FLA57bxRDVmDr8SMnS/7m26YH0jnqY4oS1QnEmrdUtp6UWNex8D88KCt+wXoOpd6Ca1DVHNnaFuotEVpJ8B3WEG3uiK6xvacpkMrtEuoswUIbOv8E1VdfF3eOSmSAneb09Nbs15U8yiBfNq4PLE8TYc22or5jDsksTyGgmOgE1m8teH4DQz+k5qhMihd9f88CqaWzkjNgucavr/QzXG16xt13unMmMD0/bzA7wDU3hprne5hycR0LDxFRlL5z5xdv4w9yseuFTYBRcQ5Lk9zA6gJUMCGcbCtfA2rYQS7lOul575EMX7SfagHMmn663QY3tzm+vsxF93Dib+xfsAI3xSxSKGeBNZ5H9MxUPNUcu1yxhDZIZX8HujsDVLfIm/VK9OS2ultBTYeKizlyPBBsM=

--- a/ci/after_script.sh
+++ b/ci/after_script.sh
@@ -26,8 +26,8 @@ if [ "$TRAVIS_EVENT_TYPE" = "push" ] ;
 then
   tar -cvzf logs.tgz logs/*
   checkError $? "Unable to compress logs folder" "Check for any previous tasks failed" "Retry"
-  ./ci/deploy_files.sh 96.118.6.151 logs.tgz;
-  checkError $? "Unable to send log files to 96.118.6.151" "Possible reason - Server could be down" "Retry"
+  ./ci/deploy_files.sh 96.118.159.200 logs.tgz;
+  checkError $? "Unable to send log files to 96.118.159.200" "Possible reason - Server could be down" "Retry"
 fi
 
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ] || [ "$TRAVIS_EVENT_TYPE" = "api" ] ;
@@ -40,8 +40,8 @@ then
   checkError $? "unable to move artifacts folder to release directory" "artifacts directory created" "Retry"
   tar -cvzf release.tgz release/*
   checkError $? "unable to compress release folder" "release folder present?" "Retry"
-  ./ci/release_osx.sh 96.118.6.151 release.tgz 
-  checkError $? "unable to send artifacts to 96.118.6.151" "96.118.6.151 down?" "Retry"
+  ./ci/release_osx.sh 96.118.159.200 release.tgz 
+  checkError $? "unable to send artifacts to 96.118.159.200" "96.118.159.200 down?" "Retry"
 fi
 
 if [ "$TRAVIS_EVENT_TYPE" = "push" ] || [ "$TRAVIS_EVENT_TYPE" = "pull_request" ] ;

--- a/ci/pxscene_generate_cache.json
+++ b/ci/pxscene_generate_cache.json
@@ -8,7 +8,7 @@
          "install" : "./ci/generate_cache_install.sh",
          "before_script" : "ccache -s; export PATH=/usr/local/opt/ccache/libexec:$PATH",
          "script" : "./ci/generate_cache_script.sh",
-         "after_script" : "ccache -s; tar -cvzf logs.tgz logs/*; ./ci/deploy_files.sh 96.118.6.151 logs.tgz; rm -rf /tmp/pxscene-build.pem"
+         "after_script" : "ccache -s; tar -cvzf logs.tgz logs/*; ./ci/deploy_files.sh 96.118.159.200 logs.tgz; rm -rf /tmp/pxscene-build.pem"
          }
    }
 }


### PR DESCRIPTION
There is a new server instance that must be used for posting of ci and release build results, reports and artifacts. This new IP address reflects the new server.