### PR TITLE
Fixed deadlock on shutown.

### DIFF
--- a/remote/Makefile
+++ b/remote/Makefile
@@ -49,9 +49,9 @@ ifeq ($V, 1)
   CC_PRETTY = $(CC)
   BUILD_CXX_PRETTY = $(BUILD_CXX)
 else
-  CXX_PRETTY = @echo " [CXX] $<" ; $(CXX)
+  CXX_PRETTY = @echo " [CXX] $@" ; $(CXX)
   LD_PRETTY = @echo "[LINK] $@" ; $(CXX)
-  CC_PRETTY = @echo " [CC] $<" ; $(CC)
+  CC_PRETTY = @echo " [CC] $@" ; $(CC)
   BUILD_CXX_PRETTY = @echo " [CC] $<" ; $(BUILD_CXX)
 endif
 
@@ -152,8 +152,8 @@ rpcSampleApp_s: $(SAMPLEAPP_OBJS) librtRemote_s.a
 
 rpcSampleSimple: librtRemote.so
 	$(CXX_PRETTY) rtSampleClient.cpp -DRT_PLATFORM_LINUX -I. -DRAPIDJSON_HAS_STDSTRING\
-    -o rtSampleClient -I../src -L. -L../build/egl -lrtCore -lrtRemote $(LIBUUID) -std=c++11
+    -o rtSampleClient -I../src -L. -L../build/egl -lrtCore -lrtRemote $(LIBUUID) -std=c++11 -pthread
 	$(CXX_PRETTY) rtSampleServer.cpp -DRT_PLATFORM_LINUX -I. -DRAPIDJSON_HAS_STDSTRING\
-    -o rtSampleServer -I../src -L. -L../build/egl -lrtCore -lrtRemote $(LIBUUID) -std=c++11
+    -o rtSampleServer -I../src -L. -L../build/egl -lrtCore -lrtRemote $(LIBUUID) -std=c++11 -pthread
 
 .PHONY: all debug clean

--- a/remote/rtRemoteClient.cpp
+++ b/remote/rtRemoteClient.cpp
@@ -371,7 +371,7 @@ rtRemoteClient::sendGet(rtRemoteMessagePtr const& req, rtRemoteCorrelationKey k,
     if (itr == res->MemberEnd())
       return RT_ERROR_PROTOCOL_ERROR;
 
-    e = rtRemoteValueReader::read(value, itr->value, shared_from_this());
+    e = rtRemoteValueReader::read(m_env, value, itr->value, shared_from_this());
     if (e == RT_OK)
       e = rtMessage_GetStatusCode(*res);
   }
@@ -417,7 +417,7 @@ rtRemoteClient::sendCall(rtRemoteMessagePtr const& req, rtRemoteCorrelationKey k
     if (itr == res->MemberEnd())
       return RT_ERROR_PROTOCOL_ERROR;
 
-    e = rtRemoteValueReader::read(result, itr->value, shared_from_this());
+    e = rtRemoteValueReader::read(m_env, result, itr->value, shared_from_this());
     if (e == RT_OK)
       e = rtMessage_GetStatusCode(*res);
   }

--- a/remote/rtRemoteFunction.h
+++ b/remote/rtRemoteFunction.h
@@ -20,6 +20,12 @@ public:
   virtual unsigned long Release();
   virtual rtError Send(int numArgs, const rtValue* args, rtValue* result);
 
+  inline std::string const& getId() const
+    { return m_id; }
+
+  inline std::string const& getName() const
+    { return m_name; }
+
 private:
   rtAtomic                          m_ref_count;
   std::string                       m_id;

--- a/remote/rtRemoteObject.h
+++ b/remote/rtRemoteObject.h
@@ -21,7 +21,7 @@ public:
   virtual unsigned long AddRef();
   virtual unsigned long Release();
 
-  inline std::string const& id() const
+  inline std::string const& getId() const
     { return m_id; }
 
 private:

--- a/remote/rtRemoteStreamSelector.h
+++ b/remote/rtRemoteStreamSelector.h
@@ -33,6 +33,7 @@ private:
   std::condition_variable                         m_streams_cond;
   int                                             m_shutdown_pipe[2];
   rtRemoteEnvironment*                            m_env;
+  bool                                            m_running;
 };
 
 #endif

--- a/remote/rtRemoteValueReader.cpp
+++ b/remote/rtRemoteValueReader.cpp
@@ -110,9 +110,17 @@ rtRemoteValueReader::read(rtRemoteEnvironment* env, rtValue& to, rapidjson::Valu
 
       auto id = obj->value.FindMember(kFieldNameObjectId);
       if (strcmp(id->value.GetString(), kNullObjectId) == 0)
+      {
         to.setObject(rtObjectRef());
+      }
       else
-        to.setObject(new rtRemoteObject(id->value.GetString(), client));
+      {
+        rtObjectRef ref = env->ObjectCache->findObject(id->value.GetString());
+        if (ref)
+          to.setObject(ref);
+        else
+          to.setObject(new rtRemoteObject(id->value.GetString(), client));
+      }
     }
     break;
 

--- a/remote/rtRemoteValueReader.cpp
+++ b/remote/rtRemoteValueReader.cpp
@@ -1,4 +1,5 @@
 #include "rtRemoteValueReader.h"
+#include "rtRemoteObjectCache.h"
 #include "rtRemoteClient.h"
 #include "rtRemoteObject.h"
 #include "rtRemoteFunction.h"
@@ -26,7 +27,8 @@ static std::string toString(rapidjson::Value const& v)
 #endif
 
 rtError
-rtRemoteValueReader::read(rtValue& to, rapidjson::Value const& from, std::shared_ptr<rtRemoteClient> const& client)
+rtRemoteValueReader::read(rtRemoteEnvironment* env, rtValue& to, rapidjson::Value const& from,
+  std::shared_ptr<rtRemoteClient> const& client)
 {
   auto type = from.FindMember(kFieldNameValueType);
   if (type  == from.MemberEnd())
@@ -146,9 +148,18 @@ rtRemoteValueReader::read(rtValue& to, rapidjson::Value const& from, std::shared
       }
 
       if (strcmp(functionId.c_str(), kNullObjectId) == 0)
+      {
         to.setFunction(rtFunctionRef());
+      }
       else
-        to.setFunction(new rtRemoteFunction(objectId, functionId, client));
+      {
+        // check object for cache first
+        rtFunctionRef ref = env->ObjectCache->findFunction(functionId);
+        if (ref)
+          to.setFunction(ref);
+        else
+          to.setFunction(new rtRemoteFunction(objectId, functionId, client));
+      }
     }
     break;
 

--- a/remote/rtRemoteValueReader.h
+++ b/remote/rtRemoteValueReader.h
@@ -7,11 +7,13 @@
 #include <rapidjson/document.h>
 
 class rtRemoteClient;
+class rtRemoteEnvironment;
 
 class rtRemoteValueReader
 {
 public:
-  static rtError read(rtValue& val, rapidjson::Value const& from, std::shared_ptr<rtRemoteClient> const& client);
+  static rtError read(rtRemoteEnvironment* env, rtValue& val, rapidjson::Value const& from,
+    std::shared_ptr<rtRemoteClient> const& client);
 };
 
 #endif

--- a/remote/rtRemoteValueWriter.cpp
+++ b/remote/rtRemoteValueWriter.cpp
@@ -1,4 +1,5 @@
 #include "rtRemoteValueWriter.h"
+#include "rtRemoteObject.h"
 #include "rtRemoteObjectCache.h"
 #include "rtRemoteConfig.h"
 #include "rtRemoteMessage.h"
@@ -23,15 +24,23 @@ namespace
     return ss.str();
   }
  
-  std::string getId(rtObjectRef const& /*ref*/)
+  std::string getId(rtObjectRef const& ref)
   {
-    rtGuid id = rtGuid::newRandom();
+    rtRemoteObject const* obj = dynamic_cast<rtRemoteObject const *>(ref.getPtr());
+    if (obj != nullptr)
+    {
+      return obj->getId();
+    }
+    else
+    {
+      rtGuid id = rtGuid::newRandom();
 
-    std::stringstream ss;
-    ss << "obj://";
-    ss << id.toString();
-    return ss.str();
-   }
+      std::stringstream ss;
+      ss << "obj://";
+      ss << id.toString();
+      return ss.str();
+    }
+  }
 }
 
 rtError
@@ -74,7 +83,9 @@ rtRemoteValueWriter::write(rtRemoteEnvironment* env, rtValue const& from,
     to.AddMember("value", val, doc.GetAllocator());
 
     if (obj)
+    {
       env->ObjectCache->insert(id, obj);
+    }
 
     return RT_OK;
   }

--- a/remote/rtRemoteValueWriter.cpp
+++ b/remote/rtRemoteValueWriter.cpp
@@ -54,7 +54,9 @@ rtRemoteValueWriter::write(rtRemoteEnvironment* env, rtValue const& from,
     to.AddMember("value", val, doc.GetAllocator());
 
     if (func)
+    {
       env->ObjectCache->insert(id, func);
+    }
 
     return RT_OK;
   }

--- a/remote/rtSampleClient.cpp
+++ b/remote/rtSampleClient.cpp
@@ -14,6 +14,38 @@
  * limitations under the License.
  */
 #include "rtRemote.h"
+#include <thread>
+#include <unistd.h>
+#include <assert.h>
+
+rtObjectRef obj;
+
+void run()
+{
+  int n = 0;
+  rtError e;
+  rtValue val;
+
+  while (true)
+  {
+    val = n++;
+
+    e = obj->Set("prop", &val);
+    if (e != RT_OK)
+    {
+      rtLogInfo("Set:%s", rtStrError(e));
+      assert(false);
+    }
+    usleep(1000 * 100);
+
+    e = obj->Get("prop", &val);
+    if (e != RT_OK)
+    {
+      rtLogInfo("Get:%s - %d", rtStrError(e), val.toInt32());
+      assert(false);
+    }
+  }
+}
 
 rtError
 upload_complete(int argc, rtValue const* argv, rtValue* result, void* argp)
@@ -22,14 +54,16 @@ upload_complete(int argc, rtValue const* argv, rtValue* result, void* argp)
   rtLogInfo("upload_complete");
   rtLogInfo("argc:%d", argc);
   rtLogInfo("argv[0]:%s", argv[0].toString().cString());
+
+  (void) result;
+  (void) argp;
+
   return RT_OK;
 }
 
 
 int main(int /*argc*/, char* /*argv*/ [])
 {
-  rtLogSetLevel(RT_LOG_INFO);
-
   rtError e;
   rtRemoteEnvironment* env = rtEnvironmentGetGlobal();
   e = rtRemoteInit(env);
@@ -40,18 +74,25 @@ int main(int /*argc*/, char* /*argv*/ [])
   }
 
   // find object
-  rtObjectRef obj;
   while ((e = rtRemoteLocateObject(env, "some_name", obj)) != RT_OK)
   {
     rtLogInfo("still looking:%s", rtStrError(e));
   }
 
-  obj.set("onUploadComplete", new rtFunctionCallback(upload_complete));
+  rtFunctionRef callback(new rtFunctionCallback(upload_complete));
+  obj.set("onUploadComplete", callback);
+
+  // std::thread t(run);
 
   while (true)
   {
-    e = rtRemoteRunUntil(env, 30000);
-    rtLogInfo("rtRemoteRunUntil:%s", rtStrError(e));
+    rtValue val;
+    e = obj->Get("onUploadComplete", &val);
+    rtLogInfo("Get:%s", rtStrError(e));
+    rtLogInfo("Type:%s", val.getTypeStr());
+    rtLogInfo("Addr:%p", val.toFunction().getPtr());
+    rtRemoteRunUntil(env, 1000);
+    sleep(1);
   }
   return 0;
 }

--- a/remote/rtSampleClient.cpp
+++ b/remote/rtSampleClient.cpp
@@ -18,6 +18,21 @@
 #include <unistd.h>
 #include <assert.h>
 
+
+class TestObject : public rtObject
+{
+  rtDeclareObject(TestObject, rtObject);
+public:
+  rtProperty(count, getCount, setCount, int);
+  rtError getCount(int& n) const { n = m_count; return RT_OK; }
+  rtError setCount(int  n) { m_count = n; return RT_OK; }
+private:
+  int m_count;
+};
+
+rtDefineObject(TestObject, rtObject);
+rtDefineProperty(TestObject, count);
+
 rtObjectRef obj;
 
 void run()
@@ -82,15 +97,24 @@ int main(int /*argc*/, char* /*argv*/ [])
   rtFunctionRef callback(new rtFunctionCallback(upload_complete));
   obj.set("onUploadComplete", callback);
 
+  rtObjectRef big(new TestObject());
+  obj.set("bigprop", big);
+
   // std::thread t(run);
 
   while (true)
   {
     rtValue val;
+    #if 0
     e = obj->Get("onUploadComplete", &val);
     rtLogInfo("Get:%s", rtStrError(e));
     rtLogInfo("Type:%s", val.getTypeStr());
     rtLogInfo("Addr:%p", val.toFunction().getPtr());
+    #endif
+    e = obj->Get("bigprop", &val);
+    rtLogInfo("get  :%s", rtStrError(e));
+    rtLogInfo("type :%s", val.getTypeStr());
+    rtLogInfo("addr :%p", val.toObject().getPtr());
     rtRemoteRunUntil(env, 1000);
     sleep(1);
   }

--- a/remote/rtSampleServer.cpp
+++ b/remote/rtSampleServer.cpp
@@ -15,6 +15,7 @@
  */
 #include "rtRemote.h"
 #include "rtObject.h"
+#include <assert.h>
 
 // design a remote object
 // 1.) MUST derive from rtObject
@@ -44,15 +45,21 @@ public:
     return RT_OK;
   }
 
+  rtProperty(prop, getProp, setProp, int);
+  rtError getProp(int& n) const { n = _n; return RT_OK; }
+  rtError setProp(int  n) { _n = n; return RT_OK; }
+
   // properties can be functions too!
   rtProperty(onUploadComplete, getOnUploadComplete, setOnUploadComplete, rtFunctionRef);
   rtError getOnUploadComplete(rtFunctionRef& func) const
   {
     func = m_callback;
+    return RT_OK;
   }
   rtError setOnUploadComplete(rtFunctionRef const& func)
   {
     m_callback = func;
+    return RT_OK;
   }
 
   // helper
@@ -62,19 +69,24 @@ public:
     {
       rtString s("upload complete");
       rtError e = m_callback.send(s);
-      rtLogInfo("send:%s", rtStrError(e));
+      if (e != RT_OK)
+      {
+        rtLogInfo("send:%s", rtStrError(e));
+      }
     }
   }
 
 private:
   rtString m_name;
   rtFunctionRef m_callback;
+  int _n;
 };
 
 // required stub definitions (they're macros)
 rtDefineObject(ContinuousVideoRecorder, rtObject);
 rtDefineProperty(ContinuousVideoRecorder, name);
 rtDefineProperty(ContinuousVideoRecorder, onUploadComplete);
+rtDefineProperty(ContinuousVideoRecorder, prop);
 
 int main(int /*argc*/, char* /*argv*/ [])
 {

--- a/remote/rtSampleServer.cpp
+++ b/remote/rtSampleServer.cpp
@@ -45,6 +45,19 @@ public:
     return RT_OK;
   }
 
+  // property as rtObject
+  rtProperty(bigprop, getBigProp, setBigProp, rtObjectRef);
+  rtError getBigProp(rtObjectRef& obj) const
+  {
+    obj = m_big;
+    return RT_OK;
+  }
+  rtError setBigProp(rtObjectRef const& obj)
+  {
+    m_big = obj;
+    return RT_OK;
+  }
+
   rtProperty(prop, getProp, setProp, int);
   rtError getProp(int& n) const { n = _n; return RT_OK; }
   rtError setProp(int  n) { _n = n; return RT_OK; }
@@ -80,6 +93,7 @@ private:
   rtString m_name;
   rtFunctionRef m_callback;
   int _n;
+  rtObjectRef m_big;
 };
 
 // required stub definitions (they're macros)
@@ -87,6 +101,7 @@ rtDefineObject(ContinuousVideoRecorder, rtObject);
 rtDefineProperty(ContinuousVideoRecorder, name);
 rtDefineProperty(ContinuousVideoRecorder, onUploadComplete);
 rtDefineProperty(ContinuousVideoRecorder, prop);
+rtDefineProperty(ContinuousVideoRecorder, bigprop);
 
 int main(int /*argc*/, char* /*argv*/ [])
 {
@@ -115,7 +130,7 @@ int main(int /*argc*/, char* /*argv*/ [])
     e = rtRemoteRunUntil(env, 1000);
     rtLogInfo("rtRemoteRunUntil: %s", rtStrError(e));
 
-    ((ContinuousVideoRecorder *)obj.getPtr())->fireOnUploadComplete();
+    // ((ContinuousVideoRecorder *)obj.getPtr())->fireOnUploadComplete();
   }
 
   return 0;


### PR DESCRIPTION
When initializing and shutting down rtRemote without actually
making any inbound or outbound connections, the shutdown
will hang on processing queue being empty. That is now fixed.