### PR TITLE
add cross-compilation support for rtRemoteConfigGen tool

### DIFF
--- a/remote/CMakeLists.txt
+++ b/remote/CMakeLists.txt
@@ -33,10 +33,14 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 set(LIBRARY_LINKER_OPTIONS -pthread -ldl -luuid -Wl,-rpath=../../,--enable-new-dtags)
 set(RTREMOTE_LINK_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../src ${CMAKE_CURRENT_SOURCE_DIR}/../build/glut ${CMAKE_CURRENT_SOURCE_DIR}/../build/egl)
 
-add_executable(rtRemoteConfigGen rtRemoteConfigGen.cpp)
-set_target_properties(rtRemoteConfigGen
-                      PROPERTIES
-                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+if (CMAKE_CROSSCOMPILING)
+    option(RTREMOTE_GENERATOR_EXPORT "Location of rtRemote export file (rtRemoteConfigGen_export.cmake) from a native build" "RTREMOTE_GENERATOR_EXPORT-file-not-found")
+    include(${RTREMOTE_GENERATOR_EXPORT})
+else(CMAKE_CROSSCOMPILING)
+    add_executable(rtRemoteConfigGen rtRemoteConfigGen.cpp)
+    set_target_properties(rtRemoteConfigGen PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+    export(TARGETS rtRemoteConfigGen FILE "${CMAKE_CURRENT_BINARY_DIR}/rtRemoteConfigGen_export.cmake")
+endif(CMAKE_CROSSCOMPILING)
 
 add_custom_command(OUTPUT rtremote.conf.gen
                    DEPENDS rtRemoteConfigGen rtremote.conf.ac


### PR DESCRIPTION
Usage:
 1. Native build
   a) from 'build-native' directory
   b) cmake ../remote
   c) make rtRemoteConfigGen VERBOSE=1

 2. Target build (assumes CMAKE_CROSSCOMPILING is ON)
   a) from 'build-target' directory
   b) cmake -DRTREMOTE_GENERATOR_EXPORT=./build-native/rtRemoteConfigGen_export.cmake ..
   c) make VERBOSE=1