### PR TITLE
Removal of freeglut related information

### DIFF
--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -37,8 +37,7 @@ fi
 if [ "$TRAVIS_OS_NAME" = "linux" ] ; 
 then 
   travis_retry sudo apt-get update
-  travis_retry sudo apt-get install git libglew-dev freeglut3 freeglut3-dev libgcrypt11-dev zlib1g-dev g++ libssl-dev nasm autoconf valgrind libyaml-dev lcov cmake x11proto-input-dev lighttpd gdb
-  cd /usr/include/X11/extensions && sudo ln -s XI.h XInput.h
+  travis_retry sudo apt-get install git libglew-dev freeglut3 freeglut3-dev libgcrypt11-dev zlib1g-dev g++ libssl-dev nasm autoconf valgrind libyaml-dev lcov cmake  lighttpd gdb
 fi
 
 if [ "$TRAVIS_OS_NAME" = "osx" ] ;

--- a/ci/generate_cache_install.sh
+++ b/ci/generate_cache_install.sh
@@ -25,8 +25,7 @@ travis_retry() {
 if [ "$TRAVIS_OS_NAME" = "linux" ] ; 
 then 
   travis_retry sudo apt-get update
-  travis_retry sudo apt-get install git libglew-dev freeglut3 freeglut3-dev libgcrypt11-dev zlib1g-dev g++ libssl-dev nasm autoconf libyaml-dev cmake x11proto-input-dev gdb
-  cd /usr/include/X11/extensions && sudo ln -s XI.h XInput.h
+  travis_retry sudo apt-get install git libglew-dev freeglut3 freeglut3-dev libgcrypt11-dev zlib1g-dev g++ libssl-dev nasm autoconf libyaml-dev cmake  gdb
 fi
 
 if [ "$TRAVIS_OS_NAME" = "osx" ] ;

--- a/examples/pxScene2d/README.md
+++ b/examples/pxScene2d/README.md
@@ -10,11 +10,7 @@
 1. Install required packages:
     
     ~~~~
-    sudo apt-get install git libglew-dev freeglut3 freeglut3-dev libgcrypt11-dev zlib1g-dev g++ libssl-dev nasm autoconf libtool cmake x11proto-input-dev
-    
-    Execute below command:
-    
-    cd /usr/include/X11/extensions && sudo ln -s XI.h XInput.h
+    sudo apt-get install git libglew-dev freeglut3 freeglut3-dev libgcrypt11-dev zlib1g-dev g++ libssl-dev nasm autoconf libtool cmake
     
     ~~~~
 

--- a/examples/pxScene2d/external/build.sh
+++ b/examples/pxScene2d/external/build.sh
@@ -164,14 +164,3 @@ fi
 
 #--------
 
-#--------- GLUT  (Non -macOS)
-
-# if [ "$(uname)" != "Darwin" ]
-# then
-#  cd freeglut
-#  cmake .
-#  make freeglut -j3
-#  cd ..
-# fi
-
-#--------

--- a/examples/pxScene2d/external/clean.sh
+++ b/examples/pxScene2d/external/clean.sh
@@ -50,10 +50,4 @@ make clean -j3
 cd ..
 fi
 
-if [ "$(uname)" != "Darwin" ] 
-then
-cd freeglut
-make clean -j3
-cd ..
-fi
 


### PR DESCRIPTION
Please find the modifications related to Removal of external/freeglut related information and x11proto-input-dev.
And regarding the comment on earlier review "Also, of course, we want the changes to the readme to reverse the freeglut instructions from this commit: 1799b5d#diff-9669f884fa4e0ff4dcb39947bd039bc7" -> This information was already removed in the commit (bc8f818) Kindly confirm.