### PR TITLE
Provided access to application to use the FilePointer to read the data in a smaller chunk.

### DIFF
--- a/src/rtFileDownloader.cpp
+++ b/src/rtFileDownloader.cpp
@@ -153,7 +153,7 @@ rtFileDownloadRequest::rtFileDownloadRequest(const char* imageUrl, void* callbac
     mDownloadedData(0), mDownloadedDataSize(), mDownloadStatusCode(0) ,mCallbackData(callbackData),
     mCallbackFunctionMutex(), mHeaderData(0), mHeaderDataSize(0), mHeaderOnly(false), mDownloadHandleExpiresTime(-2)
 #ifdef ENABLE_HTTP_CACHE
-    , mCacheEnabled(true), mIsDataInCache(false)
+    , mCacheEnabled(true), mIsDataInCache(false), mReadCacheDataInChunks(false)
 #endif
     , mIsProgressMeterSwitchOff(false), mHTTPFailOnError(false), mDefaultTimeout(false)
 {
@@ -366,6 +366,29 @@ bool rtFileDownloadRequest::isDataCached()
   return mIsDataInCache;
 }
 
+void rtFileDownloadRequest::setReadCachedDataInChunks(bool val)
+{
+  mReadCacheDataInChunks = val;
+}
+
+bool rtFileDownloadRequest::readCachedDataInChunksEnabled()
+{
+  return mReadCacheDataInChunks;
+}
+
+FILE* rtFileDownloadRequest::cacheFilePointer(void)
+{
+  rtHttpCacheData cachedData(this->fileUrl().cString());
+
+  if (true == this->cacheEnabled())
+  {
+    if ((NULL != rtFileCache::instance()) && (RT_OK == rtFileCache::instance()->httpCacheData(this->fileUrl(), cachedData)))
+    {
+      return cachedData.filePointer();
+    }
+  }
+  return NULL;
+}
 #endif //ENABLE_HTTP_CACHE
 
 void rtFileDownloadRequest::setProgressMeter(bool val)
@@ -783,7 +806,7 @@ bool rtFileDownloader::checkAndDownloadFromCache(rtFileDownloadRequest* download
   rtData data;
   if ((NULL != rtFileCache::instance()) && (RT_OK == rtFileCache::instance()->httpCacheData(downloadRequest->fileUrl(),cachedData)))
   {
-    err = cachedData.data(data);
+    err = cachedData.data(data, downloadRequest->readCachedDataInChunksEnabled());
     if (RT_OK !=  err)
     {
       return false;

--- a/src/rtFileDownloader.cpp
+++ b/src/rtFileDownloader.cpp
@@ -153,7 +153,7 @@ rtFileDownloadRequest::rtFileDownloadRequest(const char* imageUrl, void* callbac
     mDownloadedData(0), mDownloadedDataSize(), mDownloadStatusCode(0) ,mCallbackData(callbackData),
     mCallbackFunctionMutex(), mHeaderData(0), mHeaderDataSize(0), mHeaderOnly(false), mDownloadHandleExpiresTime(-2)
 #ifdef ENABLE_HTTP_CACHE
-    , mCacheEnabled(true), mIsDataInCache(false), mReadCacheDataInChunks(false)
+    , mCacheEnabled(true), mIsDataInCache(false), mDeferCacheRead(false)
 #endif
     , mIsProgressMeterSwitchOff(false), mHTTPFailOnError(false), mDefaultTimeout(false)
 {
@@ -366,14 +366,14 @@ bool rtFileDownloadRequest::isDataCached()
   return mIsDataInCache;
 }
 
-void rtFileDownloadRequest::setReadCachedDataInChunks(bool val)
+void rtFileDownloadRequest::setDeferCacheRead(bool val)
 {
-  mReadCacheDataInChunks = val;
+  mDeferCacheRead = val;
 }
 
-bool rtFileDownloadRequest::readCachedDataInChunksEnabled()
+bool rtFileDownloadRequest::deferCacheRead()
 {
-  return mReadCacheDataInChunks;
+  return mDeferCacheRead;
 }
 
 FILE* rtFileDownloadRequest::cacheFilePointer(void)
@@ -806,7 +806,10 @@ bool rtFileDownloader::checkAndDownloadFromCache(rtFileDownloadRequest* download
   rtData data;
   if ((NULL != rtFileCache::instance()) && (RT_OK == rtFileCache::instance()->httpCacheData(downloadRequest->fileUrl(),cachedData)))
   {
-    err = cachedData.data(data, downloadRequest->readCachedDataInChunksEnabled());
+    if(downloadRequest->deferCacheRead())
+      err = cachedData.deferCacheRead(data);
+    else
+      err = cachedData.data(data);
     if (RT_OK !=  err)
     {
       return false;

--- a/src/rtFileDownloader.h
+++ b/src/rtFileDownloader.h
@@ -83,8 +83,8 @@ public:
   bool cacheEnabled();
   void setDataIsCached(bool val);
   bool isDataCached();
-  void setReadCachedDataInChunks(bool val);
-  bool readCachedDataInChunksEnabled();
+  void setDeferCacheRead(bool val);
+  bool deferCacheRead();
   FILE* cacheFilePointer(void);
 #endif //ENABLE_HTTP_CACHE
   void setProgressMeter(bool val);
@@ -119,7 +119,7 @@ private:
 #ifdef ENABLE_HTTP_CACHE
   bool mCacheEnabled;
   bool mIsDataInCache;
-  bool mReadCacheDataInChunks;
+  bool mDeferCacheRead;
 #endif //ENABLE_HTTP_CACHE
   bool mIsProgressMeterSwitchOff;
   bool mHTTPFailOnError;

--- a/src/rtFileDownloader.h
+++ b/src/rtFileDownloader.h
@@ -83,6 +83,9 @@ public:
   bool cacheEnabled();
   void setDataIsCached(bool val);
   bool isDataCached();
+  void setReadCachedDataInChunks(bool val);
+  bool readCachedDataInChunksEnabled();
+  FILE* cacheFilePointer(void);
 #endif //ENABLE_HTTP_CACHE
   void setProgressMeter(bool val);
   bool isProgressMeterSwitchOff();
@@ -116,6 +119,7 @@ private:
 #ifdef ENABLE_HTTP_CACHE
   bool mCacheEnabled;
   bool mIsDataInCache;
+  bool mReadCacheDataInChunks;
 #endif //ENABLE_HTTP_CACHE
   bool mIsProgressMeterSwitchOff;
   bool mHTTPFailOnError;

--- a/src/rtHttpCache.cpp
+++ b/src/rtHttpCache.cpp
@@ -222,7 +222,7 @@ rtData& rtHttpCacheData::contentsData()
   return mData;
 }
 
-rtError rtHttpCacheData::data(rtData& data)
+rtError rtHttpCacheData::data(rtData& data, bool readCachedDataInChunks)
 {
   if (NULL == fp)
     return RT_ERROR;
@@ -258,10 +258,20 @@ rtError rtHttpCacheData::data(rtData& data)
     }
   }
 
-  if (false == readFileData())
-    return RT_ERROR;
+  if(readCachedDataInChunks)
+  {
+    char invalidData[8] = "Invalid";
+    mData.init((uint8_t*)invalidData, sizeof(invalidData));
+    data.init(mData.data(), mData.length());
+  }
+  else
+  {
+    if (false == readFileData())
+      return RT_ERROR;
 
-  data.init(mData.data(),mData.length());
+    data.init(mData.data(),mData.length());
+  }
+
   if (true == revalidateOnlyHeaders)
   {
     mUpdated = true; //headers  modified , so rewriting the cache with new header data
@@ -298,6 +308,11 @@ bool rtHttpCacheData::isUpdated()
 void rtHttpCacheData::setFilePointer(FILE* openedDescriptor)
 {
   fp = openedDescriptor;
+}
+
+FILE* rtHttpCacheData::filePointer(void)
+{
+  return fp;
 }
 
 void rtHttpCacheData::setExpirationDate()

--- a/src/rtHttpCache.h
+++ b/src/rtHttpCache.h
@@ -57,10 +57,13 @@ class rtHttpCacheData
     rtError attributes(std::map<rtString, rtString>& cacheAttributes);
 
     /* returns the file data in the cache.  This is a blocking call and will check the network for updated data if etag is used */
-    rtError data(rtData& data, bool readCachedDataInChunks);
+    rtError data(rtData& data);
 
     /* sets the image file data to be stored in cache */
     void setData(rtData& cacheData);
+
+    /* returns "Invalid" as data, and it will not read data from cache.  This is a blocking call and will check the network for updated data if etag is used */
+    rtError deferCacheRead(rtData& data);
 
     /* returns the url associated with the cache */
     rtError url(rtString& url) const;

--- a/src/rtHttpCache.h
+++ b/src/rtHttpCache.h
@@ -57,7 +57,7 @@ class rtHttpCacheData
     rtError attributes(std::map<rtString, rtString>& cacheAttributes);
 
     /* returns the file data in the cache.  This is a blocking call and will check the network for updated data if etag is used */
-    rtError data(rtData& data);
+    rtError data(rtData& data, bool readCachedDataInChunks);
 
     /* sets the image file data to be stored in cache */
     void setData(rtData& cacheData);
@@ -78,6 +78,8 @@ class rtHttpCacheData
     rtData& contentsData();
 
     void setFilePointer(FILE* fp);
+
+    FILE* filePointer(void);
 
   private:
     /* populates the map with header attribute and value */


### PR DESCRIPTION
 The existing code  allocates buffer for the full file and returning to application for use.
 If the cached file is bigger file say 30 MB, it allocates for 30 MB and store the data for use.
 Now added the provision to application to read it however it wants. Also there is no change in existing file reading machanics unless application sets setReadCachedDataInChunks.