### PR TITLE
Fix for missing ucontext -> ucontext_t

### DIFF
--- a/examples/pxScene2d/external/breakpad-chrome_55/src/client/linux/handler/exception_handler.h
+++ b/examples/pxScene2d/external/breakpad-chrome_55/src/client/linux/handler/exception_handler.h
@@ -44,6 +44,10 @@
 #include "common/using_std_string.h"
 #include "google_breakpad/common/minidump_format.h"
 
+#ifndef ucontext
+#define ucontext ucontext_t
+#endif
+
 namespace google_breakpad {
 
 // ExceptionHandler


### PR DESCRIPTION
In modern versions of glibc, ucontext is defined exclusively as
ucontext_t.  This minor fix allows the build to work again.  I don't
know which version of glibc this starts with, but it effects glibc 2.26
and later at least and wasn't needed for glibc 2.24