### PR TITLE
fix make 'clean' target

### DIFF
--- a/remote/Makefile
+++ b/remote/Makefile
@@ -134,6 +134,7 @@ clean:
 	rm -f rtremote.conf.gen
 	rm -f rtremote.conf
 	rm -f rtRemoteConfig.h
+	rm -f rtRemoteConfigBuilder.cpp
 
 perftest:
 	$(MAKE) -C tests perftest


### PR DESCRIPTION
Add missing deletion of rtRemoteConfigBuilder.cpp auto-generated file.