### PR TITLE
Implement new async-signal-safe function rtRemoteSignalCrash()

### DIFF
--- a/remote/rtRemote.cpp
+++ b/remote/rtRemote.cpp
@@ -25,6 +25,9 @@ static rtRemoteEnvironment* gEnv = nullptr;
 rtError
 rtRemoteInit(rtRemoteEnvironment* env)
 {
+  if (rtRemoteEnvironment::Crashed)
+    return RT_OBJECT_NO_LONGER_AVAILABLE;
+
   rtError e = RT_FAIL;
   std::lock_guard<std::mutex> lock(gMutex);
 
@@ -94,6 +97,12 @@ rtRemoteShutdown(rtRemoteEnvironment* env, bool immediate)
   }
 
   return e;
+}
+
+void
+rtRemoteSignalCrash()
+{
+  rtRemoteEnvironment::Crashed = 1;
 }
 
 rtError

--- a/remote/rtRemote.h
+++ b/remote/rtRemote.h
@@ -85,6 +85,12 @@ rtError
 rtRemoteShutdown(rtRemoteEnvironment* env, bool immediate = false);
 
 /**
+ * Signal rtRemote sub-system about the process crash
+ */
+void
+rtRemoteSignalCrash();
+
+/**
  * Processes a single queue item. This is an API to be called from main loop from queue callback.
  * @returns RT_OK for success
  */

--- a/remote/rtRemoteEnvironment.h
+++ b/remote/rtRemoteEnvironment.h
@@ -11,6 +11,8 @@
 #include <queue>
 #include <thread>
 
+#include <signal.h>
+
 class rtRemoteServer;
 class rtRemoteConfig;
 class rtRemoteStreamSelector;
@@ -39,6 +41,8 @@ public:
 
   uint32_t RefCount;
   bool     Initialized;
+
+  static volatile sig_atomic_t Crashed;
 
   void registerQueueReadyHandler(rtRemoteQueueReady handler, void* argp);
   void registerResponseHandler(rtRemoteMessageHandler handler, void* argp, rtRemoteCorrelationKey const& k);

--- a/remote/rtRemoteObjectCache.cpp
+++ b/remote/rtRemoteObjectCache.cpp
@@ -186,6 +186,8 @@ rtRemoteObjectCache::removeUnused()
   std::unique_lock<std::mutex> lock(sMutex);
   for (auto itr = sRefMap.begin(); itr != sRefMap.end();)
   {
+    if (rtRemoteEnvironment::Crashed)
+      break;
     // rtLogInfo("IsActive:%s LifeTime:%lld MaxIdleTime:%lld Unevictable:%d", itr->first.c_str(),
     //           std::chrono::duration_cast<std::chrono::seconds>(now - itr->second.LastUsed).count(),
     //           itr->second.MaxIdleTime.count(), itr->second.Unevictable);

--- a/remote/rtRemoteServer.cpp
+++ b/remote/rtRemoteServer.cpp
@@ -334,6 +334,13 @@ rtRemoteServer::runListener()
     timeout.tv_usec = 0;
 
     int ret = select(maxFd + 1, &readFds, NULL, &errFds, &timeout);
+
+    if (rtRemoteEnvironment::Crashed)
+    {
+      rtLogInfo("got crash signal");
+      return;
+    }
+
     if (ret == -1)
     {
       rtError e = rtErrorFromErrno(errno);

--- a/remote/rtRemoteStreamSelector.cpp
+++ b/remote/rtRemoteStreamSelector.cpp
@@ -102,6 +102,12 @@ rtRemoteStreamSelector::doPollFds()
     std::unique_lock<std::mutex> lock(m_mutex);
     m_streams_cond.wait(lock, [&]() {return !m_streams.empty() || !m_running;});
 
+    if (rtRemoteEnvironment::Crashed)
+    {
+      rtLogInfo("got crash signal");
+      return RT_OK;
+    }
+
     if (!m_running)
       return RT_OK;
 
@@ -130,6 +136,13 @@ rtRemoteStreamSelector::doPollFds()
     timeout.tv_usec = 0;
 
     int ret = select(maxFd + 1, &readFds, NULL, &errFds, &timeout);
+
+    if (rtRemoteEnvironment::Crashed)
+    {
+      rtLogInfo("got crash signal");
+      return RT_OK;
+    }
+
     if (ret == -1)
     {
       rtError e = rtErrorFromErrno(errno);


### PR DESCRIPTION
This function may be called from a signal handler.
It just informs rtRemote subsystem about the crash.
All child threads have to stop immediately after this call.