### PR TITLE
Limit the number of worker threads

### DIFF
--- a/remote/rtRemoteEnvironment.cpp
+++ b/remote/rtRemoteEnvironment.cpp
@@ -36,9 +36,9 @@ rtRemoteEnvironment::start()
   m_running = true;
   if (Config->server_use_dispatch_thread())
   {
-    rtLogInfo("starting worker thread");
-    for (int i = 0; i < kNumWorkers; ++i)
+    while (m_workers.size() < kNumWorkers)
     {
+      rtLogInfo("starting worker thread");
       thread_ptr p(new std::thread(&rtRemoteEnvironment::processRunQueue, this));
       m_workers.push_back(std::move(p));
     }


### PR DESCRIPTION
In case of error in rtRemoteInit() the call "env->start();" may be executed many times.

The current implementation creates 4 worker threads for every unsuccessful call.
The total number of created worker threads may grow indefinitely.

This change limits the total number of created threads by the value kNumWorkers.