### PR TITLE
ThreadSanitizer: fix data race in rtMutexNative.cpp

### DIFF
--- a/src/unix/rtMutexNative.cpp
+++ b/src/unix/rtMutexNative.cpp
@@ -1,27 +1,26 @@
 #include "rtMutexNative.h"
 
 
-rtMutexNative::rtMutexNative() : mLock(), mIsLocked(false)
+rtMutexNative::rtMutexNative() : mLock()
 {
     pthread_mutex_init(&mLock, NULL);
 }
 
 rtMutexNative::~rtMutexNative()
 {
-    while(mIsLocked);
+    pthread_mutex_lock(&mLock);
+    pthread_mutex_unlock(&mLock);
     pthread_mutex_destroy(&mLock);
 }
 
 void rtMutexNative::lock()
 {
     pthread_mutex_lock(&mLock);
-    mIsLocked = true;
 }
 
 void rtMutexNative::unlock()
 {
     pthread_mutex_unlock(&mLock);
-    mIsLocked = false;
 }
 
 rtMutexNativeDesc rtMutexNative::getNativeMutexDescription()

--- a/src/unix/rtMutexNative.h
+++ b/src/unix/rtMutexNative.h
@@ -18,7 +18,6 @@ public:
     rtMutexNativeDesc getNativeMutexDescription();
 private:
     pthread_mutex_t mLock;
-    volatile bool mIsLocked;
 };
 
 class rtThreadConditionNative


### PR DESCRIPTION
Fixes the following data race:
WARNING: ThreadSanitizer: data race (pid=6652)
  Write of size 1 at 0x7b3400000030 by thread T1:
    #0 rtMutexNative::unlock() pxCore/src/unix/rtMutexNative.cpp:24 (pxscene+0x0000005954c3)
    #1 rtThreadPoolNative::startThread() pxCore/src/unix/rtThreadPoolNative.cpp:83 (pxscene+0x000000595ba8)
    #2 launchThread(void*) pxCore/src/unix/rtThreadPoolNative.cpp:9 (pxscene+0x0000005956a4)
    #3 <null> <null> (libtsan.so.0+0x0000000257eb)

  Previous write of size 1 at 0x7b3400000030 by main thread (mutexes: write M516):
    #0 rtMutexNative::unlock() pxCore/src/unix/rtMutexNative.cpp:24 (pxscene+0x0000005954c3)
    #1 rtThreadPoolNative::executeTask(rtThreadTask*) pxCore/src/unix/rtThreadPoolNative.cpp:99 (pxscene+0x000000595c60)
    #2 pxTextureOffscreen::freeOffscreenDataInBackground() pxCore/examples/pxScene2d/src/pxContextGL.cpp:873 (pxscene+0x00000057fd70)
    #3 pxTextureOffscreen::bindGLTexture(int) pxCore/examples/pxScene2d/src/pxContextGL.cpp:765 (pxscene+0x00000057f576)
    #4 textureShaderProgram::draw(int, int, float*, float, int, void const*, void const*, rtRef<pxTexture>, int, int) pxCore/examples/pxScene2d/src/pxContextGL.cpp:1619 (pxscene+0x000000582280)
    #5 drawImageTexture pxCore/examples/pxScene2d/src/pxContextGL.cpp:1959 (pxscene+0x0000005767fa)
    #6 pxContext::drawImage(float, float, float, float, rtRef<pxTexture>, rtRef<pxTexture>, bool, float*, pxConstantsStretch::constants, pxConstantsStretch::constants, bool) pxCore/examples/pxScene2d/src/pxContextGL.cpp:2649 (pxscene+0x00000057af92)
    #7 pxImage::draw() pxCore/examples/pxScene2d/src/pxImage.cpp:201 (pxscene+0x00000050e8b3)
    #8 pxObject::drawInternal(bool) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1355 (pxscene+0x00000053d11e)
    #9 pxObject::drawInternal(bool) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1367 (pxscene+0x00000053d1ca)
    #10 pxScene2d::draw() pxCore/examples/pxScene2d/src/pxScene2d.cpp:2190 (pxscene+0x0000005420a4)
    #11 pxScene2d::onDraw() pxCore/examples/pxScene2d/src/pxScene2d.cpp:2376 (pxscene+0x000000542ba9)
    #12 pxScriptView::onDraw() <null> (pxscene+0x00000055ac4a)
    #13 pxViewContainer::draw() pxCore/examples/pxScene2d/src/pxScene2d.h:976 (pxscene+0x000000558f7a)
    #14 pxObject::drawInternal(bool) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1355 (pxscene+0x00000053d11e)
    #15 pxObject::drawInternal(bool) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1367 (pxscene+0x00000053d1ca)
    #16 pxScene2d::draw() pxCore/examples/pxScene2d/src/pxScene2d.cpp:2190 (pxscene+0x0000005420a4)
    #17 pxScene2d::onDraw() pxCore/examples/pxScene2d/src/pxScene2d.cpp:2376 (pxscene+0x000000542ba9)
    #18 pxScriptView::onDraw() <null> (pxscene+0x00000055ac4a)
    #19 sceneWindow::onDraw(pxSurfaceNativeDesc*) pxCore/examples/pxScene2d/src/pxScene.cpp:357 (pxscene+0x0000005952b0)
    #20 pxWindowNative::drawFrame() pxCore/src/wayland_egl/pxWindowNative.cpp:883 (pxscene+0x00000059e685)
    #21 pxWindowNative::animateAndRender() pxCore/src/wayland_egl/pxWindowNative.cpp:844 (pxscene+0x00000059e3e8)
    #22 pxWindowNative::runEventLoop() pxCore/src/wayland_egl/pxWindowNative.cpp:595 (pxscene+0x00000059d792)
    #23 pxEventLoop::run() pxCore/src/wayland_egl/pxEventLoopNative.cpp:19 (pxscene+0x0000005a1969)
    #24 pxMain(int, char**) pxCore/examples/pxScene2d/src/pxScene.cpp:618 (pxscene+0x000000593e23)
    #25 main pxCore/src/wayland_egl/pxEventLoopNative.cpp:34 (pxscene+0x0000005a19f7)

  Location is heap block of size 208 at 0x7b3400000000 allocated by main thread:
    #0 operator new(unsigned long) <null> (libtsan.so.0+0x00000006f766)
    #1 __static_initialization_and_destruction_0 pxCore/src/rtThreadPool.cpp:28 (pxscene+0x0000005a3ad5)
    #2 _GLOBAL__sub_I_rtThreadPool.cpp pxCore/src/rtThreadPool.cpp:50 (pxscene+0x0000005a3b50)
    #3 __libc_csu_init <null> (pxscene+0x00000068f53c)

  Mutex M516 (0x00000091cde0) created at:
    #0 pthread_mutex_lock <null> (libtsan.so.0+0x00000003b62e)
    #1 rtWrapperSceneUpdateEnter() pxCore/src/rtScript.cpp:108 (pxscene+0x0000005b7501)
    #2 rtScriptNodeUtils::rtFunctionWrapper::call(v8::FunctionCallbackInfo<v8::Value> const&) pxCore/src/rtScriptNode/rtFunctionWrapper.cpp:225 (pxscene+0x0000005cb967)
    #3 v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&)) ../deps/v8/src/api-arguments.cc:16 (libnode.so.48+0x0000005842c2)
    #4 pxScriptView::pxScriptView(char const*, char const*) pxCore/examples/pxScene2d/src/pxScene2d.cpp:3424 (pxscene+0x0000005497da)
    #5 sceneWindow::init(int, int, int, int, char const*) pxCore/examples/pxScene2d/src/pxScene.cpp:169 (pxscene+0x000000594716)
    #6 pxMain(int, char**) pxCore/examples/pxScene2d/src/pxScene.cpp:534 (pxscene+0x000000593dc4)
    #7 main pxCore/src/wayland_egl/pxEventLoopNative.cpp:34 (pxscene+0x0000005a19f7)

  Thread T1 (tid=6654, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x000000028e03)
    #1 rtThreadPoolNative::initialize() pxCore/src/unix/rtThreadPoolNative.cpp:35 (pxscene+0x0000005958dd)
    #2 rtThreadPoolNative::rtThreadPoolNative(int) pxCore/src/unix/rtThreadPoolNative.cpp:17 (pxscene+0x000000595762)
    #3 rtThreadPool::rtThreadPool(int) pxCore/src/rtThreadPool.cpp:31 (pxscene+0x0000005a393e)
    #4 __static_initialization_and_destruction_0 pxCore/src/rtThreadPool.cpp:28 (pxscene+0x0000005a3ae5)
    #5 _GLOBAL__sub_I_rtThreadPool.cpp pxCore/src/rtThreadPool.cpp:50 (pxscene+0x0000005a3b50)
    #6 __libc_csu_init <null> (pxscene+0x00000068f53c)

SUMMARY: ThreadSanitizer: data race pxCore/src/unix/rtMutexNative.cpp:24 in rtMutexNative::unlock()
==================
==================
WARNING: ThreadSanitizer: data race (pid=6652)
  Write of size 1 at 0x7b3400000030 by thread T2:
    #0 rtMutexNative::unlock() pxCore/src/unix/rtMutexNative.cpp:24 (pxscene+0x0000005954c3)
    #1 rtThreadPoolNative::startThread() pxCore/src/unix/rtThreadPoolNative.cpp:83 (pxscene+0x000000595ba8)
    #2 launchThread(void*) pxCore/src/unix/rtThreadPoolNative.cpp:9 (pxscene+0x0000005956a4)
    #3 <null> <null> (libtsan.so.0+0x0000000257eb)

  Previous write of size 1 at 0x7b3400000030 by main thread (mutexes: write M516):
    #0 rtMutexNative::unlock() pxCore/src/unix/rtMutexNative.cpp:24 (pxscene+0x0000005954c3)
    #1 rtThreadPoolNative::executeTask(rtThreadTask*) pxCore/src/unix/rtThreadPoolNative.cpp:99 (pxscene+0x000000595c60)
    #2 pxTextureOffscreen::freeOffscreenDataInBackground() pxCore/examples/pxScene2d/src/pxContextGL.cpp:873 (pxscene+0x00000057fd70)
    #3 pxTextureOffscreen::bindGLTexture(int) pxCore/examples/pxScene2d/src/pxContextGL.cpp:765 (pxscene+0x00000057f576)
    #4 textureShaderProgram::draw(int, int, float*, float, int, void const*, void const*, rtRef<pxTexture>, int, int) pxCore/examples/pxScene2d/src/pxContextGL.cpp:1619 (pxscene+0x000000582280)
    #5 drawImage92 pxCore/examples/pxScene2d/src/pxContextGL.cpp:2076 (pxscene+0x000000577905)
    #6 pxContext::drawImage9(float, float, float, float, float, float, rtRef<pxTexture>) pxCore/examples/pxScene2d/src/pxContextGL.cpp:2580 (pxscene+0x00000057ab36)
    #7 pxImage9::draw() pxCore/examples/pxScene2d/src/pxImage9.cpp:121 (pxscene+0x000000510be3)
    #8 pxObject::drawInternal(bool) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1355 (pxscene+0x00000053d11e)
    #9 pxObject::createSnapshot(rtRef<pxContextFramebuffer>&, bool, bool) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1554 (pxscene+0x00000053e004)
    #10 pxObject::drawInternal(bool) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1336 (pxscene+0x00000053ceea)
    #11 pxObject::drawInternal(bool) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1367 (pxscene+0x00000053d1ca)
    #12 pxObject::drawInternal(bool) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1367 (pxscene+0x00000053d1ca)
    #13 pxObject::drawInternal(bool) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1367 (pxscene+0x00000053d1ca)
    #14 pxScene2d::draw() pxCore/examples/pxScene2d/src/pxScene2d.cpp:2190 (pxscene+0x0000005420a4)
    #15 pxScene2d::onDraw() pxCore/examples/pxScene2d/src/pxScene2d.cpp:2376 (pxscene+0x000000542ba9)
    #16 pxScriptView::onDraw() <null> (pxscene+0x00000055ac4a)
    #17 pxViewContainer::draw() pxCore/examples/pxScene2d/src/pxScene2d.h:976 (pxscene+0x000000558f7a)
    #18 pxObject::drawInternal(bool) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1355 (pxscene+0x00000053d11e)
    #19 pxObject::drawInternal(bool) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1367 (pxscene+0x00000053d1ca)
    #20 pxScene2d::draw() pxCore/examples/pxScene2d/src/pxScene2d.cpp:2190 (pxscene+0x0000005420a4)
    #21 pxScene2d::onDraw() pxCore/examples/pxScene2d/src/pxScene2d.cpp:2376 (pxscene+0x000000542ba9)
    #22 pxScriptView::onDraw() <null> (pxscene+0x00000055ac4a)
    #23 sceneWindow::onDraw(pxSurfaceNativeDesc*) pxCore/examples/pxScene2d/src/pxScene.cpp:357 (pxscene+0x0000005952b0)
    #24 pxWindowNative::drawFrame() pxCore/src/wayland_egl/pxWindowNative.cpp:883 (pxscene+0x00000059e685)
    #25 pxWindowNative::animateAndRender() pxCore/src/wayland_egl/pxWindowNative.cpp:844 (pxscene+0x00000059e3e8)
    #26 pxWindowNative::runEventLoop() pxCore/src/wayland_egl/pxWindowNative.cpp:595 (pxscene+0x00000059d792)
    #27 pxEventLoop::run() pxCore/src/wayland_egl/pxEventLoopNative.cpp:19 (pxscene+0x0000005a1969)
    #28 pxMain(int, char**) pxCore/examples/pxScene2d/src/pxScene.cpp:618 (pxscene+0x000000593e23)
    #29 main pxCore/src/wayland_egl/pxEventLoopNative.cpp:34 (pxscene+0x0000005a19f7)

  Location is heap block of size 208 at 0x7b3400000000 allocated by main thread:
    #0 operator new(unsigned long) <null> (libtsan.so.0+0x00000006f766)
    #1 __static_initialization_and_destruction_0 pxCore/src/rtThreadPool.cpp:28 (pxscene+0x0000005a3ad5)
    #2 _GLOBAL__sub_I_rtThreadPool.cpp pxCore/src/rtThreadPool.cpp:50 (pxscene+0x0000005a3b50)
    #3 __libc_csu_init <null> (pxscene+0x00000068f53c)

  Mutex M516 (0x00000091cde0) created at:
    #0 pthread_mutex_lock <null> (libtsan.so.0+0x00000003b62e)
    #1 rtWrapperSceneUpdateEnter() pxCore/src/rtScript.cpp:108 (pxscene+0x0000005b7501)
    #2 rtScriptNodeUtils::rtFunctionWrapper::call(v8::FunctionCallbackInfo<v8::Value> const&) pxCore/src/rtScriptNode/rtFunctionWrapper.cpp:225 (pxscene+0x0000005cb967)
    #3 v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&)) ../deps/v8/src/api-arguments.cc:16 (libnode.so.48+0x0000005842c2)
    #4 pxScriptView::pxScriptView(char const*, char const*) pxCore/examples/pxScene2d/src/pxScene2d.cpp:3424 (pxscene+0x0000005497da)
    #5 sceneWindow::init(int, int, int, int, char const*) pxCore/examples/pxScene2d/src/pxScene.cpp:169 (pxscene+0x000000594716)
    #6 pxMain(int, char**) pxCore/examples/pxScene2d/src/pxScene.cpp:534 (pxscene+0x000000593dc4)
    #7 main pxCore/src/wayland_egl/pxEventLoopNative.cpp:34 (pxscene+0x0000005a19f7)

  Thread T2 (tid=6655, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x000000028e03)
    #1 rtThreadPoolNative::initialize() pxCore/src/unix/rtThreadPoolNative.cpp:35 (pxscene+0x0000005958dd)
    #2 rtThreadPoolNative::rtThreadPoolNative(int) pxCore/src/unix/rtThreadPoolNative.cpp:17 (pxscene+0x000000595762)
    #3 rtThreadPool::rtThreadPool(int) pxCore/src/rtThreadPool.cpp:31 (pxscene+0x0000005a393e)
    #4 __static_initialization_and_destruction_0 pxCore/src/rtThreadPool.cpp:28 (pxscene+0x0000005a3ae5)
    #5 _GLOBAL__sub_I_rtThreadPool.cpp pxCore/src/rtThreadPool.cpp:50 (pxscene+0x0000005a3b50)
    #6 __libc_csu_init <null> (pxscene+0x00000068f53c)

SUMMARY: ThreadSanitizer: data race pxCore/src/unix/rtMutexNative.cpp:24 in rtMutexNative::unlock()
==================
==================
WARNING: ThreadSanitizer: data race (pid=6652)
  Write of size 1 at 0x000000f3c3b8 by thread T1 (mutexes: write M256):
    #0 rtMutexNative::lock() pxCore/src/unix/rtMutexNative.cpp:18 (pxscene+0x00000059547f)
    #1 rtThreadQueue::addTask(void (*)(void*, void*), void*, void*) pxCore/src/rtThreadQueue.cpp:31 (pxscene+0x0000005a3c3c)
    #2 cleanupOffscreen(void*) pxCore/examples/pxScene2d/src/pxContextGL.cpp:1164 (pxscene+0x000000575614)
    #3 rtThreadTask::execute() pxCore/src/rtThreadTask.cpp:38 (pxscene+0x0000005a7850)
    #4 rtThreadPoolNative::startThread() pxCore/src/unix/rtThreadPoolNative.cpp:87 (pxscene+0x000000595bbf)
    #5 launchThread(void*) pxCore/src/unix/rtThreadPoolNative.cpp:9 (pxscene+0x0000005956a4)
    #6 <null> <null> (libtsan.so.0+0x0000000257eb)

  Previous write of size 1 at 0x000000f3c3b8 by main thread (mutexes: write M516):
    #0 rtMutexNative::unlock() pxCore/src/unix/rtMutexNative.cpp:24 (pxscene+0x0000005954c3)
    #1 rtThreadQueue::process(double) pxCore/src/rtThreadQueue.cpp:73 (pxscene+0x0000005a3f18)
    #2 pxScene2d::onUpdate(double) pxCore/examples/pxScene2d/src/pxScene2d.cpp:2264 (pxscene+0x0000005423bf)
    #3 pxScriptView::onUpdate(double) <null> (pxscene+0x00000055abbc)
    #4 pxViewContainer::update(double) pxCore/examples/pxScene2d/src/pxScene2d.h:969 (pxscene+0x000000558ece)
    #5 pxObject::update(double) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1098 (pxscene+0x00000053c063)
    #6 pxScene2d::update(double) pxCore/examples/pxScene2d/src/pxScene2d.cpp:2406 (pxscene+0x000000542cef)
    #7 pxScene2d::onUpdate(double) pxCore/examples/pxScene2d/src/pxScene2d.cpp:2273 (pxscene+0x00000054244d)
    #8 pxScriptView::onUpdate(double) <null> (pxscene+0x00000055abbc)
    #9 sceneWindow::onAnimationTimer() pxCore/examples/pxScene2d/src/pxScene.cpp:365 (pxscene+0x000000595348)
    #10 pxWindowNative::onAnimationTimerInternal() pxCore/src/wayland_egl/pxWindowNative.cpp:488 (pxscene+0x00000059d1c6)
    #11 pxWindowNative::animateAndRender() pxCore/src/wayland_egl/pxWindowNative.cpp:853 (pxscene+0x00000059e49c)
    #12 pxWindowNative::runEventLoop() pxCore/src/wayland_egl/pxWindowNative.cpp:595 (pxscene+0x00000059d792)
    #13 pxEventLoop::run() pxCore/src/wayland_egl/pxEventLoopNative.cpp:19 (pxscene+0x0000005a1969)
    #14 pxMain(int, char**) pxCore/examples/pxScene2d/src/pxScene.cpp:618 (pxscene+0x000000593e23)
    #15 main pxCore/src/wayland_egl/pxEventLoopNative.cpp:34 (pxscene+0x0000005a19f7)

  Location is global 'gUIThreadQueue' of size 128 at 0x000000f3c340 (pxscene+0x000000f3c3b8)

  Mutex M256 (0x000000f3c390) created at:
    #0 pthread_mutex_init <null> (libtsan.so.0+0x00000002971e)
    #1 rtMutexNative::rtMutexNative() pxCore/src/unix/rtMutexNative.cpp:6 (pxscene+0x0000005953f8)
    #2 rtMutex::rtMutex() pxCore/src/unix/../rtMutex.h:30 (pxscene+0x0000004e41d8)
    #3 rtThreadQueue::rtThreadQueue() pxCore/src/rtThreadQueue.cpp:26 (pxscene+0x0000005a3b98)
    #4 __static_initialization_and_destruction_0 pxCore/examples/pxScene2d/src/pxContextGL.cpp:127 (pxscene+0x00000057c68a)
    #5 _GLOBAL__sub_I_pxContextGL.cpp pxCore/examples/pxScene2d/src/pxContextGL.cpp:2994 (pxscene+0x00000057c754)
    #6 __libc_csu_init <null> (pxscene+0x00000068f53c)

  Mutex M516 (0x00000091cde0) created at:
    #0 pthread_mutex_lock <null> (libtsan.so.0+0x00000003b62e)
    #1 rtWrapperSceneUpdateEnter() pxCore/src/rtScript.cpp:108 (pxscene+0x0000005b7501)
    #2 rtScriptNodeUtils::rtFunctionWrapper::call(v8::FunctionCallbackInfo<v8::Value> const&) pxCore/src/rtScriptNode/rtFunctionWrapper.cpp:225 (pxscene+0x0000005cb967)
    #3 v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&)) ../deps/v8/src/api-arguments.cc:16 (libnode.so.48+0x0000005842c2)
    #4 pxScriptView::pxScriptView(char const*, char const*) pxCore/examples/pxScene2d/src/pxScene2d.cpp:3424 (pxscene+0x0000005497da)
    #5 sceneWindow::init(int, int, int, int, char const*) pxCore/examples/pxScene2d/src/pxScene.cpp:169 (pxscene+0x000000594716)
    #6 pxMain(int, char**) pxCore/examples/pxScene2d/src/pxScene.cpp:534 (pxscene+0x000000593dc4)
    #7 main pxCore/src/wayland_egl/pxEventLoopNative.cpp:34 (pxscene+0x0000005a19f7)

  Thread T1 (tid=6654, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x000000028e03)
    #1 rtThreadPoolNative::initialize() pxCore/src/unix/rtThreadPoolNative.cpp:35 (pxscene+0x0000005958dd)
    #2 rtThreadPoolNative::rtThreadPoolNative(int) pxCore/src/unix/rtThreadPoolNative.cpp:17 (pxscene+0x000000595762)
    #3 rtThreadPool::rtThreadPool(int) pxCore/src/rtThreadPool.cpp:31 (pxscene+0x0000005a393e)
    #4 __static_initialization_and_destruction_0 pxCore/src/rtThreadPool.cpp:28 (pxscene+0x0000005a3ae5)
    #5 _GLOBAL__sub_I_rtThreadPool.cpp pxCore/src/rtThreadPool.cpp:50 (pxscene+0x0000005a3b50)
    #6 __libc_csu_init <null> (pxscene+0x00000068f53c)

SUMMARY: ThreadSanitizer: data race pxCore/src/unix/rtMutexNative.cpp:18 in rtMutexNative::lock()
==================
rt: WARN pxScene2d.cpp:2323 -- Thread-6652: pxScene fps: 12  (below warn threshold of 25)
==================
WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock) (pid=6652)
  Cycle in lock order graph: M359 (0x7b1400000550) => M516 (0x00000091cde0) => M359

  Mutex M516 acquired here while holding mutex M359 in main thread:
    #0 pthread_mutex_lock <null> (libtsan.so.0+0x00000003b62e)
    #1 rtWrapperSceneUpdateEnter() pxCore/src/rtScript.cpp:108 (pxscene+0x0000005b7501)
    #2 rtScriptNodeUtils::rtFunctionWrapper::call(v8::FunctionCallbackInfo<v8::Value> const&) pxCore/src/rtScriptNode/rtFunctionWrapper.cpp:225 (pxscene+0x0000005cb967)
    #3 v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&)) ../deps/v8/src/api-arguments.cc:16 (libnode.so.48+0x0000005842c2)
    #4 pxScriptView::pxScriptView(char const*, char const*) pxCore/examples/pxScene2d/src/pxScene2d.cpp:3424 (pxscene+0x0000005497da)
    #5 sceneWindow::init(int, int, int, int, char const*) pxCore/examples/pxScene2d/src/pxScene.cpp:169 (pxscene+0x000000594716)
    #6 pxMain(int, char**) pxCore/examples/pxScene2d/src/pxScene.cpp:534 (pxscene+0x000000593dc4)
    #7 main pxCore/src/wayland_egl/pxEventLoopNative.cpp:34 (pxscene+0x0000005a19f7)

    Hint: use TSAN_OPTIONS=second_deadlock_stack=1 to get more informative warning message

  Mutex M359 acquired here while holding mutex M516 in main thread:
    #0 pthread_mutex_lock <null> (libtsan.so.0+0x00000003b62e)
    #1 v8::internal::ThreadManager::Lock() ../deps/v8/src/v8threads.cc:154 (libnode.so.48+0x000000b3f610)
    #2 rtEmit::Send(int, rtValue const*, rtValue*) pxCore/src/rtObject.cpp:130 (pxscene+0x00000060620c)
    #3 rtEmitRef::Send(int, rtValue const*, rtValue*) pxCore/src/rtObject.cpp:163 (pxscene+0x0000006063a8)
    #4 rtFunctionBase::Send(int, rtValue const*) pxCore/src/rtObject.h:220 (pxscene+0x000000609109)
    #5 rtFunctionBase::send(rtValue const&, rtValue const&) pxCore/src/rtObject.cpp:510 (pxscene+0x000000607ebb)
    #6 pxScene2d::onUpdate(double) pxCore/examples/pxScene2d/src/pxScene2d.cpp:2343 (pxscene+0x000000542992)
    #7 pxScriptView::onUpdate(double) <null> (pxscene+0x00000055abbc)
    #8 sceneWindow::onAnimationTimer() pxCore/examples/pxScene2d/src/pxScene.cpp:365 (pxscene+0x000000595348)
    #9 pxWindowNative::onAnimationTimerInternal() pxCore/src/wayland_egl/pxWindowNative.cpp:488 (pxscene+0x00000059d1c6)
    #10 pxWindowNative::animateAndRender() pxCore/src/wayland_egl/pxWindowNative.cpp:853 (pxscene+0x00000059e49c)
    #11 pxWindowNative::runEventLoop() pxCore/src/wayland_egl/pxWindowNative.cpp:595 (pxscene+0x00000059d792)
    #12 pxEventLoop::run() pxCore/src/wayland_egl/pxEventLoopNative.cpp:19 (pxscene+0x0000005a1969)
    #13 pxMain(int, char**) pxCore/examples/pxScene2d/src/pxScene.cpp:618 (pxscene+0x000000593e23)
    #14 main pxCore/src/wayland_egl/pxEventLoopNative.cpp:34 (pxscene+0x0000005a19f7)

SUMMARY: ThreadSanitizer: lock-order-inversion (potential deadlock) (/lib64/libtsan.so.0+0x3b62e) in pthread_mutex_lock