### PR TITLE
Fix double free error with sandbox imports

### DIFF
--- a/examples/pxScene2d/src/rcvrcore/XModule.js
+++ b/examples/pxScene2d/src/rcvrcore/XModule.js
@@ -214,12 +214,17 @@ XModule.prototype._importModule = function(requiredModuleSet, readyCallBack, fai
       } else {
         bPath = _this.name;
       }
-      var nmodules = _this.appSandbox.importTracking[bPath].length;
-      for (var modindex=0; modindex<nmodules; modindex++)
-      {
-        _this.appSandbox.importTracking[bPath].pop();
+
+      var imports = _this.appSandbox.importTracking[bPath];
+
+      if(imports !== undefined && imports !== null && imports.length !== undefined) {
+        var nmodules = _this.appSandbox.importTracking[bPath].length;
+        for (var modindex=0; modindex<nmodules; modindex++)
+        {
+          _this.appSandbox.importTracking[bPath].pop();
+        }
+        delete _this.appSandbox.importTracking[bPath];
       }
-      delete _this.appSandbox.importTracking[bPath];
 
       log.message(7, "XMODULE ABOUT TO NOTIFY [" + _this.name + "] that all its imports are Ready");
       if( readyCallBack !== null && readyCallBack !== undefined ) {


### PR DESCRIPTION
For some reason, the `appSandbox.importTracking[bPath]` is being
evaluated multiple times.  During the first pass, that whole object is
deleted, so on the second pass, it evaluates to undefined and the module
import can't finish.

I don't know exactly what is causing this problem, but this fix
re-enables things that ran under 0.35.0.x. The problem _might_ be
related to calling px.import multiple times from the same file, but
that's only a guess based on log output and what I suspect this module
might be for.