### PR TITLE
permissions for wayland apps;

### DIFF
--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -1494,12 +1494,13 @@ public:
 
   rtError loadArchive(const rtString& url, rtObjectRef& archive)
   {
-    bool allowed;
-    if (allows(url, allowed) == RT_OK && !allowed)
+#ifdef ENABLE_PERMISSIONS_CHECK
+    if (!mPermissions.allows(url.cString(), rtPermissions::DEFAULT))
     {
       rtLogError("url '%s' is not allowed", url.cString());
       return RT_ERROR_NOT_ALLOWED;
     }
+#endif
 
     rtError e = RT_FAIL;
     rtRef<pxArchive> a = new pxArchive;

--- a/src/rtPermissions.cpp
+++ b/src/rtPermissions.cpp
@@ -25,69 +25,67 @@
 #include <../remote/rapidjson/error/en.h>
 
 #include <stdlib.h>
+#include <algorithm>
 
+
+// Bootstrap
 const char* rtPermissions::DEFAULT_CONFIG_FILE = "./pxscenepermissions.conf";
 const char* rtPermissions::CONFIG_ENV_NAME = "PXSCENE_PERMISSIONS_CONFIG";
-std::map<std::string, std::string> rtPermissions::mAssignMap;
-std::map<std::string, permissionsMap_t> rtPermissions::mRolesMap;
+const int rtPermissions::CONFIG_BUFFER_SIZE = 65536;
+rtPermissions::assignMap_t rtPermissions::mAssignMap;
+rtPermissions::roleMap_t rtPermissions::mRolesMap;
 std::string rtPermissions::mConfigPath;
 
-template<typename Map> typename Map::const_iterator
-findBestWildcardMatch(Map const& map, typename Map::key_type const& key)
-{
-  if (key.empty())
-    return map.end();
 
+template<typename Map> typename Map::const_iterator
+rtPermissions::findWildcard(Map const& map, typename Map::key_type const& key)
+{
   size_t bestMatchLength = 0;
-  typename Map::const_iterator it = map.begin();
   typename Map::const_iterator best = map.end();
-  for (; it != map.end(); ++it)
+  for (typename Map::const_iterator it = map.begin(); it != map.end(); ++it)
   {
-    const char* url = key.c_str();
-    const char* wildcard = it->first.c_str();
-    size_t len = 0;
-    const char* wildcardAlt = NULL;
-    size_t lenAlt = 0;
-    for (; *url; url++)
+    if (it->first.second != key.second)
     {
-      while (*wildcard == '*')
-      {
-        wildcardAlt = ++wildcard;
-        lenAlt = len;
-      }
-      if (*url == *wildcard)
-      {
-        wildcard++;
-        len++;
-      }
-      else if (wildcardAlt != NULL)
-      {
-        wildcard = wildcardAlt;
-        len = lenAlt;
-      }
-      else
-      {
-        break;
-      }
+      continue;
     }
-    for (; *wildcard == '*'; wildcard++);
-    if (*wildcard == 0 && len >= bestMatchLength)
+    const char* url = key.first.c_str();
+    const char* w = it->first.first.c_str();
+    const char* wAlt = NULL;
+    size_t len = 0;
+    size_t lenAlt = 0;
+    for (; *url && w; url++)
     {
-      bestMatchLength = len;
-      best = it;
+      for (; *w == '*'; wAlt = ++w, lenAlt = len);
+      bool equal = *url == *w;
+      w = equal ? w + 1 : wAlt;
+      len = equal ? len + 1 : lenAlt;
+    }
+    if (w)
+    {
+      for (; *w == '*'; w++);
+      if (*w == 0 && len >= bestMatchLength)
+      {
+        bestMatchLength = len;
+        best = it;
+      }
     }
   }
-
+  if (best == map.end() && key.second != DEFAULT)
+  {
+    typename Map::key_type key2 = key;
+    key2.second = DEFAULT;
+    return findWildcard(map, key2);
+  }
   return best;
 }
 
-permissionsMap_t permissionsJsonToMap(const rapidjson::Value& json)
+rtPermissions::permissionsMap_t permissionsJsonToMap(const rapidjson::Value& json)
 {
-  permissionsMap_t ret;
-  for (int i = 0; i < 3; i++)
+  rtPermissions::permissionsMap_t ret;
+  for (int i = 0; i < 4; i++)
   {
     // first level... "url", "serviceManager", "features"
-    const char* sectionName = i == 1 ? "serviceManager" : (i == 2 ? "features" : "url");
+    const char* sectionName = i == 1 ? "serviceManager" : (i == 2 ? "features" : (i == 3 ? "applications" : "url"));
     if (json.HasMember(sectionName))
     {
       const rapidjson::Value& sec = json[sectionName];
@@ -101,9 +99,10 @@ permissionsMap_t permissionsJsonToMap(const rapidjson::Value& json)
           for (rapidjson::SizeType k = 0; k < arr.Size(); k++)
           {
             // third level... array of urls
-            std::string key = i == 1 ? "serviceManager://" : (i == 2 ? "feature://" : "");
-            key += arr[k].GetString();
-            ret[key] = j == 0;
+            rtPermissions::wildcard_t w;
+            w.first = arr[k].GetString();
+            w.second = rtPermissions::Type(i);
+            ret[w] = j == 0;
           }
         }
       }
@@ -112,13 +111,13 @@ permissionsMap_t permissionsJsonToMap(const rapidjson::Value& json)
   return ret;
 }
 
-permissionsMap_t permissionsObjectToMap(const rtObjectRef& permissionsObject)
+rtPermissions::permissionsMap_t permissionsObjectToMap(const rtObjectRef& permissionsObject)
 {
-  permissionsMap_t ret;
-  for (int i = 0; i < 3; i++)
+  rtPermissions::permissionsMap_t ret;
+  for (int i = 0; i < 4; i++)
   {
     // first level... "url", "serviceManager", "features"
-    const char* sectionName = i == 1 ? "serviceManager" : (i == 2 ? "features" : "url");
+    const char* sectionName = i == 1 ? "serviceManager" : (i == 2 ? "features" : (i == 3 ? "applications" : "url"));
     const rtObjectRef& sec = permissionsObject.get<rtObjectRef>(sectionName);
     if (sec)
     {
@@ -133,9 +132,10 @@ permissionsMap_t permissionsObjectToMap(const rtObjectRef& permissionsObject)
           for (uint32_t k = 0; k < len; k++)
           {
             // third level... array of urls
-            std::string key = i == 1 ? "serviceManager://" : (i == 2 ? "feature://" : "");
-            key += arr.get<rtString>(k).cString();
-            ret[key] = j == 0;
+            rtPermissions::wildcard_t w;
+            w.first = arr.get<rtString>(k).cString();
+            w.second = rtPermissions::Type(i);
+            ret[w] = j == 0;
           }
         }
       }
@@ -178,13 +178,13 @@ rtError rtPermissions::loadBootstrapConfig(const char* filename)
   FILE* fp = fopen(s, "rb");
   if (NULL == fp)
   {
-    rtLogInfo("Permissions config read error : cannot open '%s'", s);
+    rtLogDebug("Permissions config read error : cannot open '%s'", s);
     return RT_FAIL;
   }
 
   rapidjson::Document doc;
   rapidjson::ParseResult result;
-  char readBuffer[65536];
+  char readBuffer[CONFIG_BUFFER_SIZE];
   memset(readBuffer, 0, sizeof(readBuffer));
   rapidjson::FileReadStream is(fp, readBuffer, sizeof(readBuffer));
   result = doc.ParseStream(is);
@@ -206,7 +206,10 @@ rtError rtPermissions::loadBootstrapConfig(const char* filename)
   const rapidjson::Value& assign = doc["assign"];
   for (rapidjson::Value::ConstMemberIterator itr = assign.MemberBegin(); itr != assign.MemberEnd(); ++itr)
   {
-    mAssignMap[itr->name.GetString()] = itr->value.GetString();
+    wildcard_t w;
+    w.first = itr->name.GetString();
+    w.second = DEFAULT;
+    mAssignMap[w] = itr->value.GetString();
   }
   const rapidjson::Value& roles = doc["roles"];
   for (rapidjson::Value::ConstMemberIterator itr = roles.MemberBegin(); itr != roles.MemberEnd(); ++itr)
@@ -230,14 +233,13 @@ rtError rtPermissions::setOrigin(const char* origin)
 {
   if (origin && *origin && !mAssignMap.empty())
   {
-    std::map<std::string, std::string>::const_iterator it =
-      findBestWildcardMatch(mAssignMap, origin);
-
+    wildcard_t w;
+    w.first = origin;
+    w.second = DEFAULT;
+    assignMap_t::const_iterator it = findWildcard(mAssignMap, w);
     if (it != mAssignMap.end())
     {
-      std::map<std::string, permissionsMap_t>::const_iterator jt =
-        mRolesMap.find(it->second);
-
+      roleMap_t::const_iterator jt = mRolesMap.find(it->second);
       if (jt != mRolesMap.end())
       {
         mPermissionsMap = jt->second;
@@ -262,46 +264,28 @@ rtError rtPermissions::setParent(const rtPermissions* parent)
   return RT_OK;
 }
 
-rtError rtPermissions::allows(const char* url, bool& o) const
+rtError rtPermissions::allows(const char* s, rtPermissions::Type type, bool& o) const
 {
-  bool allow = true; // default
+  o = true; // default
 
-  if (url && *url && !mPermissionsMap.empty())
+  if (s && !mPermissionsMap.empty())
   {
-    rtString urlOrigin = rtUrlGetOrigin(url);
-    if (!urlOrigin.isEmpty())
+    wildcard_t w;
+    w.second = type;
+    if (type == DEFAULT)
     {
-      permissionsMap_t::const_iterator it =
-        findBestWildcardMatch(mPermissionsMap, urlOrigin.cString());
-
-      if (it != mPermissionsMap.end())
-      {
-        allow = it->second;
-        if (allow && mParent)
-        {
-          return mParent->allows(url, o);
-        }
-      }
+      w.first = rtUrlGetOrigin(s).cString();
     }
-  }
-
-  o = allow;
-  return RT_OK;
-}
-
-rtError rtPermissions::findMatch(const char* url, std::string& match) const
-{
-  if (url && *url && !mPermissionsMap.empty())
-  {
-    permissionsMap_t::const_iterator it =
-      findBestWildcardMatch(mPermissionsMap, url);
-
+    if (type != DEFAULT || w.first.empty())
+    {
+      w.first = s;
+    }
+    permissionsMap_t::const_iterator it = findWildcard(mPermissionsMap, w);
     if (it != mPermissionsMap.end())
     {
-      match = it->first;
-      return RT_OK;
+      o = it->second;
     }
   }
 
-  return RT_FAIL;
+  return (o && mParent) ? mParent->allows(s, type, o) : RT_OK;
 }

--- a/tests/pxScene2d/supportfiles/pxscenepermissions.sample.conf
+++ b/tests/pxScene2d/supportfiles/pxscenepermissions.sample.conf
@@ -33,6 +33,12 @@
         "allow" : [
           "screenshot"
         ]
+      },
+      "applications" : {
+        "block" : [ "*" ],
+        "allow" : [
+          "browser"
+        ]
       }
     },
     "untrusted" : {
@@ -47,6 +53,9 @@
         "block" : [
           "screenshot"
         ]
+      },
+      "applications" : {
+        "block" : [ "browser" ]
       }
     }
   },

--- a/tests/pxScene2d/test_rtPermissions1.cpp
+++ b/tests/pxScene2d/test_rtPermissions1.cpp
@@ -25,6 +25,8 @@ public:
       p.set("serviceManager", serviceManager);
       rtObjectRef features = new rtMapObject();
       p.set("features", features);
+      rtObjectRef applications = new rtMapObject();
+      p.set("applications", applications);
       rtArrayObject* url_allow = new rtArrayObject();
       url_allow->pushBack("*");
       rtObjectRef url_allow_ref = url_allow;
@@ -37,57 +39,67 @@ public:
       features_allow->pushBack("screenshot");
       rtObjectRef features_allow_ref = features_allow;
       features.set("allow", features_allow_ref);
+      rtArrayObject* applications_allow = new rtArrayObject();
+      applications_allow->pushBack("browser");
+      rtObjectRef applications_allow_ref = applications_allow;
+      applications.set("allow", applications_allow_ref);
       permissions = p;
     }
+
+    EXPECT_TRUE (RT_OK == mPermissions.set(permissions));
+    EXPECT_TRUE (RT_OK == mPermissions.setParent(NULL));
 
     // FullTrust
     // Allow everything
     // NOTE: these blocks of checks have identical URLs across thew whole file. If you change one, change the rest too!
-    EXPECT_TRUE (allows(NULL, permissions, NULL));
-    EXPECT_TRUE (allows("", permissions, NULL));
-    EXPECT_TRUE (allows("foo", permissions, NULL));
-    EXPECT_TRUE (allows("foo://", permissions, NULL));
-    EXPECT_TRUE (allows("foo://example.com", permissions, NULL));
-    EXPECT_TRUE (allows("foo://github.com", permissions, NULL));
-    EXPECT_TRUE (allows("foo://localhost", permissions, NULL));
-    EXPECT_TRUE (allows("http://", permissions, NULL));
-    EXPECT_TRUE (allows("https://", permissions, NULL));
-    EXPECT_TRUE (allows("http://example.com", permissions, NULL));
-    EXPECT_TRUE (allows("https://example.com", permissions, NULL));
-    EXPECT_TRUE (allows("https://github.com", permissions, NULL));
-    EXPECT_TRUE (allows("https://github.com:80", permissions, NULL));
-    EXPECT_TRUE (allows("https://github.com:80/", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost/", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:10004", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", permissions, NULL));
-    EXPECT_TRUE (allows("http://127.0.0.1:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[::1]:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://::1:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://127.0.0.1:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[::1]:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("http://::1:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("https://localhost", permissions, NULL));
-    EXPECT_TRUE (allows("https://localhost/", permissions, NULL));
-    EXPECT_TRUE (allows("https://localhost:10004", permissions, NULL));
-    EXPECT_TRUE (allows("https://localhost:50050", permissions, NULL));
-    EXPECT_TRUE (allows("serviceManager://", permissions, NULL));
-    EXPECT_TRUE (allows("serviceManager://org.rdk.soundPlayer_1", permissions, NULL));
-    EXPECT_TRUE (allows("serviceManager://com.comcast.application", permissions, NULL));
-    EXPECT_TRUE (allows("serviceManager://com.comcast.stateObserver", permissions, NULL));
-    EXPECT_TRUE (allows("serviceManager://com.comcast.FrameRate", permissions, NULL));
-    EXPECT_TRUE (allows("feature://", permissions, NULL));
-    EXPECT_TRUE (allows("feature://screenshot", permissions, NULL));
-    EXPECT_TRUE (allows("feature://unknown", permissions, NULL));
+    EXPECT_TRUE (allows(NULL, rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://github.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com:80", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com:80/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("", rtPermissions::SERVICE));
+    EXPECT_TRUE (allows("org.rdk.soundPlayer_1", rtPermissions::SERVICE));
+    EXPECT_TRUE (allows("com.comcast.application", rtPermissions::SERVICE));
+    EXPECT_TRUE (allows("com.comcast.stateObserver", rtPermissions::SERVICE));
+    EXPECT_TRUE (allows("com.comcast.FrameRate", rtPermissions::SERVICE));
+    EXPECT_TRUE (allows("", rtPermissions::FEATURE));
+    EXPECT_TRUE (allows("screenshot", rtPermissions::FEATURE));
+    EXPECT_TRUE (allows("unknown", rtPermissions::FEATURE));
+    EXPECT_TRUE (allows("", rtPermissions::WAYLAND));
+    EXPECT_TRUE (allows("browser", rtPermissions::WAYLAND));
+    EXPECT_TRUE (allows("unknown", rtPermissions::WAYLAND));
 
     rtObjectRef childPermissions;
     {
@@ -128,56 +140,63 @@ public:
       childPermissions = p;
     }
 
+    EXPECT_TRUE (RT_OK == mPermissions.set(childPermissions));
+    EXPECT_TRUE (RT_OK == mParentPermissions.set(permissions));
+    EXPECT_TRUE (RT_OK == mPermissions.setParent(&mParentPermissions));
+
     // FullTrust -> Child
     // Allow everything
     // + Block all http://localhost... URL-s except http://localhost:50050
     // + Block 3 given serviceManager-s
     // + Block all features except screenshot
-    EXPECT_TRUE (allows(NULL, childPermissions, permissions));
-    EXPECT_TRUE (allows("", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo://", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo://example.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo://github.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo://localhost", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://example.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://example.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://github.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://github.com:80", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://github.com:80/", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost/", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost:10004", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://127.0.0.1:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[::1]:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://::1:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://127.0.0.1:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[::1]:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://::1:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://localhost", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://localhost/", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://localhost:10004", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://localhost:50050", childPermissions, permissions));
-    EXPECT_TRUE (allows("serviceManager://", childPermissions, permissions));
-    EXPECT_TRUE (allows("serviceManager://org.rdk.soundPlayer_1", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.application", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.stateObserver", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.FrameRate", childPermissions, permissions));
-    EXPECT_FALSE(allows("feature://", childPermissions, permissions));
-    EXPECT_TRUE (allows("feature://screenshot", childPermissions, permissions));
-    EXPECT_FALSE(allows("feature://unknown", childPermissions, permissions));
+    EXPECT_TRUE (allows(NULL, rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://github.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com:80", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com:80/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("", rtPermissions::SERVICE));
+    EXPECT_TRUE (allows("org.rdk.soundPlayer_1", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.application", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.stateObserver", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.FrameRate", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("", rtPermissions::FEATURE));
+    EXPECT_TRUE (allows("screenshot", rtPermissions::FEATURE));
+    EXPECT_FALSE(allows("unknown", rtPermissions::FEATURE));
+    EXPECT_TRUE (allows("", rtPermissions::WAYLAND));
+    EXPECT_TRUE (allows("browser", rtPermissions::WAYLAND));
+    EXPECT_TRUE (allows("unknown", rtPermissions::WAYLAND));
   }
 
   void testUntrusted()
@@ -191,6 +210,8 @@ public:
       p.set("serviceManager", serviceManager);
       rtObjectRef features = new rtMapObject();
       p.set("features", features);
+      rtObjectRef applications = new rtMapObject();
+      p.set("applications", applications);
       rtArrayObject* url_allow = new rtArrayObject();
       url_allow->pushBack("*");
       rtObjectRef url_allow_ref = url_allow;
@@ -211,59 +232,74 @@ public:
       features_block->pushBack("screenshot");
       rtObjectRef features_block_ref = features_block;
       features.set("block", features_block_ref);
+      rtArrayObject* applications_allow = new rtArrayObject();
+      applications_allow->pushBack("*");
+      rtObjectRef applications_allow_ref = applications_allow;
+      applications.set("allow", applications_allow_ref);
+      rtArrayObject* applications_block = new rtArrayObject();
+      applications_block->pushBack("browser");
+      rtObjectRef applications_block_ref = applications_block;
+      applications.set("block", applications_block_ref);
       permissions = p;
     }
+
+    EXPECT_TRUE (RT_OK == mPermissions.set(permissions));
+    EXPECT_TRUE (RT_OK == mPermissions.setParent(NULL));
 
     // Untrusted
     // Allow everything
     // + Block all http://localhost... URL-s
     // + Block all serviceManager-s
     // + Block feature screenshot
-    EXPECT_TRUE (allows(NULL, permissions, NULL));
-    EXPECT_TRUE (allows("", permissions, NULL));
-    EXPECT_TRUE (allows("foo", permissions, NULL));
-    EXPECT_TRUE (allows("foo://", permissions, NULL));
-    EXPECT_TRUE (allows("foo://example.com", permissions, NULL));
-    EXPECT_TRUE (allows("foo://github.com", permissions, NULL));
-    EXPECT_TRUE (allows("foo://localhost", permissions, NULL));
-    EXPECT_TRUE (allows("http://", permissions, NULL));
-    EXPECT_TRUE (allows("https://", permissions, NULL));
-    EXPECT_TRUE (allows("http://example.com", permissions, NULL));
-    EXPECT_TRUE (allows("https://example.com", permissions, NULL));
-    EXPECT_TRUE (allows("https://github.com", permissions, NULL));
-    EXPECT_TRUE (allows("https://github.com:80", permissions, NULL));
-    EXPECT_TRUE (allows("https://github.com:80/", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost/", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost:10004", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost:50050", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost:50050/authService", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost:50050/authService/getDeviceId", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost:50050/authService/getAuthToken", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost:50050/authService/getSessionToken", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost:50050/authService/getServiceAccessToken", permissions, NULL));
-    EXPECT_TRUE (allows("http://127.0.0.1:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[::1]:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://::1:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://127.0.0.1:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[::1]:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("http://::1:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("https://localhost", permissions, NULL));
-    EXPECT_TRUE (allows("https://localhost/", permissions, NULL));
-    EXPECT_TRUE (allows("https://localhost:10004", permissions, NULL));
-    EXPECT_TRUE (allows("https://localhost:50050", permissions, NULL));
-    EXPECT_FALSE(allows("serviceManager://", permissions, NULL));
-    EXPECT_FALSE(allows("serviceManager://org.rdk.soundPlayer_1", permissions, NULL));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.application", permissions, NULL));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.stateObserver", permissions, NULL));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.FrameRate", permissions, NULL));
-    EXPECT_TRUE (allows("feature://", permissions, NULL));
-    EXPECT_FALSE(allows("feature://screenshot", permissions, NULL));
-    EXPECT_TRUE (allows("feature://unknown", permissions, NULL));
+    // + Block application browser
+    EXPECT_TRUE (allows(NULL, rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://github.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com:80", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com:80/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:50050/authService", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:50050/authService/getDeviceId", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:50050/authService/getAuthToken", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:50050/authService/getSessionToken", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:50050/authService/getServiceAccessToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("org.rdk.soundPlayer_1", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.application", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.stateObserver", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.FrameRate", rtPermissions::SERVICE));
+    EXPECT_TRUE (allows("", rtPermissions::FEATURE));
+    EXPECT_FALSE(allows("screenshot", rtPermissions::FEATURE));
+    EXPECT_TRUE (allows("unknown", rtPermissions::FEATURE));
+    EXPECT_TRUE (allows("", rtPermissions::WAYLAND));
+    EXPECT_FALSE(allows("browser", rtPermissions::WAYLAND));
+    EXPECT_TRUE (allows("unknown", rtPermissions::WAYLAND));
 
     rtObjectRef childPermissions;
     {
@@ -304,56 +340,63 @@ public:
       childPermissions = p;
     }
 
+    EXPECT_TRUE (RT_OK == mPermissions.set(childPermissions));
+    EXPECT_TRUE (RT_OK == mParentPermissions.set(permissions));
+    EXPECT_TRUE (RT_OK == mPermissions.setParent(&mParentPermissions));
+
     // Untrusted -> Child
     // Allow everything
     // + Block all http://localhost... URL-s
     // + Block all serviceManager-s
-    // + Block all features
-    EXPECT_TRUE (allows(NULL, childPermissions, permissions));
-    EXPECT_TRUE (allows("", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo://", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo://example.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo://github.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo://localhost", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://example.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://example.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://github.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://github.com:80", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://github.com:80/", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost/", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost:10004", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost:50050", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost:50050/authService", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost:50050/authService/getDeviceId", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost:50050/authService/getAuthToken", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost:50050/authService/getSessionToken", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost:50050/authService/getServiceAccessToken", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://127.0.0.1:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[::1]:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://::1:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://127.0.0.1:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[::1]:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://::1:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://localhost", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://localhost/", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://localhost:10004", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://localhost:50050", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://org.rdk.soundPlayer_1", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.application", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.stateObserver", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.FrameRate", childPermissions, permissions));
-    EXPECT_FALSE(allows("feature://", childPermissions, permissions));
-    EXPECT_FALSE(allows("feature://screenshot", childPermissions, permissions));
-    EXPECT_FALSE(allows("feature://unknown", childPermissions, permissions));
+    // + Block all features except screenshot
+    EXPECT_TRUE (allows(NULL, rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://github.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com:80", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com:80/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:50050/authService", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:50050/authService/getDeviceId", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:50050/authService/getAuthToken", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:50050/authService/getSessionToken", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:50050/authService/getServiceAccessToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("org.rdk.soundPlayer_1", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.application", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.stateObserver", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.FrameRate", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("", rtPermissions::FEATURE));
+    EXPECT_FALSE(allows("screenshot", rtPermissions::FEATURE));
+    EXPECT_FALSE(allows("unknown", rtPermissions::FEATURE));
+    EXPECT_TRUE (allows("", rtPermissions::WAYLAND));
+    EXPECT_FALSE(allows("browser", rtPermissions::WAYLAND));
+    EXPECT_TRUE (allows("unknown", rtPermissions::WAYLAND));
   }
 
   void testLimitedTrust()
@@ -367,6 +410,8 @@ public:
       p.set("serviceManager", serviceManager);
       rtObjectRef features = new rtMapObject();
       p.set("features", features);
+      rtObjectRef applications = new rtMapObject();
+      p.set("applications", applications);
       rtArrayObject* url_allow = new rtArrayObject();
       url_allow->pushBack("*");
       url_allow->pushBack("http://localhost:50050");
@@ -393,59 +438,74 @@ public:
       features_block->pushBack("*");
       rtObjectRef features_block_ref = features_block;
       features.set("block", features_block_ref);
+      rtArrayObject* applications_allow = new rtArrayObject();
+      applications_allow->pushBack("browser");
+      rtObjectRef applications_allow_ref = applications_allow;
+      applications.set("allow", applications_allow_ref);
+      rtArrayObject* applications_block = new rtArrayObject();
+      applications_block->pushBack("*");
+      rtObjectRef applications_block_ref = applications_block;
+      applications.set("block", applications_block_ref);
       permissions = p;
     }
+
+    EXPECT_TRUE (RT_OK == mPermissions.set(permissions));
+    EXPECT_TRUE (RT_OK == mPermissions.setParent(NULL));
 
     // LimitedTrust
     // Allow everything
     // + Block all http://localhost... URL-s except http://localhost:50050
     // + Block 2 serviceManager-s
     // + Block all features except screenshot
-    EXPECT_TRUE (allows(NULL, permissions, NULL));
-    EXPECT_TRUE (allows("", permissions, NULL));
-    EXPECT_TRUE (allows("foo", permissions, NULL));
-    EXPECT_TRUE (allows("foo://", permissions, NULL));
-    EXPECT_TRUE (allows("foo://example.com", permissions, NULL));
-    EXPECT_TRUE (allows("foo://github.com", permissions, NULL));
-    EXPECT_TRUE (allows("foo://localhost", permissions, NULL));
-    EXPECT_TRUE (allows("http://", permissions, NULL));
-    EXPECT_TRUE (allows("https://", permissions, NULL));
-    EXPECT_TRUE (allows("http://example.com", permissions, NULL));
-    EXPECT_TRUE (allows("https://example.com", permissions, NULL));
-    EXPECT_TRUE (allows("https://github.com", permissions, NULL));
-    EXPECT_TRUE (allows("https://github.com:80", permissions, NULL));
-    EXPECT_TRUE (allows("https://github.com:80/", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost/", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost:10004", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", permissions, NULL));
-    EXPECT_TRUE (allows("http://127.0.0.1:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[::1]:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://::1:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://127.0.0.1:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[::1]:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("http://::1:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", permissions, NULL));
-    EXPECT_TRUE (allows("https://localhost", permissions, NULL));
-    EXPECT_TRUE (allows("https://localhost/", permissions, NULL));
-    EXPECT_TRUE (allows("https://localhost:10004", permissions, NULL));
-    EXPECT_TRUE (allows("https://localhost:50050", permissions, NULL));
-    EXPECT_TRUE (allows("serviceManager://", permissions, NULL));
-    EXPECT_TRUE (allows("serviceManager://org.rdk.soundPlayer_1", permissions, NULL));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.application", permissions, NULL));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.stateObserver", permissions, NULL));
-    EXPECT_TRUE (allows("serviceManager://com.comcast.FrameRate", permissions, NULL));
-    EXPECT_FALSE(allows("feature://", permissions, NULL));
-    EXPECT_TRUE (allows("feature://screenshot", permissions, NULL));
-    EXPECT_FALSE(allows("feature://unknown", permissions, NULL));
+    // + Block all applications except browser
+    EXPECT_TRUE (allows(NULL, rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://github.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com:80", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com:80/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("", rtPermissions::SERVICE));
+    EXPECT_TRUE (allows("org.rdk.soundPlayer_1", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.application", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.stateObserver", rtPermissions::SERVICE));
+    EXPECT_TRUE (allows("com.comcast.FrameRate", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("", rtPermissions::FEATURE));
+    EXPECT_TRUE (allows("screenshot", rtPermissions::FEATURE));
+    EXPECT_FALSE(allows("unknown", rtPermissions::FEATURE));
+    EXPECT_FALSE(allows("", rtPermissions::WAYLAND));
+    EXPECT_TRUE (allows("browser", rtPermissions::WAYLAND));
+    EXPECT_FALSE(allows("unknown", rtPermissions::WAYLAND));
 
     rtObjectRef childPermissions;
     {
@@ -486,56 +546,63 @@ public:
       childPermissions = p;
     }
 
+    EXPECT_TRUE (RT_OK == mPermissions.set(childPermissions));
+    EXPECT_TRUE (RT_OK == mParentPermissions.set(permissions));
+    EXPECT_TRUE (RT_OK == mPermissions.setParent(&mParentPermissions));
+
     // LimitedTrust -> Child
     // Allow everything
     // + Block all http://localhost... URL-s except http://localhost:50050
     // + Block 3 serviceManager-s
     // + Block all features except screenshot
-    EXPECT_TRUE (allows(NULL, childPermissions, permissions));
-    EXPECT_TRUE (allows("", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo://", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo://example.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo://github.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo://localhost", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://example.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://example.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://github.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://github.com:80", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://github.com:80/", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost/", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost:10004", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://127.0.0.1:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[::1]:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://::1:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://127.0.0.1:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[::1]:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://::1:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://localhost", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://localhost/", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://localhost:10004", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://localhost:50050", childPermissions, permissions));
-    EXPECT_TRUE (allows("serviceManager://", childPermissions, permissions));
-    EXPECT_TRUE (allows("serviceManager://org.rdk.soundPlayer_1", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.application", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.stateObserver", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.FrameRate", childPermissions, permissions));
-    EXPECT_FALSE(allows("feature://", childPermissions, permissions));
-    EXPECT_TRUE (allows("feature://screenshot", childPermissions, permissions));
-    EXPECT_FALSE(allows("feature://unknown", childPermissions, permissions));
+    EXPECT_TRUE (allows(NULL, rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://github.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("foo://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com:80", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://github.com:80/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("", rtPermissions::SERVICE));
+    EXPECT_TRUE (allows("org.rdk.soundPlayer_1", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.application", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.stateObserver", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.FrameRate", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("", rtPermissions::FEATURE));
+    EXPECT_TRUE (allows("screenshot", rtPermissions::FEATURE));
+    EXPECT_FALSE(allows("unknown", rtPermissions::FEATURE));
+    EXPECT_FALSE(allows("", rtPermissions::WAYLAND));
+    EXPECT_TRUE (allows("browser", rtPermissions::WAYLAND));
+    EXPECT_FALSE(allows("unknown", rtPermissions::WAYLAND));
   }
 
   void testRealWorldExample()
@@ -549,6 +616,8 @@ public:
       p.set("serviceManager", serviceManager);
       rtObjectRef features = new rtMapObject();
       p.set("features", features);
+      rtObjectRef applications = new rtMapObject();
+      p.set("applications", applications);
       rtArrayObject* url_allow = new rtArrayObject();
       url_allow->pushBack("http://*");
       url_allow->pushBack("https://*");
@@ -608,59 +677,74 @@ public:
       features_block->pushBack("*");
       rtObjectRef features_block_ref = features_block;
       features.set("block", features_block_ref);
+      rtArrayObject* applications_allow = new rtArrayObject();
+      applications_allow->pushBack("browser");
+      rtObjectRef applications_allow_ref = applications_allow;
+      applications.set("allow", applications_allow_ref);
+      rtArrayObject* applications_block = new rtArrayObject();
+      applications_block->pushBack("*");
+      rtObjectRef applications_block_ref = applications_block;
+      applications.set("block", applications_block_ref);
       permissions = p;
     }
+
+    EXPECT_TRUE (RT_OK == mPermissions.set(permissions));
+    EXPECT_TRUE (RT_OK == mPermissions.setParent(NULL));
 
     // RealWorldExample
     // Block everything
     // + Allow all http://... and https://... except github.com and localhost UNLESS localhost port is 50050 and scheme is http
     // + Allow 2 serviceManager-s
     // + Allow feature screenshot
-    EXPECT_TRUE (allows(NULL, permissions, NULL));
-    EXPECT_TRUE (allows("", permissions, NULL));
-    EXPECT_TRUE (allows("foo", permissions, NULL));
-    EXPECT_FALSE(allows("foo://", permissions, NULL));
-    EXPECT_FALSE(allows("foo://example.com", permissions, NULL));
-    EXPECT_FALSE(allows("foo://github.com", permissions, NULL));
-    EXPECT_FALSE(allows("foo://localhost", permissions, NULL));
-    EXPECT_TRUE (allows("http://", permissions, NULL));
-    EXPECT_TRUE (allows("https://", permissions, NULL));
-    EXPECT_TRUE (allows("http://example.com", permissions, NULL));
-    EXPECT_TRUE (allows("https://example.com", permissions, NULL));
-    EXPECT_FALSE(allows("https://github.com", permissions, NULL));
-    EXPECT_FALSE(allows("https://github.com:80", permissions, NULL));
-    EXPECT_FALSE(allows("https://github.com:80/", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost/", permissions, NULL));
-    EXPECT_FALSE(allows("http://localhost:10004", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", permissions, NULL));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", permissions, NULL));
-    EXPECT_TRUE (allows("http://127.0.0.1:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[::1]:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://::1:50050/", permissions, NULL));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", permissions, NULL));
-    EXPECT_FALSE(allows("http://127.0.0.1:1001/", permissions, NULL));
-    EXPECT_FALSE(allows("http://[::1]:1001/", permissions, NULL));
-    EXPECT_FALSE(allows("http://[0:0:0:0:0:0:0:1]:1001/", permissions, NULL));
-    EXPECT_FALSE(allows("http://::1:1001/", permissions, NULL));
-    EXPECT_FALSE(allows("http://0:0:0:0:0:0:0:1:1001/", permissions, NULL));
-    EXPECT_FALSE(allows("https://localhost", permissions, NULL));
-    EXPECT_FALSE(allows("https://localhost/", permissions, NULL));
-    EXPECT_FALSE(allows("https://localhost:10004", permissions, NULL));
-    EXPECT_FALSE(allows("https://localhost:50050", permissions, NULL));
-    EXPECT_FALSE(allows("serviceManager://", permissions, NULL));
-    EXPECT_FALSE(allows("serviceManager://org.rdk.soundPlayer_1", permissions, NULL));
-    EXPECT_TRUE (allows("serviceManager://com.comcast.application", permissions, NULL));
-    EXPECT_TRUE (allows("serviceManager://com.comcast.stateObserver", permissions, NULL));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.FrameRate", permissions, NULL));
-    EXPECT_FALSE(allows("feature://", permissions, NULL));
-    EXPECT_TRUE (allows("feature://screenshot", permissions, NULL));
-    EXPECT_FALSE(allows("feature://unknown", permissions, NULL));
+    // + Allow application browser
+    EXPECT_TRUE (allows(NULL, rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("foo", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("foo://", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("foo://example.com", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("foo://github.com", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("foo://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://example.com", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://github.com", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://github.com:80", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://github.com:80/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://127.0.0.1:1001/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://[::1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://[0:0:0:0:0:0:0:1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://::1:1001/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://0:0:0:0:0:0:0:1:1001/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://localhost", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://localhost/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("org.rdk.soundPlayer_1", rtPermissions::SERVICE));
+    EXPECT_TRUE (allows("com.comcast.application", rtPermissions::SERVICE));
+    EXPECT_TRUE (allows("com.comcast.stateObserver", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.FrameRate", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("", rtPermissions::FEATURE));
+    EXPECT_TRUE (allows("screenshot", rtPermissions::FEATURE));
+    EXPECT_FALSE(allows("unknown", rtPermissions::FEATURE));
+    EXPECT_FALSE(allows("", rtPermissions::WAYLAND));
+    EXPECT_TRUE (allows("browser", rtPermissions::WAYLAND));
+    EXPECT_FALSE(allows("unknown", rtPermissions::WAYLAND));
 
     rtObjectRef childPermissions;
     {
@@ -701,77 +785,74 @@ public:
       childPermissions = p;
     }
 
+    EXPECT_TRUE (RT_OK == mPermissions.set(childPermissions));
+    EXPECT_TRUE (RT_OK == mParentPermissions.set(permissions));
+    EXPECT_TRUE (RT_OK == mPermissions.setParent(&mParentPermissions));
+
     // RealWorldExample -> Child
     // Block everything
     // + Allow http://localhost:50050
     // + Allow feature screenshot
-    EXPECT_TRUE (allows(NULL, childPermissions, permissions));
-    EXPECT_TRUE (allows("", childPermissions, permissions));
-    EXPECT_TRUE (allows("foo", childPermissions, permissions));
-    EXPECT_FALSE(allows("foo://", childPermissions, permissions));
-    EXPECT_FALSE(allows("foo://example.com", childPermissions, permissions));
-    EXPECT_FALSE(allows("foo://github.com", childPermissions, permissions));
-    EXPECT_FALSE(allows("foo://localhost", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://example.com", childPermissions, permissions));
-    EXPECT_TRUE (allows("https://example.com", childPermissions, permissions));
-    EXPECT_FALSE(allows("https://github.com", childPermissions, permissions));
-    EXPECT_FALSE(allows("https://github.com:80", childPermissions, permissions));
-    EXPECT_FALSE(allows("https://github.com:80/", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost/", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://localhost:10004", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://127.0.0.1:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[::1]:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://::1:50050/", childPermissions, permissions));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://127.0.0.1:1001/", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://[::1]:1001/", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://[0:0:0:0:0:0:0:1]:1001/", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://::1:1001/", childPermissions, permissions));
-    EXPECT_FALSE(allows("http://0:0:0:0:0:0:0:1:1001/", childPermissions, permissions));
-    EXPECT_FALSE(allows("https://localhost", childPermissions, permissions));
-    EXPECT_FALSE(allows("https://localhost/", childPermissions, permissions));
-    EXPECT_FALSE(allows("https://localhost:10004", childPermissions, permissions));
-    EXPECT_FALSE(allows("https://localhost:50050", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://org.rdk.soundPlayer_1", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.application", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.stateObserver", childPermissions, permissions));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.FrameRate", childPermissions, permissions));
-    EXPECT_FALSE(allows("feature://", childPermissions, permissions));
-    EXPECT_TRUE (allows("feature://screenshot", childPermissions, permissions));
-    EXPECT_FALSE(allows("feature://unknown", childPermissions, permissions));
+    EXPECT_TRUE (allows(NULL, rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("foo", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("foo://", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("foo://example.com", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("foo://github.com", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("foo://localhost", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://example.com", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("https://example.com", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://github.com", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://github.com:80", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://github.com:80/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://127.0.0.1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[::1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://::1:50050/", rtPermissions::DEFAULT));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://127.0.0.1:1001/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://[::1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://[0:0:0:0:0:0:0:1]:1001/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://::1:1001/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("http://0:0:0:0:0:0:0:1:1001/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://localhost", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://localhost/", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://localhost:10004", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("https://localhost:50050", rtPermissions::DEFAULT));
+    EXPECT_FALSE(allows("", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("org.rdk.soundPlayer_1", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.application", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.stateObserver", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("com.comcast.FrameRate", rtPermissions::SERVICE));
+    EXPECT_FALSE(allows("", rtPermissions::FEATURE));
+    EXPECT_TRUE (allows("screenshot", rtPermissions::FEATURE));
+    EXPECT_FALSE(allows("unknown", rtPermissions::FEATURE));
+    EXPECT_FALSE(allows("", rtPermissions::WAYLAND));
+    EXPECT_TRUE (allows("browser", rtPermissions::WAYLAND));
+    EXPECT_FALSE(allows("unknown", rtPermissions::WAYLAND));
   }
 
 private:
-  bool allows(const char* url, const rtObjectRef& permissions, const rtObjectRef& parentPermissions)
+  bool allows(const char* url, rtPermissions::Type type)
   {
-    rtPermissions* p = new rtPermissions();
-    rtPermissions* parent = new rtPermissions();
-    if (permissions)
-    {
-      EXPECT_TRUE (RT_OK == p->set(permissions));
-    }
-    if (parentPermissions)
-    {
-      EXPECT_TRUE (RT_OK == parent->set(parentPermissions));
-      EXPECT_TRUE (RT_OK == p->setParent(parent));
-    }
-
-    bool allows;
-    EXPECT_TRUE (RT_OK == p->allows(url, allows));
-    delete p;
-    return allows;
+    bool a;
+    EXPECT_TRUE (RT_OK == mPermissions.allows(url, type, a));
+    return a;
   }
+
+  rtPermissions mPermissions;
+  rtPermissions mParentPermissions;
 };
 
 TEST_F(rtPermissions1Test, rtPermissionsTests)

--- a/tests/pxScene2d/test_rtPermissions2.cpp
+++ b/tests/pxScene2d/test_rtPermissions2.cpp
@@ -16,171 +16,183 @@ public:
 
   void test()
   {
+    EXPECT_TRUE (RT_OK == rtPermissions::clearBootstrapConfig());
+    EXPECT_TRUE (RT_OK == rtPermissions::loadBootstrapConfig("supportfiles/pxscenepermissions.sample.conf"));
+
     // Bootstrap -> FullTrust
     // Allow everything
-    EXPECT_TRUE (allows(NULL, "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("foo", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("foo://", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("foo://example.com", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("foo://github.com", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("foo://localhost", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("https://", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://example.com", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("https://example.com", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("https://github.com", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("https://github.com:80", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("https://github.com:80/", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://localhost", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://localhost/", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://localhost:10004", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://localhost:50050", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://localhost:50050/authService", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://127.0.0.1:50050/", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://[::1]:50050/", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://::1:50050/", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://127.0.0.1:1001/", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://[::1]:1001/", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://::1:1001/", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("https://localhost", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("https://localhost/", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("https://localhost:10004", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("https://localhost:50050", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("serviceManager://", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("serviceManager://org.rdk.soundPlayer_1", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("serviceManager://com.comcast.application", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("serviceManager://com.comcast.stateObserver", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("serviceManager://com.comcast.FrameRate", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("feature://", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("feature://screenshot", "https://xfinity.comcast.com"));
-    EXPECT_TRUE (allows("feature://unknown", "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows(NULL, rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("foo", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("foo://", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("foo://example.com", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("foo://github.com", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("foo://localhost", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("https://", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://example.com", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("https://example.com", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("https://github.com", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("https://github.com:80", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("https://github.com:80/", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://localhost", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://localhost/", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://localhost:10004", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://localhost:50050", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://localhost:50050/authService", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://127.0.0.1:50050/", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://[::1]:50050/", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://::1:50050/", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://127.0.0.1:1001/", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://[::1]:1001/", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://::1:1001/", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("https://localhost", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("https://localhost/", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("https://localhost:10004", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("https://localhost:50050", rtPermissions::DEFAULT, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("", rtPermissions::SERVICE, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("org.rdk.soundPlayer_1", rtPermissions::SERVICE, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("com.comcast.application", rtPermissions::SERVICE, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("com.comcast.stateObserver", rtPermissions::SERVICE, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("com.comcast.FrameRate", rtPermissions::SERVICE, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("", rtPermissions::FEATURE, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("screenshot", rtPermissions::FEATURE, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("unknown", rtPermissions::FEATURE, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("", rtPermissions::WAYLAND, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("browser", rtPermissions::WAYLAND, "https://xfinity.comcast.com"));
+    EXPECT_TRUE (allows("unknown", rtPermissions::WAYLAND, "https://xfinity.comcast.com"));
 
     // Bootstrap -> LimitedTrust
     // Allow everything
     // + Block all http://localhost... URL-s except http://localhost:50050
     // + Block 2 serviceManager-s
     // + Block all features except screenshot
-    EXPECT_TRUE (allows(NULL, "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("foo", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("foo://", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("foo://example.com", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("foo://github.com", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("foo://localhost", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("https://", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://example.com", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("https://example.com", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("https://github.com", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("https://github.com:80", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("https://github.com:80/", "https://foo.partner2.com"));
-    EXPECT_FALSE(allows("http://localhost", "https://foo.partner2.com"));
-    EXPECT_FALSE(allows("http://localhost/", "https://foo.partner2.com"));
-    EXPECT_FALSE(allows("http://localhost:10004", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://localhost:50050", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://localhost:50050/authService", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://127.0.0.1:50050/", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://[::1]:50050/", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://::1:50050/", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://127.0.0.1:1001/", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://[::1]:1001/", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://::1:1001/", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("https://localhost", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("https://localhost/", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("https://localhost:10004", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("https://localhost:50050", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("serviceManager://", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("serviceManager://org.rdk.soundPlayer_1", "https://foo.partner2.com"));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.application", "https://foo.partner2.com"));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.stateObserver", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("serviceManager://com.comcast.FrameRate", "https://foo.partner2.com"));
-    EXPECT_FALSE(allows("feature://", "https://foo.partner2.com"));
-    EXPECT_TRUE (allows("feature://screenshot", "https://foo.partner2.com"));
-    EXPECT_FALSE(allows("feature://unknown", "https://foo.partner2.com"));
+    // + Block all applications except browser
+    EXPECT_TRUE (allows(NULL, rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("foo", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("foo://", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("foo://example.com", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("foo://github.com", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("foo://localhost", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("https://", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://example.com", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("https://example.com", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("https://github.com", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("https://github.com:80", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("https://github.com:80/", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_FALSE(allows("http://localhost", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_FALSE(allows("http://localhost/", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_FALSE(allows("http://localhost:10004", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://localhost:50050", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://localhost:50050/authService", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getDeviceId", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getAuthToken", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getSessionToken", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://localhost:50050/authService/getServiceAccessToken", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://127.0.0.1:50050/", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://[::1]:50050/", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://::1:50050/", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://127.0.0.1:1001/", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://[::1]:1001/", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://::1:1001/", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("https://localhost", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("https://localhost/", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("https://localhost:10004", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("https://localhost:50050", rtPermissions::DEFAULT, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("", rtPermissions::SERVICE, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("org.rdk.soundPlayer_1", rtPermissions::SERVICE, "https://foo.partner2.com"));
+    EXPECT_FALSE(allows("com.comcast.application", rtPermissions::SERVICE, "https://foo.partner2.com"));
+    EXPECT_FALSE(allows("com.comcast.stateObserver", rtPermissions::SERVICE, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("com.comcast.FrameRate", rtPermissions::SERVICE, "https://foo.partner2.com"));
+    EXPECT_FALSE(allows("", rtPermissions::FEATURE, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("screenshot", rtPermissions::FEATURE, "https://foo.partner2.com"));
+    EXPECT_FALSE(allows("unknown", rtPermissions::FEATURE, "https://foo.partner2.com"));
+    EXPECT_FALSE(allows("", rtPermissions::WAYLAND, "https://foo.partner2.com"));
+    EXPECT_TRUE (allows("browser", rtPermissions::WAYLAND, "https://foo.partner2.com"));
+    EXPECT_FALSE(allows("unknown", rtPermissions::WAYLAND, "https://foo.partner2.com"));
 
     // Bootstrap -> Untrusted
     // Allow everything
     // + Block all http://localhost... URL-s
     // + Block all serviceManager-s
     // + Block feature screenshot
-    EXPECT_TRUE (allows(NULL, "http://example.com"));
-    EXPECT_TRUE (allows("", "http://example.com"));
-    EXPECT_TRUE (allows("http://example.com", "http://example.com"));
-    EXPECT_TRUE (allows("foo://", "http://example.com"));
-    EXPECT_TRUE (allows("foo://example.com", "http://example.com"));
-    EXPECT_TRUE (allows("foo://github.com", "http://example.com"));
-    EXPECT_TRUE (allows("foo://localhost", "http://example.com"));
-    EXPECT_TRUE (allows("http://", "http://example.com"));
-    EXPECT_TRUE (allows("https://", "http://example.com"));
-    EXPECT_TRUE (allows("http://example.com", "http://example.com"));
-    EXPECT_TRUE (allows("https://example.com", "http://example.com"));
-    EXPECT_TRUE (allows("https://github.com", "http://example.com"));
-    EXPECT_TRUE (allows("https://github.com:80", "http://example.com"));
-    EXPECT_TRUE (allows("https://github.com:80/", "http://example.com"));
-    EXPECT_FALSE(allows("http://localhost", "http://example.com"));
-    EXPECT_FALSE(allows("http://localhost/", "http://example.com"));
-    EXPECT_FALSE(allows("http://localhost:10004", "http://example.com"));
-    EXPECT_FALSE(allows("http://localhost:50050", "http://example.com"));
-    EXPECT_FALSE(allows("http://localhost:50050/authService", "http://example.com"));
-    EXPECT_FALSE(allows("http://localhost:50050/authService/getDeviceId", "http://example.com"));
-    EXPECT_FALSE(allows("http://localhost:50050/authService/getAuthToken", "http://example.com"));
-    EXPECT_FALSE(allows("http://localhost:50050/authService/getSessionToken", "http://example.com"));
-    EXPECT_FALSE(allows("http://localhost:50050/authService/getServiceAccessToken", "http://example.com"));
-    EXPECT_TRUE (allows("http://127.0.0.1:50050/", "http://example.com"));
-    EXPECT_TRUE (allows("http://[::1]:50050/", "http://example.com"));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", "http://example.com"));
-    EXPECT_TRUE (allows("http://::1:50050/", "http://example.com"));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", "http://example.com"));
-    EXPECT_TRUE (allows("http://127.0.0.1:1001/", "http://example.com"));
-    EXPECT_TRUE (allows("http://[::1]:1001/", "http://example.com"));
-    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", "http://example.com"));
-    EXPECT_TRUE (allows("http://::1:1001/", "http://example.com"));
-    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", "http://example.com"));
-    EXPECT_TRUE (allows("https://localhost", "http://example.com"));
-    EXPECT_TRUE (allows("https://localhost/", "http://example.com"));
-    EXPECT_TRUE (allows("https://localhost:10004", "http://example.com"));
-    EXPECT_TRUE (allows("https://localhost:50050", "http://example.com"));
-    EXPECT_FALSE(allows("serviceManager://", "http://example.com"));
-    EXPECT_FALSE(allows("serviceManager://org.rdk.soundPlayer_1", "http://example.com"));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.application", "http://example.com"));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.stateObserver", "http://example.com"));
-    EXPECT_FALSE(allows("serviceManager://com.comcast.FrameRate", "http://example.com"));
-    EXPECT_TRUE (allows("feature://", "http://example.com"));
-    EXPECT_FALSE(allows("feature://screenshot", "http://example.com"));
-    EXPECT_TRUE (allows("feature://unknown", "http://example.com"));
+    // + Block application browser
+    EXPECT_TRUE (allows(NULL, rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("http://example.com", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("foo://", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("foo://example.com", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("foo://github.com", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("foo://localhost", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("http://", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("https://", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("http://example.com", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("https://example.com", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("https://github.com", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("https://github.com:80", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("https://github.com:80/", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_FALSE(allows("http://localhost", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_FALSE(allows("http://localhost/", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_FALSE(allows("http://localhost:10004", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_FALSE(allows("http://localhost:50050", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_FALSE(allows("http://localhost:50050/authService", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_FALSE(allows("http://localhost:50050/authService/getDeviceId", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_FALSE(allows("http://localhost:50050/authService/getAuthToken", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_FALSE(allows("http://localhost:50050/authService/getSessionToken", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_FALSE(allows("http://localhost:50050/authService/getServiceAccessToken", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("http://127.0.0.1:50050/", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("http://[::1]:50050/", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:50050/", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("http://::1:50050/", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:50050/", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("http://127.0.0.1:1001/", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("http://[::1]:1001/", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("http://[0:0:0:0:0:0:0:1]:1001/", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("http://::1:1001/", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("http://0:0:0:0:0:0:0:1:1001/", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("https://localhost", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("https://localhost/", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("https://localhost:10004", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_TRUE (allows("https://localhost:50050", rtPermissions::DEFAULT, "http://example.com"));
+    EXPECT_FALSE(allows("", rtPermissions::SERVICE, "http://example.com"));
+    EXPECT_FALSE(allows("org.rdk.soundPlayer_1", rtPermissions::SERVICE, "http://example.com"));
+    EXPECT_FALSE(allows("com.comcast.application", rtPermissions::SERVICE, "http://example.com"));
+    EXPECT_FALSE(allows("com.comcast.stateObserver", rtPermissions::SERVICE, "http://example.com"));
+    EXPECT_FALSE(allows("com.comcast.FrameRate", rtPermissions::SERVICE, "http://example.com"));
+    EXPECT_TRUE (allows("", rtPermissions::FEATURE, "http://example.com"));
+    EXPECT_FALSE(allows("screenshot", rtPermissions::FEATURE, "http://example.com"));
+    EXPECT_TRUE (allows("unknown", rtPermissions::FEATURE, "http://example.com"));
+    EXPECT_TRUE (allows("", rtPermissions::WAYLAND, "http://example.com"));
+    EXPECT_FALSE(allows("browser", rtPermissions::WAYLAND, "http://example.com"));
+    EXPECT_TRUE (allows("unknown", rtPermissions::WAYLAND, "http://example.com"));
+
+    EXPECT_TRUE (RT_OK == rtPermissions::clearBootstrapConfig());
   }
 
 private:
-  bool allows(const char* url, const char* origin)
+  bool allows(const char* url, rtPermissions::Type type, const char* origin)
   {
-    rtPermissions* p = new rtPermissions();
-    EXPECT_TRUE (RT_OK == p->clearBootstrapConfig());
-    EXPECT_TRUE (RT_OK == p->loadBootstrapConfig("supportfiles/pxscenepermissions.sample.conf"));
-    EXPECT_TRUE (RT_OK == p->setOrigin(origin));
-
+    EXPECT_TRUE (RT_OK == mPermissions.setOrigin(origin));
     bool allows;
-    EXPECT_TRUE (RT_OK == p->allows(url, allows));
-    EXPECT_TRUE (RT_OK == p->clearBootstrapConfig());
-    delete p;
+    EXPECT_TRUE (RT_OK == mPermissions.allows(url, type, allows));
     return allows;
   }
+
+  rtPermissions mPermissions;
 };
 
 TEST_F(rtPermissions2Test, rtPermissionsTests)

--- a/tests/pxScene2d/test_rtPermissions4.cpp
+++ b/tests/pxScene2d/test_rtPermissions4.cpp
@@ -16,305 +16,249 @@ public:
 
   void test1()
   {
-    rtObjectRef permissions;
-    {
-      rtObjectRef p = new rtMapObject();
-      rtObjectRef url = new rtMapObject();
-      p.set("url", url);
-      rtObjectRef serviceManager = new rtMapObject();
-      rtArrayObject* url_allow = new rtArrayObject();
-      url_allow->pushBack("*");
-      url_allow->pushBack("qwerty");
-      url_allow->pushBack("https://comcast.com");
-      url_allow->pushBack("https://comcast.com            ");
-      url_allow->pushBack("            https://comcast.com");
-      rtObjectRef url_allow_ref = url_allow;
-      url.set("allow", url_allow_ref);
-      permissions = p;
-    }
+    mPermissionsMap.clear();
+    mPermissionsMap[rtPermissions::wildcard_t("*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("qwerty", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://comcast.com", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://comcast.com            ", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("            https://comcast.com", rtPermissions::DEFAULT)] = true;
 
-    EXPECT_EQ (-1,test(permissions, "", ""));
-    EXPECT_EQ (0, test(permissions, "asdfgh", "*"));
-    EXPECT_EQ (0, test(permissions, "qwerty", "qwerty"));
-    EXPECT_EQ (0, test(permissions, "*", "*"));
-    EXPECT_EQ (0, test(permissions, "***", "*"));
-    EXPECT_EQ (0, test(permissions, "https://comcast.com", "https://comcast.com"));
-    EXPECT_EQ (0, test(permissions, "https://comcast.com            ", "https://comcast.com            "));
-    EXPECT_EQ (0, test(permissions, "            https://comcast.com", "            https://comcast.com"));
+    EXPECT_EQ (0, test("", "*"));
+    EXPECT_EQ (0, test("asdfgh", "*"));
+    EXPECT_EQ (0, test("qwerty", "qwerty"));
+    EXPECT_EQ (0, test("*", "*"));
+    EXPECT_EQ (0, test("***", "*"));
+    EXPECT_EQ (0, test("https://comcast.com", "https://comcast.com"));
+    EXPECT_EQ (0, test("https://comcast.com            ", "https://comcast.com            "));
+    EXPECT_EQ (0, test("            https://comcast.com", "            https://comcast.com"));
   }
 
   void test2()
   {
-    rtObjectRef permissions;
-    {
-      rtObjectRef p = new rtMapObject();
-      rtObjectRef url = new rtMapObject();
-      p.set("url", url);
-      rtObjectRef serviceManager = new rtMapObject();
-      rtArrayObject* url_allow = new rtArrayObject();
-      url_allow->pushBack("https://");
-      url_allow->pushBack("https://*");
-      url_allow->pushBack("*://*");
-      url_allow->pushBack("https://comcast.com");
-      url_allow->pushBack("https://comcast.com*");
-      url_allow->pushBack("https://*comcast.com");
-      url_allow->pushBack("*://comcast.com");
-      url_allow->pushBack("https://*.comcast.com/*");
-      url_allow->pushBack("https://*.comcast.com/*/index");
-      url_allow->pushBack("https://*.comcast.com/*/index?*");
-      url_allow->pushBack("https://comcast.com/index/*");
-      url_allow->pushBack("https://*.comcast.com/*/index?p1=*");
-      url_allow->pushBack("http://localhost:*");
-      url_allow->pushBack("http://127.0.0.1:*");
-      url_allow->pushBack("http://[::1]:*");
-      url_allow->pushBack("http://[0:0:0:0:0:0:0:1]:*");
-      url_allow->pushBack("http://::1:*");
-      url_allow->pushBack("http://0:0:0:0:0:0:0:1:*");
-      url_allow->pushBack("http://*:*@www.my_site.com");
-      url_allow->pushBack("http://*/index*");
-      rtObjectRef url_allow_ref = url_allow;
-      url.set("allow", url_allow_ref);
-      permissions = p;
-    }
+    mPermissionsMap.clear();
+    mPermissionsMap[rtPermissions::wildcard_t("https://", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("*://*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://comcast.com", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://comcast.com*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://*comcast.com", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("*://comcast.com", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://*.comcast.com/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://*.comcast.com/*/index", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://*.comcast.com/*/index?*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://comcast.com/index/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://*.comcast.com/*/index?p1=*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://localhost:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://127.0.0.1:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://[::1]:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://[0:0:0:0:0:0:0:1]:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://::1:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://0:0:0:0:0:0:0:1:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://*:*@www.my_site.com", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://*/index*", rtPermissions::DEFAULT)] = true;
 
-    EXPECT_EQ (0, test(permissions, "http://", "*://*"));
-    EXPECT_EQ (0, test(permissions, "https://", "https://*"));
-    EXPECT_EQ (0, test(permissions, "https://comcast.com", "https://comcast.com*"));
-    EXPECT_EQ (0, test(permissions, "https://m.xfinity.comcast.com/index", "https://*.comcast.com/*"));
-    EXPECT_EQ (0, test(permissions, "https://m.xfinity.comcast.com/blabla/index", "https://*.comcast.com/*/index"));
-    EXPECT_EQ (0, test(permissions, "https://m.xfinity.comcast.com/blabla/index?some=some1&parm=value#p1", "https://*.comcast.com/*/index?*"));
-    EXPECT_EQ (0, test(permissions, "https://m.comcast.com/", "https://*.comcast.com/*"));
-    EXPECT_EQ (0, test(permissions, "https://comcast.com/index/blahblah", "https://comcast.com/index/*"));
-    EXPECT_EQ (0, test(permissions, "https://m.comcast.com/a/index?p1=1", "https://*.comcast.com/*/index?p1=*"));
-    EXPECT_EQ (0, test(permissions, "http://localhost:50050/authService/getDeviceId", "http://localhost:*"));
-    EXPECT_EQ (0, test(permissions, "http://127.0.0.1:50050/authService/getDeviceId", "http://127.0.0.1:*"));
-    EXPECT_EQ (0, test(permissions, "http://[::1]:50050/authService/getDeviceId", "http://[::1]:*"));
-    EXPECT_EQ (0, test(permissions, "http://[0:0:0:0:0:0:0:1]:50050/authService/getDeviceId", "http://[0:0:0:0:0:0:0:1]:*"));
-    EXPECT_EQ (0, test(permissions, "http://::1:50050/authService/getDeviceId", "http://::1:*"));
-    EXPECT_EQ (0, test(permissions, "http://0:0:0:0:0:0:0:1:50050/authService/getDeviceId", "http://0:0:0:0:0:0:0:1:*"));
-    EXPECT_EQ (0, test(permissions, "http://my_email%40gmail.com:password@www.my_site.com", "http://*:*@www.my_site.com"));
-    EXPECT_EQ (0, test(permissions, "http://敷リオワニ内前ヲルホ/index.js", "http://*/index*"));
+    EXPECT_EQ (0, test("http://", "*://*"));
+    EXPECT_EQ (0, test("https://", "https://*"));
+    EXPECT_EQ (0, test("https://comcast.com", "https://comcast.com*"));
+    EXPECT_EQ (0, test("https://m.xfinity.comcast.com/index", "https://*.comcast.com/*"));
+    EXPECT_EQ (0, test("https://m.xfinity.comcast.com/blabla/index", "https://*.comcast.com/*/index"));
+    EXPECT_EQ (0, test("https://m.xfinity.comcast.com/blabla/index?some=some1&parm=value#p1", "https://*.comcast.com/*/index?*"));
+    EXPECT_EQ (0, test("https://m.comcast.com/", "https://*.comcast.com/*"));
+    EXPECT_EQ (0, test("https://comcast.com/index/blahblah", "https://comcast.com/index/*"));
+    EXPECT_EQ (0, test("https://m.comcast.com/a/index?p1=1", "https://*.comcast.com/*/index?p1=*"));
+    EXPECT_EQ (0, test("http://localhost:50050/authService/getDeviceId", "http://localhost:*"));
+    EXPECT_EQ (0, test("http://127.0.0.1:50050/authService/getDeviceId", "http://127.0.0.1:*"));
+    EXPECT_EQ (0, test("http://[::1]:50050/authService/getDeviceId", "http://[::1]:*"));
+    EXPECT_EQ (0, test("http://[0:0:0:0:0:0:0:1]:50050/authService/getDeviceId", "http://[0:0:0:0:0:0:0:1]:*"));
+    EXPECT_EQ (0, test("http://::1:50050/authService/getDeviceId", "http://::1:*"));
+    EXPECT_EQ (0, test("http://0:0:0:0:0:0:0:1:50050/authService/getDeviceId", "http://0:0:0:0:0:0:0:1:*"));
+    EXPECT_EQ (0, test("http://my_email%40gmail.com:password@www.my_site.com", "http://*:*@www.my_site.com"));
+    EXPECT_EQ (0, test("http://敷リオワニ内前ヲルホ/index.js", "http://*/index*"));
   }
 
   void test3()
   {
-    rtObjectRef permissions;
-    {
-      rtObjectRef p = new rtMapObject();
-      rtObjectRef url = new rtMapObject();
-      p.set("url", url);
-      rtObjectRef serviceManager = new rtMapObject();
-      rtArrayObject* url_allow = new rtArrayObject();
-      url_allow->pushBack("https://*");
-      url_allow->pushBack("https://*.comcast.com");
-      url_allow->pushBack("https://comcast.com/*");
-      url_allow->pushBack("HTTPS://COMCAST.COM");
-      url_allow->pushBack("https://*.comcast.com/*");
-      url_allow->pushBack("https://*.comcast.com/*/index?p1=*");
-      url_allow->pushBack("https://*.comcast.com/*/index");
-      url_allow->pushBack("*://github.com");
-      url_allow->pushBack("*://github.com/*");
-      url_allow->pushBack("*://github.com:*");
-      url_allow->pushBack("*://github.com:*/*");
-      url_allow->pushBack("http://localhost:*");
-      url_allow->pushBack("http://localhost:*/*");
-      url_allow->pushBack("http://127.0.0.1");
-      url_allow->pushBack("http://127.0.0.1:*");
-      url_allow->pushBack("http://127.0.0.1:*/*");
-      url_allow->pushBack("http://[::1]");
-      url_allow->pushBack("http://[::1]:*");
-      url_allow->pushBack("http://[::1]:*/*");
-      url_allow->pushBack("http://[0:0:0:0:0:0:0:1]");
-      url_allow->pushBack("http://[0:0:0:0:0:0:0:1]:*");
-      url_allow->pushBack("http://[0:0:0:0:0:0:0:1]:*/*");
-      url_allow->pushBack("http://::1");
-      url_allow->pushBack("http://::1:*");
-      url_allow->pushBack("http://::1:*/*");
-      url_allow->pushBack("http://0:0:0:0:0:0:0:1");
-      url_allow->pushBack("http://0:0:0:0:0:0:0:1:*");
-      url_allow->pushBack("http://0:0:0:0:0:0:0:1:*/*");
-      url_allow->pushBack("https://localhost");
-      url_allow->pushBack("https://localhost:*");
-      url_allow->pushBack("https://localhost:*/*");
-      url_allow->pushBack("https://127.0.0.1");
-      url_allow->pushBack("https://127.0.0.1:*");
-      url_allow->pushBack("https://127.0.0.1:*/*");
-      url_allow->pushBack("https://[::1]");
-      url_allow->pushBack("https://[::1]:*");
-      url_allow->pushBack("https://[::1]:*/*");
-      url_allow->pushBack("https://[0:0:0:0:0:0:0:1]");
-      url_allow->pushBack("https://[0:0:0:0:0:0:0:1]:*");
-      url_allow->pushBack("https://[0:0:0:0:0:0:0:1]:*/*");
-      url_allow->pushBack("https://::1");
-      url_allow->pushBack("https://::1:*");
-      url_allow->pushBack("https://::1:*/*");
-      url_allow->pushBack("https://0:0:0:0:0:0:0:1");
-      url_allow->pushBack("https://0:0:0:0:0:0:0:1:*");
-      url_allow->pushBack("https://0:0:0:0:0:0:0:1:*/*");
-      url_allow->pushBack("serviceManager://*");
-      url_allow->pushBack("feature://*");
-      url_allow->pushBack("serviceManager://com.comcast.application");
-      url_allow->pushBack("serviceManager://com.comcast.stateObserver");
-      url_allow->pushBack("serviceManager://com.comcast.FrameRate");
-      rtObjectRef url_allow_ref = url_allow;
-      url.set("allow", url_allow_ref);
-      permissions = p;
-    }
+    mPermissionsMap.clear();
+    mPermissionsMap[rtPermissions::wildcard_t("https://*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://*.comcast.com", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://comcast.com/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("HTTPS://COMCAST.COM", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://*.comcast.com/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://*.comcast.com/*/index?p1=*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://*.comcast.com/*/index", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("*://github.com", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("*://github.com/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("*://github.com:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("*://github.com:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://localhost:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://localhost:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://127.0.0.1", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://127.0.0.1:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://127.0.0.1:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://[::1]", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://[::1]:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://[::1]:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://[0:0:0:0:0:0:0:1]", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://[0:0:0:0:0:0:0:1]:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://[0:0:0:0:0:0:0:1]:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://::1", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://::1:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://::1:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://0:0:0:0:0:0:0:1", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://0:0:0:0:0:0:0:1:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://0:0:0:0:0:0:0:1:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://localhost", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://localhost:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://localhost:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://127.0.0.1", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://127.0.0.1:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://127.0.0.1:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://[::1]", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://[::1]:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://[::1]:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://[0:0:0:0:0:0:0:1]", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://[0:0:0:0:0:0:0:1]:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://[0:0:0:0:0:0:0:1]:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://::1", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://::1:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://::1:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://0:0:0:0:0:0:0:1", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://0:0:0:0:0:0:0:1:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://0:0:0:0:0:0:0:1:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("foo://*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("bar://*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("foo://com.comcast.application", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("foo://com.comcast.stateObserver", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("foo://com.comcast.FrameRate", rtPermissions::DEFAULT)] = true;
 
-    EXPECT_EQ (-1,test(permissions, "http://", ""));
-    EXPECT_EQ (0, test(permissions, "https://comcast.com", "https://*"));
-    EXPECT_EQ (0, test(permissions, "https://m.comcast.com", "https://*.comcast.com"));
-    EXPECT_EQ (0, test(permissions, "https://comcast.com/", "https://comcast.com/*"));
-    EXPECT_EQ (0, test(permissions, "https://m.comcast.com/a/index?p2=1", "https://*.comcast.com/*"));
-    EXPECT_EQ (0, test(permissions, "https://m.comcast.com/a/index?p1=1", "https://*.comcast.com/*/index?p1=*"));
-    EXPECT_EQ (0, test(permissions, "HTTPS://COMCAST.COM", "HTTPS://COMCAST.COM"));
-    EXPECT_EQ (0, test(permissions, "https://m.xfinity.comcast.com/blabla/index?some=some1&parm=value#p1", "https://*.comcast.com/*"));
-    EXPECT_EQ (0, test(permissions, "https://m.xfinity.comcast.com/bla/bla/index", "https://*.comcast.com/*/index"));
-    EXPECT_EQ (0, test(permissions, "https://github.com", "*://github.com"));
-    EXPECT_EQ (0, test(permissions, "https://github.com/", "*://github.com/*"));
-    EXPECT_EQ (0, test(permissions, "https://github.com:443", "*://github.com:*"));
-    EXPECT_EQ (0, test(permissions, "https://github.com:443/", "*://github.com:*/*"));
-    EXPECT_EQ (-1,test(permissions, "http://localhost", ""));
-    EXPECT_EQ (0, test(permissions, "http://localhost:50050", "http://localhost:*"));
-    EXPECT_EQ (0, test(permissions, "http://localhost:50050/", "http://localhost:*/*"));
-    EXPECT_EQ (0, test(permissions, "http://127.0.0.1", "http://127.0.0.1"));
-    EXPECT_EQ (0, test(permissions, "http://127.0.0.1:50050", "http://127.0.0.1:*"));
-    EXPECT_EQ (0, test(permissions, "http://127.0.0.1:50050/", "http://127.0.0.1:*/*"));
-    EXPECT_EQ (0, test(permissions, "http://[::1]", "http://[::1]"));
-    EXPECT_EQ (0, test(permissions, "http://[::1]:50050", "http://[::1]:*"));
-    EXPECT_EQ (0, test(permissions, "http://[::1]:50050/", "http://[::1]:*/*"));
-    EXPECT_EQ (0, test(permissions, "http://[0:0:0:0:0:0:0:1]", "http://[0:0:0:0:0:0:0:1]"));
-    EXPECT_EQ (0, test(permissions, "http://[0:0:0:0:0:0:0:1]:50050", "http://[0:0:0:0:0:0:0:1]:*"));
-    EXPECT_EQ (0, test(permissions, "http://[0:0:0:0:0:0:0:1]:50050/", "http://[0:0:0:0:0:0:0:1]:*/*"));
-    EXPECT_EQ (0, test(permissions, "http://::1", "http://::1"));
-    EXPECT_EQ (0, test(permissions, "http://::1:50050", "http://::1:*"));
-    EXPECT_EQ (0, test(permissions, "http://::1:50050/", "http://::1:*/*"));
-    EXPECT_EQ (0, test(permissions, "http://0:0:0:0:0:0:0:1", "http://0:0:0:0:0:0:0:1"));
-    EXPECT_EQ (0, test(permissions, "http://0:0:0:0:0:0:0:1:50050", "http://0:0:0:0:0:0:0:1:*"));
-    EXPECT_EQ (0, test(permissions, "http://0:0:0:0:0:0:0:1:50050/", "http://0:0:0:0:0:0:0:1:*/*"));
-    EXPECT_EQ (0, test(permissions, "https://localhost", "https://localhost"));
-    EXPECT_EQ (0, test(permissions, "https://localhost:50050", "https://localhost:*"));
-    EXPECT_EQ (0, test(permissions, "https://localhost:50050/", "https://localhost:*/*"));
-    EXPECT_EQ (0, test(permissions, "https://127.0.0.1", "https://127.0.0.1"));
-    EXPECT_EQ (0, test(permissions, "https://127.0.0.1:50050", "https://127.0.0.1:*"));
-    EXPECT_EQ (0, test(permissions, "https://127.0.0.1:50050/", "https://127.0.0.1:*/*"));
-    EXPECT_EQ (0, test(permissions, "https://[::1]", "https://[::1]"));
-    EXPECT_EQ (0, test(permissions, "https://[::1]:50050", "https://[::1]:*"));
-    EXPECT_EQ (0, test(permissions, "https://[::1]:50050/", "https://[::1]:*/*"));
-    EXPECT_EQ (0, test(permissions, "https://[0:0:0:0:0:0:0:1]", "https://[0:0:0:0:0:0:0:1]"));
-    EXPECT_EQ (0, test(permissions, "https://[0:0:0:0:0:0:0:1]:50050", "https://[0:0:0:0:0:0:0:1]:*"));
-    EXPECT_EQ (0, test(permissions, "https://[0:0:0:0:0:0:0:1]:50050/", "https://[0:0:0:0:0:0:0:1]:*/*"));
-    EXPECT_EQ (0, test(permissions, "https://::1", "https://::1"));
-    EXPECT_EQ (0, test(permissions, "https://::1:50050", "https://::1:*"));
-    EXPECT_EQ (0, test(permissions, "https://::1:50050/", "https://::1:*/*"));
-    EXPECT_EQ (0, test(permissions, "https://0:0:0:0:0:0:0:1", "https://0:0:0:0:0:0:0:1"));
-    EXPECT_EQ (0, test(permissions, "https://0:0:0:0:0:0:0:1:50050", "https://0:0:0:0:0:0:0:1:*"));
-    EXPECT_EQ (0, test(permissions, "https://0:0:0:0:0:0:0:1:50050/", "https://0:0:0:0:0:0:0:1:*/*"));
-    EXPECT_EQ (0, test(permissions, "serviceManager://api1", "serviceManager://*"));
-    EXPECT_EQ (0, test(permissions, "feature://screenshot", "feature://*"));
-    EXPECT_EQ (0, test(permissions, "serviceManager://com.comcast.application", "serviceManager://com.comcast.application"));
-    EXPECT_EQ (0, test(permissions, "serviceManager://com.comcast.stateObserver", "serviceManager://com.comcast.stateObserver"));
-    EXPECT_EQ (0, test(permissions, "serviceManager://com.comcast.FrameRate", "serviceManager://com.comcast.FrameRate"));
+    EXPECT_EQ (-1,test("http://", ""));
+    EXPECT_EQ (0, test("https://comcast.com", "https://*"));
+    EXPECT_EQ (0, test("https://m.comcast.com", "https://*.comcast.com"));
+    EXPECT_EQ (0, test("https://comcast.com/", "https://comcast.com/*"));
+    EXPECT_EQ (0, test("https://m.comcast.com/a/index?p2=1", "https://*.comcast.com/*"));
+    EXPECT_EQ (0, test("https://m.comcast.com/a/index?p1=1", "https://*.comcast.com/*/index?p1=*"));
+    EXPECT_EQ (0, test("HTTPS://COMCAST.COM", "HTTPS://COMCAST.COM"));
+    EXPECT_EQ (0, test("https://m.xfinity.comcast.com/blabla/index?some=some1&parm=value#p1", "https://*.comcast.com/*"));
+    EXPECT_EQ (0, test("https://m.xfinity.comcast.com/bla/bla/index", "https://*.comcast.com/*/index"));
+    EXPECT_EQ (0, test("https://github.com", "*://github.com"));
+    EXPECT_EQ (0, test("https://github.com/", "*://github.com/*"));
+    EXPECT_EQ (0, test("https://github.com:443", "*://github.com:*"));
+    EXPECT_EQ (0, test("https://github.com:443/", "*://github.com:*/*"));
+    EXPECT_EQ (-1,test("http://localhost", ""));
+    EXPECT_EQ (0, test("http://localhost:50050", "http://localhost:*"));
+    EXPECT_EQ (0, test("http://localhost:50050/", "http://localhost:*/*"));
+    EXPECT_EQ (0, test("http://127.0.0.1", "http://127.0.0.1"));
+    EXPECT_EQ (0, test("http://127.0.0.1:50050", "http://127.0.0.1:*"));
+    EXPECT_EQ (0, test("http://127.0.0.1:50050/", "http://127.0.0.1:*/*"));
+    EXPECT_EQ (0, test("http://[::1]", "http://[::1]"));
+    EXPECT_EQ (0, test("http://[::1]:50050", "http://[::1]:*"));
+    EXPECT_EQ (0, test("http://[::1]:50050/", "http://[::1]:*/*"));
+    EXPECT_EQ (0, test("http://[0:0:0:0:0:0:0:1]", "http://[0:0:0:0:0:0:0:1]"));
+    EXPECT_EQ (0, test("http://[0:0:0:0:0:0:0:1]:50050", "http://[0:0:0:0:0:0:0:1]:*"));
+    EXPECT_EQ (0, test("http://[0:0:0:0:0:0:0:1]:50050/", "http://[0:0:0:0:0:0:0:1]:*/*"));
+    EXPECT_EQ (0, test("http://::1", "http://::1"));
+    EXPECT_EQ (0, test("http://::1:50050", "http://::1:*"));
+    EXPECT_EQ (0, test("http://::1:50050/", "http://::1:*/*"));
+    EXPECT_EQ (0, test("http://0:0:0:0:0:0:0:1", "http://0:0:0:0:0:0:0:1"));
+    EXPECT_EQ (0, test("http://0:0:0:0:0:0:0:1:50050", "http://0:0:0:0:0:0:0:1:*"));
+    EXPECT_EQ (0, test("http://0:0:0:0:0:0:0:1:50050/", "http://0:0:0:0:0:0:0:1:*/*"));
+    EXPECT_EQ (0, test("https://localhost", "https://localhost"));
+    EXPECT_EQ (0, test("https://localhost:50050", "https://localhost:*"));
+    EXPECT_EQ (0, test("https://localhost:50050/", "https://localhost:*/*"));
+    EXPECT_EQ (0, test("https://127.0.0.1", "https://127.0.0.1"));
+    EXPECT_EQ (0, test("https://127.0.0.1:50050", "https://127.0.0.1:*"));
+    EXPECT_EQ (0, test("https://127.0.0.1:50050/", "https://127.0.0.1:*/*"));
+    EXPECT_EQ (0, test("https://[::1]", "https://[::1]"));
+    EXPECT_EQ (0, test("https://[::1]:50050", "https://[::1]:*"));
+    EXPECT_EQ (0, test("https://[::1]:50050/", "https://[::1]:*/*"));
+    EXPECT_EQ (0, test("https://[0:0:0:0:0:0:0:1]", "https://[0:0:0:0:0:0:0:1]"));
+    EXPECT_EQ (0, test("https://[0:0:0:0:0:0:0:1]:50050", "https://[0:0:0:0:0:0:0:1]:*"));
+    EXPECT_EQ (0, test("https://[0:0:0:0:0:0:0:1]:50050/", "https://[0:0:0:0:0:0:0:1]:*/*"));
+    EXPECT_EQ (0, test("https://::1", "https://::1"));
+    EXPECT_EQ (0, test("https://::1:50050", "https://::1:*"));
+    EXPECT_EQ (0, test("https://::1:50050/", "https://::1:*/*"));
+    EXPECT_EQ (0, test("https://0:0:0:0:0:0:0:1", "https://0:0:0:0:0:0:0:1"));
+    EXPECT_EQ (0, test("https://0:0:0:0:0:0:0:1:50050", "https://0:0:0:0:0:0:0:1:*"));
+    EXPECT_EQ (0, test("https://0:0:0:0:0:0:0:1:50050/", "https://0:0:0:0:0:0:0:1:*/*"));
+    EXPECT_EQ (0, test("foo://api1", "foo://*"));
+    EXPECT_EQ (0, test("bar://screenshot", "bar://*"));
+    EXPECT_EQ (0, test("foo://com.comcast.application", "foo://com.comcast.application"));
+    EXPECT_EQ (0, test("foo://com.comcast.stateObserver", "foo://com.comcast.stateObserver"));
+    EXPECT_EQ (0, test("foo://com.comcast.FrameRate", "foo://com.comcast.FrameRate"));
   }
 
   void test4()
   {
-    rtObjectRef permissions;
-    {
-      rtObjectRef p = new rtMapObject();
-      rtObjectRef url = new rtMapObject();
-      p.set("url", url);
-      rtObjectRef serviceManager = new rtMapObject();
-      rtArrayObject* url_allow = new rtArrayObject();
-      url_allow->pushBack("*");
-      url_allow->pushBack("*://*");
-      url_allow->pushBack("*://github.com");
-      url_allow->pushBack("*://github.com/*");
-      url_allow->pushBack("*://github.com:*");
-      url_allow->pushBack("*://github.com:*/*");
-      url_allow->pushBack("https://github.com/*");
-      url_allow->pushBack("https://github.com/pxscene/*");
-      url_allow->pushBack("*://github.com/pxscene/*");
-      rtObjectRef url_allow_ref = url_allow;
-      url.set("allow", url_allow_ref);
-      permissions = p;
-    }
+    mPermissionsMap.clear();
+    mPermissionsMap[rtPermissions::wildcard_t("*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("*://*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("*://github.com", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("*://github.com/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("*://github.com:*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("*://github.com:*/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://github.com/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("https://github.com/pxscene/*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("*://github.com/pxscene/*", rtPermissions::DEFAULT)] = true;
 
-    EXPECT_EQ (0, test(permissions, "https://github.com/pxscene/pxCore/blob/master/examples/pxScene2d/README.md", "https://github.com/pxscene/*"));
-    EXPECT_EQ (0, test(permissions, "https://github.com:443/pxscene/pxCore/blob/master/examples/pxScene2d/README.md", "*://github.com:*/*"));
-    EXPECT_EQ (0, test(permissions, "http://github.com/pxscene/pxCore/blob/master/examples/pxScene2d/README.md", "*://github.com/pxscene/*"));
-    EXPECT_EQ (0, test(permissions, "https://github.com/features", "https://github.com/*"));
-    EXPECT_EQ (0, test(permissions, "https://github.com:443/features", "*://github.com:*/*"));
-    EXPECT_EQ (0, test(permissions, "http://github.com/features", "*://github.com/*"));
-    EXPECT_EQ (0, test(permissions, "https://github.com/pxscene", "https://github.com/*"));
-    EXPECT_EQ (0, test(permissions, "https://github.com:443/pxscene", "*://github.com:*/*"));
-    EXPECT_EQ (0, test(permissions, "http://github.com/pxscene", "*://github.com/*"));
-    EXPECT_EQ (0, test(permissions, "blablahttps://github.com/features", "*://github.com/*"));
-    EXPECT_EQ (0, test(permissions, "blablah", "*"));
-    EXPECT_EQ (0, test(permissions, "blablah:/", "*"));
-    EXPECT_EQ (0, test(permissions, "blablah://", "*://*"));
-    EXPECT_EQ (0, test(permissions, "blablah:///", "*://*"));
-    EXPECT_EQ (0, test(permissions, "blablah://abc", "*://*"));
-    EXPECT_EQ (0, test(permissions, "blablah://github.com", "*://github.com"));
-    EXPECT_EQ (0, test(permissions, "blablah://github.com:8080", "*://github.com:*"));
-    EXPECT_EQ (0, test(permissions, "https://google.com", "*://*"));
-    EXPECT_EQ (0, test(permissions, "http://google.com", "*://*"));
-    EXPECT_EQ (0, test(permissions, "github.com", "*"));
-    EXPECT_EQ (0, test(permissions, "github.com://github.com", "*://github.com"));
-    EXPECT_EQ (0, test(permissions, "github.com/pxscene/pxCore/blob/master/examples/pxScene2d/README.md", "*"));
-    EXPECT_EQ (0, test(permissions, "github.com:80/pxscene/pxCore/blob/master/examples/pxScene2d/README.md", "*"));
-    EXPECT_EQ (0, test(permissions, "ftp://github.com", "*://github.com"));
-    EXPECT_EQ (0, test(permissions, "ftp://github.com:21", "*://github.com:*"));
-    EXPECT_EQ (0, test(permissions, "ftp://github.com:21/", "*://github.com:*/*"));
-    EXPECT_EQ (0, test(permissions, "ftp://github.com:21/pxscene/blabla", "*://github.com:*/*"));
-    EXPECT_EQ (0, test(permissions, "ftp://github.com/pxscene/blabla", "*://github.com/pxscene/*"));
+    EXPECT_EQ (0, test("https://github.com/pxscene/pxCore/blob/master/examples/pxScene2d/README.md", "https://github.com/pxscene/*"));
+    EXPECT_EQ (0, test("https://github.com:443/pxscene/pxCore/blob/master/examples/pxScene2d/README.md", "*://github.com:*/*"));
+    EXPECT_EQ (0, test("http://github.com/pxscene/pxCore/blob/master/examples/pxScene2d/README.md", "*://github.com/pxscene/*"));
+    EXPECT_EQ (0, test("https://github.com/features", "https://github.com/*"));
+    EXPECT_EQ (0, test("https://github.com:443/features", "*://github.com:*/*"));
+    EXPECT_EQ (0, test("http://github.com/features", "*://github.com/*"));
+    EXPECT_EQ (0, test("https://github.com/pxscene", "https://github.com/*"));
+    EXPECT_EQ (0, test("https://github.com:443/pxscene", "*://github.com:*/*"));
+    EXPECT_EQ (0, test("http://github.com/pxscene", "*://github.com/*"));
+    EXPECT_EQ (0, test("blablahttps://github.com/features", "*://github.com/*"));
+    EXPECT_EQ (0, test("blablah", "*"));
+    EXPECT_EQ (0, test("blablah:/", "*"));
+    EXPECT_EQ (0, test("blablah://", "*://*"));
+    EXPECT_EQ (0, test("blablah:///", "*://*"));
+    EXPECT_EQ (0, test("blablah://abc", "*://*"));
+    EXPECT_EQ (0, test("blablah://github.com", "*://github.com"));
+    EXPECT_EQ (0, test("blablah://github.com:8080", "*://github.com:*"));
+    EXPECT_EQ (0, test("https://google.com", "*://*"));
+    EXPECT_EQ (0, test("http://google.com", "*://*"));
+    EXPECT_EQ (0, test("github.com", "*"));
+    EXPECT_EQ (0, test("github.com://github.com", "*://github.com"));
+    EXPECT_EQ (0, test("github.com/pxscene/pxCore/blob/master/examples/pxScene2d/README.md", "*"));
+    EXPECT_EQ (0, test("github.com:80/pxscene/pxCore/blob/master/examples/pxScene2d/README.md", "*"));
+    EXPECT_EQ (0, test("ftp://github.com", "*://github.com"));
+    EXPECT_EQ (0, test("ftp://github.com:21", "*://github.com:*"));
+    EXPECT_EQ (0, test("ftp://github.com:21/", "*://github.com:*/*"));
+    EXPECT_EQ (0, test("ftp://github.com:21/pxscene/blabla", "*://github.com:*/*"));
+    EXPECT_EQ (0, test("ftp://github.com/pxscene/blabla", "*://github.com/pxscene/*"));
   }
 
   void test5()
   {
-    rtObjectRef permissions;
-    {
-      rtObjectRef p = new rtMapObject();
-      rtObjectRef url = new rtMapObject();
-      p.set("url", url);
-      rtObjectRef serviceManager = new rtMapObject();
-      rtArrayObject* url_allow = new rtArrayObject();
-      url_allow->pushBack("*");
-      url_allow->pushBack("http://localhost:50050/authService/getDeviceId");
-      url_allow->pushBack("http://localhost*");
-      url_allow->pushBack("serviceManager://*");
-      url_allow->pushBack("feature://*");
-      rtObjectRef url_allow_ref = url_allow;
-      url.set("allow", url_allow_ref);
-      permissions = p;
-    }
+    mPermissionsMap.clear();
+    mPermissionsMap[rtPermissions::wildcard_t("*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://localhost:50050/authService/getDeviceId", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("http://localhost*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("foo://*", rtPermissions::DEFAULT)] = true;
+    mPermissionsMap[rtPermissions::wildcard_t("bar://*", rtPermissions::DEFAULT)] = true;
 
-    EXPECT_EQ (0, test(permissions, "http://localhost/", "http://localhost*"));
+    EXPECT_EQ (0, test("http://localhost/", "http://localhost*"));
   }
 
 private:
   // -1 if not found, 0 if 'expectedResult' matches, 1 if 'expectedResult' doesn't match
-  int test(const rtObjectRef& permissions, const char* url, const char* expectedResult)
+  int test(const char* url, const char* expectedResult)
   {
-    rtPermissions* p = new rtPermissions();
-    EXPECT_TRUE (RT_OK == p->set(permissions));
-
-    std::string match;
-    int ret;
-    if (RT_OK != p->findMatch(url, match))
-    {
-      ret = -1;
-    }
-    else
-    {
-      if (0 == match.compare(expectedResult))
-        return 0;
-      rtLogError("differs: actual '%s' expected '%s'", match.c_str(), expectedResult);
-      return 1;
-    }
-    delete p;
-    return ret;
+    rtPermissions::wildcard_t w;
+    w.first = url;
+    w.second = rtPermissions::DEFAULT;
+    rtPermissions::permissionsMap_t::const_iterator it = rtPermissions::findWildcard(mPermissionsMap, w);
+    if (it == mPermissionsMap.end())
+      return -1;
+    if (0 == it->first.first.compare(expectedResult))
+      return 0;
+    rtLogError("differs: actual '%s' expected '%s'", it->first.first.c_str(), expectedResult);
+    return 1;
   }
+
+  rtPermissions::permissionsMap_t mPermissionsMap;
 };
 
 TEST_F(rtPermissions4Test, rtPermissionsTests)


### PR DESCRIPTION
redesigned rtPermissions to not expose custom URL schemes (added enum instead);
reworked tests to reuse rtPermissions objects and include wayland apps