### PR TITLE
Reduce rss memory used by rtremote

### DIFF
--- a/remote/rtRemoteMulticastResolver.cpp
+++ b/remote/rtRemoteMulticastResolver.cpp
@@ -466,7 +466,7 @@ rtRemoteMulticastResolver::runListener()
 {
   rtRemoteSocketBuffer buff;
   buff.reserve(1024 * 1024);
-  buff.resize(1024 * 1024);
+  buff.resize(1024);
 
   while (true)
   {

--- a/remote/rtRemoteServer.cpp
+++ b/remote/rtRemoteServer.cpp
@@ -315,10 +315,6 @@ rtRemoteServer::runListener()
 {
   time_t lastKeepAliveCheck = 0;
 
-  rtRemoteSocketBuffer buff;
-  buff.reserve(1024 * 1024);
-  buff.resize(1024 * 1024);
-
   while (true)
   {
     int maxFd = 0;

--- a/remote/rtRemoteStreamSelector.cpp
+++ b/remote/rtRemoteStreamSelector.cpp
@@ -84,7 +84,6 @@ rtRemoteStreamSelector::doPollFds()
 {
   rtRemoteSocketBuffer buff;
   buff.reserve(m_env->Config->stream_socket_buffer_size());
-  buff.resize(m_env->Config->stream_socket_buffer_size());
 
   const auto keepAliveInterval = std::chrono::seconds(m_env->Config->stream_keep_alive_interval());
   auto lastKeepAliveSent = std::chrono::steady_clock::now();


### PR DESCRIPTION
Average rt remote message takes ~200-300 bytes, so touching 1MB is overhead in this case.

Instead, let rtReadMessage resize the buffer as required (capacity remains the same). 