### PR TITLE
add possibility to resolve servicemanager dependencies

### DIFF
--- a/src/wayland_egl/pxEventLoopNative.cpp
+++ b/src/wayland_egl/pxEventLoopNative.cpp
@@ -28,8 +28,9 @@ void pxEventLoop::exit()
 
 ///////////////////////////////////////////
 // Entry Point 
-
+#ifndef ENABLE_EGL_GENERIC
 int main(int argc, char** argv)
 {
   return pxMain(argc, argv);
 }
+#endif


### PR DESCRIPTION
fixes the following lookup error while loading libservicemanager.so.1:
  /usr/lib/libpxscene.so: error: symbol lookup error: undefined symbol: _Z6pxMainiPPc (fatal)