### PR TITLE
fix compilation errors -Werror=unused-variable

### DIFF
--- a/src/rtScriptDuk/rtFunctionWrapper.cpp
+++ b/src/rtScriptDuk/rtFunctionWrapper.cpp
@@ -3,9 +3,6 @@
 
 #include <vector>
 
-static const char* kClassName = "Function";
-
-
 rtFunctionWrapper::rtFunctionWrapper(const rtFunctionRef& ref)
   : rtWrapper(ref)
 {
@@ -158,4 +155,3 @@ rtError jsFunctionWrapper::Send(int numArgs, const rtValue* args, rtValue* resul
   duk_pop(mDukCtx);
   return 0;
 }
-

--- a/src/rtScriptDuk/rtObjectWrapper.cpp
+++ b/src/rtScriptDuk/rtObjectWrapper.cpp
@@ -10,9 +10,7 @@ extern "C" {
 #include "duv.h"
 }
 
-static const char* kClassName   = "rtObject";
 static const char* kFuncAllKeys = "allKeys";
-static const char* kPropLength = "length";
 
 const char* jsObjectWrapper::kIsJavaScriptObjectWrapper = "8907a0a6-ef86-4c3d-aea1-c40c0aa2f6f0";
 
@@ -77,7 +75,7 @@ static duk_ret_t dukObjectMethodGetStub(duk_context *ctx)
 
   int numArgs = duk_get_top(ctx);
 
-  if (funcInfo->mType == dukObjectFunctionInfo::eGetProp) 
+  if (funcInfo->mType == dukObjectFunctionInfo::eGetProp)
   {
     rtValue val;
     obj->Get(funcInfo->mMethodName.c_str(), &val);
@@ -85,7 +83,7 @@ static duk_ret_t dukObjectMethodGetStub(duk_context *ctx)
     return 1;
   }
 
-  if (funcInfo->mType == dukObjectFunctionInfo::eSetProp) 
+  if (funcInfo->mType == dukObjectFunctionInfo::eSetProp)
   {
     duk_dup(ctx, 0);
     rtValue val = duk2rt(ctx);
@@ -99,7 +97,7 @@ static duk_ret_t dukObjectMethodGetStub(duk_context *ctx)
   assert(numArgs < 16);
   rtValue args[16];
 
-  for (int i = 0; i < numArgs; ++i) 
+  for (int i = 0; i < numArgs; ++i)
   {
     duk_dup(ctx, i);
     args[i] = duk2rt(ctx);
@@ -139,33 +137,33 @@ static void wrapObjToDuk(duk_context *ctx, const rtObjectRef& ref)
 
   rtMethodMap* mOrig = ref->getMap();
 
-  if (mOrig == NULL) 
+  if (mOrig == NULL)
   {
     duk_push_pointer(ctx, NULL);
     duk_put_prop_string(ctx, -2, "\xff""\xff""funcInfoList");
     return;
   }
 
-  if (methodCache.count(mOrig) == 0) 
+  if (methodCache.count(mOrig) == 0)
   {
     rtMethodMap* m = mOrig;
 
-    while (m) 
+    while (m)
     {
       rtMethodEntry *e = m->getFirstMethod();
-      while (e) 
+      while (e)
       {
         dukObjectFunctionInfo *funcInfo = new dukObjectFunctionInfo();
         funcInfo->mMethodName = e->mMethodName;
         funcInfo->mIsVoid = e->mReturnType == RT_voidType;
         funcInfo->mType = dukObjectFunctionInfo::eMethod;
 
-        if (prevInfo == NULL) 
+        if (prevInfo == NULL)
         {
           firstInfo = funcInfo;
           prevInfo = funcInfo;
-        } 
-        else 
+        }
+        else
         {
           prevInfo->mNext = funcInfo;
           prevInfo = funcInfo;
@@ -178,49 +176,49 @@ static void wrapObjToDuk(duk_context *ctx, const rtObjectRef& ref)
     }
 
     m = mOrig;
-    while (m) 
+    while (m)
     {
       rtPropertyEntry* e = m->getFirstProperty();
-      while (e) 
+      while (e)
       {
-        if (!e->mGetThunk && !e->mSetThunk) 
+        if (!e->mGetThunk && !e->mSetThunk)
         {
           e = e->mNext;
           continue;
         }
 
-        if (e->mGetThunk) 
+        if (e->mGetThunk)
         {
           dukObjectFunctionInfo *funcInfo = new dukObjectFunctionInfo();
           funcInfo->mMethodName = e->mPropertyName;
           funcInfo->mIsVoid = false;
           funcInfo->mType = dukObjectFunctionInfo::eGetProp;
 
-          if (prevInfo == NULL) 
+          if (prevInfo == NULL)
           {
             firstInfo = funcInfo;
             prevInfo = funcInfo;
-          } 
-          else 
+          }
+          else
           {
             prevInfo->mNext = funcInfo;
             prevInfo = funcInfo;
           }
         }
 
-        if (e->mSetThunk) 
+        if (e->mSetThunk)
         {
           dukObjectFunctionInfo *funcInfo = new dukObjectFunctionInfo();
           funcInfo->mMethodName = e->mPropertyName;
           funcInfo->mIsVoid = false;
           funcInfo->mType = dukObjectFunctionInfo::eSetProp;
 
-          if (prevInfo == NULL) 
+          if (prevInfo == NULL)
           {
             firstInfo = funcInfo;
             prevInfo = funcInfo;
-          } 
-          else 
+          }
+          else
           {
             prevInfo->mNext = funcInfo;
             prevInfo = funcInfo;
@@ -234,13 +232,13 @@ static void wrapObjToDuk(duk_context *ctx, const rtObjectRef& ref)
     }
 
     methodCache[mOrig] = firstInfo;
-  } 
-  else 
+  }
+  else
   {
     firstInfo = methodCache[mOrig];
   }
 
-  for (prevInfo = firstInfo; prevInfo != NULL; prevInfo = prevInfo->mNext) 
+  for (prevInfo = firstInfo; prevInfo != NULL; prevInfo = prevInfo->mNext)
   {
     if (prevInfo->mType == dukObjectFunctionInfo::eMethod)
     {
@@ -275,10 +273,10 @@ static void wrapObjToDuk(duk_context *ctx, const rtObjectRef& ref)
     dukObjectFunctionInfo *infoPtr[2] = { prevInfo, prevInfo->mNext };
 
     int objFuncIdx = 0;
-    for (objFuncIdx = 0; objFuncIdx < 2; ++objFuncIdx) 
+    for (objFuncIdx = 0; objFuncIdx < 2; ++objFuncIdx)
     {
       dukObjectFunctionInfo *info = infoPtr[objFuncIdx];
-      if (info == NULL || info->mMethodName != prevInfo->mMethodName) 
+      if (info == NULL || info->mMethodName != prevInfo->mMethodName)
       {
         break;
       }
@@ -296,7 +294,7 @@ static void wrapObjToDuk(duk_context *ctx, const rtObjectRef& ref)
       }
     }
 
-    if (objFuncIdx == 2) 
+    if (objFuncIdx == 2)
     {
       prevInfo = prevInfo->mNext;
     }
@@ -351,7 +349,7 @@ void rtObjectWrapper::createFromObjectReference(duk_context *ctx, const rtObject
       {
         uint32_t len = keys.get<uint32_t>("length");
 
-        duk_idx_t obj_idx = duk_push_object(ctx);
+        (void)duk_push_object(ctx);
 
         for (uint32_t i = 0; i < len; ++i)
         {
@@ -385,7 +383,7 @@ void rtObjectWrapper::createFromObjectReference(duk_context *ctx, const rtObject
       {
         duk_bool_t rt = duk_get_global_string(ctx, "Promise");
 
-        // [func] 
+        // [func]
         assert(rt);
 
         uint32_t isResolved = 0;
@@ -437,12 +435,12 @@ void rtObjectWrapper::createFromObjectReference(duk_context *ctx, const rtObject
         #endif
 
         duk_bool_t rt = duk_get_global_string(ctx, "constructPromise");
-        // [func] 
+        // [func]
         assert(rt);
 
         wrapObjToDuk(ctx, ref);
 
-        // [func obj] 
+        // [func obj]
 
         if (duk_pcall(ctx, 1) != 0) {
           duv_dump_error(ctx, -1);
@@ -463,7 +461,7 @@ void rtObjectWrapper::createFromObjectReference(duk_context *ctx, const rtObject
         const_cast<rtObjectRef &>(ref).set("promiseId", rtString(promiseObjName.c_str()));
        // const_cast<rtObjectRef &>(ref).set("promiseContext", (void*)ctx);
 #else
-        const_cast<rtObjectRef &>(ref).set("promiseId", "blah");  
+        const_cast<rtObjectRef &>(ref).set("promiseId", "blah");
 #endif
 #endif
         return;
@@ -618,7 +616,7 @@ rtError jsObjectWrapper::Get(uint32_t i, rtValue* value) const
 {
   // unsupported yet
   //assert(0);
-  // TODO no error propogation.. 
+  // TODO no error propogation..
   *value = dukGetProp(i);
   return RT_OK;
 }

--- a/src/rtScriptDuk/rtScriptDuk.cpp
+++ b/src/rtScriptDuk/rtScriptDuk.cpp
@@ -201,7 +201,7 @@ public:
     return rtAtomicInc(&mRefCount);
   }
 
-  unsigned long Release();  
+  unsigned long Release();
 
   rtError init();
 
@@ -282,8 +282,6 @@ extern bool use_inspector;
 extern bool debug_wait_connect;
 }
 
-static int exec_argc;
-static const char** exec_argv;
 static rtAtomic sNextId = 100;
 
 
@@ -355,7 +353,7 @@ void rtDukContext::clonedEnvironment(rtDukContextRef clone_me)
 {
   rtLogInfo(__FUNCTION__);
   duk_idx_t thr_idx = duk_push_thread(clone_me->dukCtx);
-  
+
   duk_dup(clone_me->dukCtx, -1);
   rtDukPutIdentToGlobal(clone_me->dukCtx);
 
@@ -391,7 +389,7 @@ rtError rtDukContext::add(const char *name, rtValue const& val)
 {
   rt2duk(dukCtx, val);
   rtDukPutIdentToGlobal(dukCtx, name);
-  
+
   return RT_OK;
 }
 
@@ -1024,11 +1022,11 @@ rtError rtDukContext::runFile(const char *file, rtValue* retVal /*= NULL*/, cons
   // Read the script file
   js_file   = file;
   js_script = readFile(file);
-  
+
   if( js_script.empty() ) // load error
   {
     rtLogError(" %s  ... load error / not found.",__PRETTY_FUNCTION__);
-     
+
     return RT_FAIL;
   }
 

--- a/src/rtScriptNode/rtWrapperUtils.cpp
+++ b/src/rtScriptNode/rtWrapperUtils.cpp
@@ -7,19 +7,13 @@ extern uv_mutex_t threadMutex;
 #include <rtMutex.h>
 
 #ifdef __APPLE__
-static pthread_mutex_t sSceneLock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER; //PTHREAD_MUTEX_INITIALIZER;
-static pthread_t sCurrentSceneThread;
 #ifndef RUNINMAIN
 static pthread_mutex_t sObjectMapMutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER; //PTHREAD_MUTEX_INITIALIZER;
 #endif //!RUNINMAIN
 #elif defined(USE_STD_THREADS)
 #include <thread>
 #include <mutex>
-static std::mutex sSceneLock;
-static std::thread::id sCurrentSceneThread;
 #else
-static pthread_mutex_t sSceneLock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
-static pthread_t sCurrentSceneThread;
 #ifndef RUNINMAIN
 static pthread_mutex_t sObjectMapMutex = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
 #endif //!RUNINMAIN
@@ -266,8 +260,8 @@ rtWrapperSceneUpdateEnter();
     entry->CreationContextId = contextIdCreation;
     objectMap.insert(std::make_pair(from.getPtr(), entry));
   }
-rtWrapperSceneUpdateExit(); 
-#ifndef RUNINMAIN 
+rtWrapperSceneUpdateExit();
+#ifndef RUNINMAIN
   pthread_mutex_unlock(&sObjectMapMutex);
 #endif
 


### PR DESCRIPTION
Fixes the following errors:

src/rtScriptDuk/rtScriptDuk.cpp:286:21: error: ‘exec_argv’ defined but not used [-Werror=unused-variable]
 static const char** exec_argv;
                     ^~~~~~~~~
src/rtScriptDuk/rtScriptDuk.cpp:285:12: error: ‘exec_argc’ defined but not used [-Werror=unused-variable]
 static int exec_argc;
            ^~~~~~~~~
cc1plus: all warnings being treated as errors

pxCore/src/rtScriptDuk/rtObjectWrapper.cpp:354:19: error: unused variable ‘obj_idx’ [-Werror=unused-variable]
         duk_idx_t obj_idx = duk_push_object(ctx);
                   ^~~~~~~
pxCore/src/rtScriptDuk/rtObjectWrapper.cpp: At global scope:
pxCore/src/rtScriptDuk/rtObjectWrapper.cpp:15:20: error: ‘kPropLength’ defined but not used [-Werror=unused-variable]
 static const char* kPropLength = "length";
                    ^~~~~~~~~~~
pxCore/src/rtScriptDuk/rtObjectWrapper.cpp:13:20: error: ‘kClassName’ defined but not used [-Werror=unused-variable]
 static const char* kClassName   = "rtObject";
                    ^~~~~~~~~~

pxCore/src/rtScriptDuk/rtFunctionWrapper.cpp:6:20: error: ‘kClassName’ defined but not used [-Werror=unused-variable]
 static const char* kClassName = "Function";
                    ^~~~~~~~~~
pxCore/src/rtScriptDuk/rtObjectWrapper.cpp:354:19: error: unused variable ‘obj_idx’ [-Werror=unused-variable]
         duk_idx_t obj_idx = duk_push_object(ctx);
                   ^~~~~~~
src/rtScriptDuk/rtObjectWrapper.cpp: At global scope:
src/rtScriptDuk/rtObjectWrapper.cpp:15:20: error: ‘kPropLength’ defined but not used [-Werror=unused-variable]
 static const char* kPropLength = "length";
                    ^~~~~~~~~~~
src/rtScriptDuk/rtObjectWrapper.cpp:13:20: error: ‘kClassName’ defined but not used [-Werror=unused-variable]
 static const char* kClassName   = "rtObject";
                    ^~~~~~~~~~
src/rtScriptNode/rtWrapperUtils.cpp:22:18: error: ‘sCurrentSceneThread’ defined but not used [-Werror=unused-variable]
 static pthread_t sCurrentSceneThread;
                  ^~~~~~~~~~~~~~~~~~~
src/rtScriptNode/rtWrapperUtils.cpp:21:24: error: ‘sSceneLock’ defined but not used [-Werror=unused-variable]
 static pthread_mutex_t sSceneLock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
                        ^~~~~~~~~~