### PR TITLE
add missing header file

### DIFF
--- a/remote/rtRemoteConfigGen.cpp
+++ b/remote/rtRemoteConfigGen.cpp
@@ -1,3 +1,4 @@
+#include <functional>
 #include <exception>
 #include <memory>
 #include <map>


### PR DESCRIPTION
It fixes the following compilation error (using gcc 7.2):
$ make
 [CC] rtRemoteConfigGen.cpp
rtRemoteConfigGen.cpp:121:8: error: ‘std::function’ has not been declared
   std::function<void (FILE* , ConfigItem const& )> func)
        ^~~~~~~~
rtRemoteConfigGen.cpp:121:16: error: expected ‘,’ or ‘...’ before ‘<’ token
   std::function<void (FILE* , ConfigItem const& )> func)
                ^
rtRemoteConfigGen.cpp: In function ‘void processConfigParamList(FILE*, const Value&, int)’:
rtRemoteConfigGen.cpp:141:5: error: ‘func’ was not declared in this scope
     func(f, item);
     ^~~~
rtRemoteConfigGen.cpp:141:5: note: suggested alternative: ‘fputc’
     func(f, item);
     ^~~~
     fputc
rtRemoteConfigGen.cpp: In function ‘std::set<ConfigItem> buildConfigItems(const Value&)’:
rtRemoteConfigGen.cpp:166:4: error: cannot convert ‘buildConfigItems(const Value&)::<lambda(FILE*, const ConfigItem&)>’ to ‘int’ for argument ‘3’ to ‘void processConfigParamList(FILE*, const Value&, int)’
   });
    ^
make: *** [Makefile:99: obj/rtRemoteConfigGen] Error 1