### PR TITLE
remove unsupported GCC pragma

### DIFF
--- a/src/rtNode.h
+++ b/src/rtNode.h
@@ -34,12 +34,6 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
-#ifndef PX_PLATFORM_MAC
-#ifndef __clang__
-#pragma GCC diagnostic ignored "-Werror"
-#endif
-#endif
-
 #pragma GCC diagnostic ignored "-Wall"
 #endif
 


### PR DESCRIPTION
In file included from pxscene/pxCore/src/rtNode.cpp:56:0:
pxCore/src/rtNode.h:39:32: error: ‘-Werror’ is not an option that controls warnings [-Werror=pragmas]
 #pragma GCC diagnostic ignored "-Werror"
                                ^~~~~~~~~