### PR TITLE
fixes for build.sh clean.sh and buildWindows.bat scripts

### DIFF
--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -58,6 +58,7 @@ then
 #    brew install lighttpd
     brew install gcovr
     brew install lcov
+    brew install quilt
     brew install --HEAD ccache
     ls -al $HOME/.ccache
   fi

--- a/examples/pxScene2d/external/build.sh
+++ b/examples/pxScene2d/external/build.sh
@@ -148,15 +148,14 @@ if [ "$(uname)" != "Darwin" ]; then
 
 fi
 
-if [ ! -e dukluv/build/duktape.a ]
+if [ ! -e dukluv/build/libduktape.a ]
 then
     cd dukluv
-    #patch -p0 < patches/compile_fix.patch
-    git apply patches/dukluv.git.patch
-    mkdir build
+    quilt push -aq || test $? = 2
+    mkdir -p build
     cd build
     cmake ..
-    make
+    make "-j${make_parallel}"
     cd ..
 fi
 

--- a/examples/pxScene2d/external/buildWindows.bat
+++ b/examples/pxScene2d/external/buildWindows.bat
@@ -27,7 +27,7 @@ CALL vcbuild.bat x86 nosign
 cd ..
 
 cd dukluv
-patch -p0 < patches/compile_fix.patch
+patch -p1 < patches/dukluv.git.patch
 mkdir build
 cd build
 cmake ..

--- a/examples/pxScene2d/external/clean.sh
+++ b/examples/pxScene2d/external/clean.sh
@@ -25,11 +25,11 @@ cd ..
 
 #--------- ZLIB 
 cd zlib
-make clean -j3
+make distclean -j3
 cd ..
 
 #--------- LIBNODE 
-cd libnode-v6.9.0
+cd node
 make clean -j3
 rm -rf icu_* config.* out/
 cd ..
@@ -50,4 +50,5 @@ make clean -j3
 cd ..
 fi
 
-
+#--------- dukluv
+rm -rf dukluv/build

--- a/examples/pxScene2d/external/dukluv/patches/dukluv.git.patch
+++ b/examples/pxScene2d/external/dukluv/patches/dukluv.git.patch
@@ -1,7 +1,7 @@
-diff --git a/examples/pxScene2d/external/dukluv/src/duv.c b/examples/pxScene2d/external/dukluv/src/duv.c
+diffdukluv/src/duv.c b/examples/pxScene2d/external/dukluv/src/duv.c
 index a2d2ca6..21a5312 100644
---- a/examples/pxScene2d/external/dukluv/src/duv.c
-+++ b/examples/pxScene2d/external/dukluv/src/duv.c
+--- dukluv/src/duv.c
++++ dukluv/src/duv.c
 @@ -13,6 +13,7 @@
  #include "fs.h"
  #include "misc.h"
@@ -20,10 +20,10 @@ index a2d2ca6..21a5312 100644
  
    {NULL, NULL, 0},
  };
-diff --git a/examples/pxScene2d/external/dukluv/src/main.c b/examples/pxScene2d/external/dukluv/src/main.c
+diffdukluv/src/main.c b/examples/pxScene2d/external/dukluv/src/main.c
 index 8444138..797642a 100644
---- a/examples/pxScene2d/external/dukluv/src/main.c
-+++ b/examples/pxScene2d/external/dukluv/src/main.c
+--- dukluv/src/main.c
++++ dukluv/src/main.c
 @@ -1,6 +1,6 @@
  #include "duv.h"
  #include "misc.h"
@@ -56,10 +56,10 @@ index 8444138..797642a 100644
  }
  
  struct duv_list {
-diff --git a/examples/pxScene2d/external/dukluv/uv.cmake b/examples/pxScene2d/external/dukluv/uv.cmake
+diffdukluv/uv.cmake b/examples/pxScene2d/external/dukluv/uv.cmake
 index c638aeb..195cebf 100644
---- a/examples/pxScene2d/external/dukluv/uv.cmake
-+++ b/examples/pxScene2d/external/dukluv/uv.cmake
+--- dukluv/uv.cmake
++++ dukluv/uv.cmake
 @@ -121,7 +121,6 @@ else()
      ${LIBUVDIR}/src/unix/timer.c
      ${LIBUVDIR}/src/unix/tty.c
@@ -76,13 +76,10 @@ index c638aeb..195cebf 100644
      ${LIBUVDIR}/src/unix/proctitle.c
      ${LIBUVDIR}/src/unix/darwin.c
      ${LIBUVDIR}/src/unix/fsevents.c
- )
- 
- 
-diff --git a/examples/pxScene2d/external/dukluv/CMakeLists.txt b/examples/pxScene2d/external/dukluv/CMakeLists.txt
+diffdukluv/CMakeLists.txt b/examples/pxScene2d/external/dukluv/CMakeLists.txt
 index 967b987..4afc8ab 100644
---- a/examples/pxScene2d/external/dukluv/CMakeLists.txt
-+++ b/examples/pxScene2d/external/dukluv/CMakeLists.txt
+--- dukluv/CMakeLists.txt
++++ dukluv/CMakeLists.txt
 @@ -1,7 +1,10 @@
 -cmake_minimum_required(VERSION 2.8.9)
 +cmake_minimum_required(VERSION 2.8)

--- a/examples/pxScene2d/external/dukluv/patches/series
+++ b/examples/pxScene2d/external/dukluv/patches/series
@@ -1,0 +1,1 @@
+dukluv.git.patch -p1


### PR DESCRIPTION
- allows build.sh & clean.sh to be run multiple times without errors,
- fix buildWindows.bat after #794 merge.