### PR TITLE
Implement rtRemoteShutdown immediate (ignoring RefCount)

### DIFF
--- a/remote/rtRemote.cpp
+++ b/remote/rtRemote.cpp
@@ -75,7 +75,7 @@ rtRemoteShutdown(rtRemoteEnvironment* env, bool immediate)
   rtError e = RT_FAIL;
   std::lock_guard<std::mutex> lock(gMutex);
 
-  if (immediate || !--env->RefCount)
+  if (!--env->RefCount || immediate)
   {
     if (env->RefCount)
       rtLogWarn("immediate shutdown (reference count: %u), deleting", env->RefCount);

--- a/remote/rtRemote.h
+++ b/remote/rtRemote.h
@@ -78,10 +78,11 @@ rtRemoteUnregisterDisconnectedCallback( rtRemoteEnvironment* env, remoteDisconne
 
 /**
  * Shutdown rtRemote sub-system
+ * @param immediate ignore RefCount
  * @returns RT_OK for success
  */
 rtError
-rtRemoteShutdown(rtRemoteEnvironment* env);
+rtRemoteShutdown(rtRemoteEnvironment* env, bool immediate = false);
 
 /**
  * Processes a single queue item. This is an API to be called from main loop from queue callback.


### PR DESCRIPTION
1. Implement rtRemoteShutdown() immediate (ignoring RefCount)
2. Do not start rtRemoteEnvironment if env->Server->open() failed