### PR TITLE
fix -Werror=unused-but-set-variable compilation error

### DIFF
--- a/src/rtPathUtils.cpp
+++ b/src/rtPathUtils.cpp
@@ -28,11 +28,11 @@
 
 #include <sys/stat.h>
 
-rtError rtGetCurrentDirectory(rtString& d) 
+rtError rtGetCurrentDirectory(rtString& d)
 {
   char* p = getcwd(NULL, 0);
 
-  if (p) 
+  if (p)
   {
     d = p;
     free(p);
@@ -67,7 +67,7 @@ rtError rtGetHomeDirectory(rtString& d)
   if (rtGetEnv(homeDir, d) == RT_OK)
     e = rtEnsureTrailingPathSeparator(d);
 
-  return RT_OK;
+  return e;
 }
 
 bool rtFileExists(const char* f)


### PR DESCRIPTION
Fixes the following compilation error:
pxCore/src/rtPathUtils.cpp: In function ‘rtError rtGetHomeDirectory(rtString&)’:
pxCore/src/rtPathUtils.cpp:59:11: error: variable ‘e’ set but not used [-Werror=unused-but-set-variable]
   rtError e = RT_FAIL;
           ^