### PR TITLE
fix breakpad compilation error

### DIFF
--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -37,7 +37,7 @@ fi
 if [ "$TRAVIS_OS_NAME" = "linux" ] ; 
 then 
   travis_retry sudo apt-get update
-  travis_retry sudo apt-get install git libglew-dev freeglut3 freeglut3-dev libgcrypt11-dev zlib1g-dev g++ libssl-dev nasm autoconf valgrind libyaml-dev lcov cmake  lighttpd gdb
+  travis_retry sudo apt-get install git libglew-dev freeglut3 freeglut3-dev libgcrypt11-dev zlib1g-dev g++ libssl-dev nasm autoconf valgrind libyaml-dev lcov cmake  lighttpd gdb quilt
 fi
 
 if [ "$TRAVIS_OS_NAME" = "osx" ] ;

--- a/examples/pxScene2d/external/breakpad-chrome_55/patches/0001-replace-struct-ucontext-with-ucontext_t.patch
+++ b/examples/pxScene2d/external/breakpad-chrome_55/patches/0001-replace-struct-ucontext-with-ucontext_t.patch
@@ -1,0 +1,196 @@
+Patch from: https://raw.githubusercontent.com/faulesocke/void-packages/fd6f3fee1e8024358be6dc82de028b8b0271bbd9/srcpkgs/chromium/patches/0002-replace-struct-ucontext-with-ucontext_t.patch
+
+--- breakpad/src/client/linux/dump_writer_common/ucontext_reader.cc
++++ breakpad/src/client/linux/dump_writer_common/ucontext_reader.cc
+@@ -40,15 +40,15 @@ namespace google_breakpad {
+ 
+ #if defined(__i386__)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[REG_ESP];
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[REG_EIP];
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                                     const struct _libc_fpstate* fp) {
+   const greg_t* regs = uc->uc_mcontext.gregs;
+ 
+@@ -88,15 +88,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
+ 
+ #elif defined(__x86_64)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[REG_RSP];
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[REG_RIP];
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                                     const struct _libc_fpstate* fpregs) {
+   const greg_t* regs = uc->uc_mcontext.gregs;
+ 
+@@ -145,15 +145,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
+ 
+ #elif defined(__ARM_EABI__)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.arm_sp;
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.arm_pc;
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc) {
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc) {
+   out->context_flags = MD_CONTEXT_ARM_FULL;
+ 
+   out->iregs[0] = uc->uc_mcontext.arm_r0;
+@@ -184,15 +184,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc) {
+ 
+ #elif defined(__aarch64__)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.sp;
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.pc;
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                                     const struct fpsimd_context* fpregs) {
+   out->context_flags = MD_CONTEXT_ARM64_FULL;
+ 
+@@ -210,15 +210,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
+ 
+ #elif defined(__mips__)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[MD_CONTEXT_MIPS_REG_SP];
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.pc;
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc) {
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc) {
+ #if _MIPS_SIM == _ABI64
+   out->context_flags = MD_CONTEXT_MIPS64_FULL;
+ #elif _MIPS_SIM == _ABIO32
+--- breakpad/src/client/linux/dump_writer_common/ucontext_reader.h
++++ breakpad/src/client/linux/dump_writer_common/ucontext_reader.h
+@@ -41,21 +41,21 @@ namespace google_breakpad {
+ 
+ // Wraps platform-dependent implementations of accessors to ucontext structs.
+ struct UContextReader {
+-  static uintptr_t GetStackPointer(const struct ucontext* uc);
++  static uintptr_t GetStackPointer(const ucontext_t* uc);
+ 
+-  static uintptr_t GetInstructionPointer(const struct ucontext* uc);
++  static uintptr_t GetInstructionPointer(const ucontext_t* uc);
+ 
+   // Juggle a arch-specific ucontext into a minidump format
+   //   out: the minidump structure
+   //   info: the collection of register structures.
+ #if defined(__i386__) || defined(__x86_64)
+-  static void FillCPUContext(RawContextCPU *out, const ucontext *uc,
++  static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                              const struct _libc_fpstate* fp);
+ #elif defined(__aarch64__)
+-  static void FillCPUContext(RawContextCPU *out, const ucontext *uc,
++  static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                              const struct fpsimd_context* fpregs);
+ #else
+-  static void FillCPUContext(RawContextCPU *out, const ucontext *uc);
++  static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc);
+ #endif
+ };
+ 
+--- breakpad/src/client/linux/handler/exception_handler.cc
++++ breakpad/src/client/linux/handler/exception_handler.cc
+@@ -439,9 +439,9 @@ bool ExceptionHandler::HandleSignal(int sig, siginfo_t* info, void* uc) {
+   // Fill in all the holes in the struct to make Valgrind happy.
+   memset(&g_crash_context_, 0, sizeof(g_crash_context_));
+   memcpy(&g_crash_context_.siginfo, info, sizeof(siginfo_t));
+-  memcpy(&g_crash_context_.context, uc, sizeof(struct ucontext));
++  memcpy(&g_crash_context_.context, uc, sizeof(ucontext_t));
+ #if defined(__aarch64__)
+-  struct ucontext* uc_ptr = (struct ucontext*)uc;
++  ucontext_t* uc_ptr = (ucontext_t*)uc;
+   struct fpsimd_context* fp_ptr =
+       (struct fpsimd_context*)&uc_ptr->uc_mcontext.__reserved;
+   if (fp_ptr->head.magic == FPSIMD_MAGIC) {
+@@ -452,7 +452,7 @@ bool ExceptionHandler::HandleSignal(int sig, siginfo_t* info, void* uc) {
+   // FP state is not part of user ABI on ARM Linux.
+   // In case of MIPS Linux FP state is already part of struct ucontext
+   // and 'float_state' is not a member of CrashContext.
+-  struct ucontext* uc_ptr = (struct ucontext*)uc;
++  ucontext_t* uc_ptr = (ucontext_t*)uc;
+   if (uc_ptr->uc_mcontext.fpregs) {
+     memcpy(&g_crash_context_.float_state, uc_ptr->uc_mcontext.fpregs,
+            sizeof(g_crash_context_.float_state));
+@@ -476,7 +476,7 @@ bool ExceptionHandler::SimulateSignalDelivery(int sig) {
+   // ExceptionHandler::HandleSignal().
+   siginfo.si_code = SI_USER;
+   siginfo.si_pid = getpid();
+-  struct ucontext context;
++  ucontext_t context;
+   getcontext(&context);
+   return HandleSignal(sig, &siginfo, &context);
+ }
+--- breakpad/src/client/linux/handler/exception_handler.h
++++ breakpad/src/client/linux/handler/exception_handler.h
+@@ -191,7 +191,7 @@ class ExceptionHandler {
+   struct CrashContext {
+     siginfo_t siginfo;
+     pid_t tid;  // the crashing thread.
+-    struct ucontext context;
++    ucontext_t context;
+ #if !defined(__ARM_EABI__) && !defined(__mips__)
+     // #ifdef this out because FP state is not part of user ABI for Linux ARM.
+     // In case of MIPS Linux FP state is already part of struct
+--- breakpad/src/client/linux/microdump_writer/microdump_writer.cc
++++ breakpad/src/client/linux/microdump_writer/microdump_writer.cc
+@@ -571,7 +571,7 @@ class MicrodumpWriter {
+ 
+   void* Alloc(unsigned bytes) { return dumper_->allocator()->Alloc(bytes); }
+ 
+-  const struct ucontext* const ucontext_;
++  const ucontext_t* const ucontext_;
+ #if !defined(__ARM_EABI__) && !defined(__mips__)
+   const google_breakpad::fpstate_t* const float_state_;
+ #endif
+--- breakpad/src/client/linux/minidump_writer/minidump_writer.cc
++++ breakpad/src/client/linux/minidump_writer/minidump_writer.cc
+@@ -1248,7 +1248,7 @@ class MinidumpWriter {
+   const int fd_;  // File descriptor where the minidum should be written.
+   const char* path_;  // Path to the file where the minidum should be written.
+ 
+-  const struct ucontext* const ucontext_;  // also from the signal handler
++  const ucontext_t* const ucontext_;  // also from the signal handler
+ #if !defined(__ARM_EABI__) && !defined(__mips__)
+   const google_breakpad::fpstate_t* const float_state_;  // ditto
+ #endif
+-- 
+2.13.2
+

--- a/examples/pxScene2d/external/build.sh
+++ b/examples/pxScene2d/external/build.sh
@@ -141,6 +141,7 @@ fi
 if [ "$(uname)" != "Darwin" ]; then
 
   cd breakpad
+  quilt push -aq || test $? = 2
   ./configure
   make
   cd ..


### PR DESCRIPTION
Compilation log excerpt:

src/client/linux/dump_writer_common/ucontext_reader.cc: In static member function ‘static uintptr_t google_breakpad::UContextReader::GetStackPointer(const google_breakpad::ucontext*)’:
src/client/linux/dump_writer_common/ucontext_reader.cc:92:12: error: invalid use of incomplete type ‘const struct google_breakpad::ucontext’
   return uc->uc_mcontext.gregs[REG_RSP];
            ^~
In file included from src/client/linux/dump_writer_common/ucontext_reader.cc:30:0:
./src/client/linux/dump_writer_common/ucontext_reader.h:44:49: note: forward declaration of ‘struct google_breakpad::ucontext’
   static uintptr_t GetStackPointer(const struct ucontext* uc);
                                                 ^~~~~~~~
src/client/linux/dump_writer_common/ucontext_reader.cc:92:14: error: invalid use of incomplete type ‘const struct google_breakpad::ucontext’
   return uc->uc_mcontext.gregs[REG_RSP];
              ^~~~~~~~~~~
In file included from src/client/linux/dump_writer_common/ucontext_reader.cc:30:0:
./src/client/linux/dump_writer_common/ucontext_reader.h:44:49: note: forward declaration of ‘struct google_breakpad::ucontext’
   static uintptr_t GetStackPointer(const struct ucontext* uc);
                                                 ^~~~~~~~
src/client/linux/dump_writer_common/ucontext_reader.cc: In static member function ‘static uintptr_t google_breakpad::UContextReader::GetInstructionPointer(const google_breakpad::ucontext*)’:
src/client/linux/dump_writer_common/ucontext_reader.cc:96:12: error: invalid use of incomplete type ‘const struct google_breakpad::ucontext’
   return uc->uc_mcontext.gregs[REG_RIP];
            ^~

The patch applied comes from: https://raw.githubusercontent.com/faulesocke/void-packages/fd6f3fee1e8024358be6dc82de028b8b0271bbd9/srcpkgs/chromium/patches/0002-replace-struct-ucontext-with-ucontext_t.patch