### PR TITLE
Reverting decoderHandle passing from Pxcore. 

### DIFF
--- a/examples/pxScene2d/external/westeros-stub/westeros-compositor.h
+++ b/examples/pxScene2d/external/westeros-stub/westeros-compositor.h
@@ -5,7 +5,6 @@
 
 typedef unsigned int uint32_t;
 typedef int wl_fixed_t;
-typedef unsigned long long int 	uint64_t;
 
 typedef struct _WstRect
 {
@@ -60,7 +59,6 @@ typedef enum _WstHints
 typedef void (*WstTerminatedCallback)( WstCompositor *ctx, void *userData );
 typedef void (*WstDispatchCallback)( WstCompositor *ctx, void *userData );
 typedef void (*WstInvalidateSceneCallback)( WstCompositor *ctx, void *userData );
-typedef void (*WstDecodeHandlerCallback)( WstCompositor *ctx, void *userData, uint64_t decoderHandle);
 typedef void (*WstHidePointerCallback)( WstCompositor *ctx, bool hidePointer, void *userData );
 typedef void (*WstClientStatus)( WstCompositor *ctx, int status, int clientPID, int detail, void *userData );
 
@@ -353,8 +351,6 @@ bool WstCompositorSetDispatchCallback( WstCompositor *ctx, WstDispatchCallback c
  * scene has become invalid and that WstCompositorComposeEmbedded should be called.
  */
 bool WstCompositorSetInvalidateCallback( WstCompositor *ctx, WstInvalidateSceneCallback cb, void *userData );
-
-bool WstCompositorSetDecoderHandleCallback( WstCompositor *ctx, WstDecodeHandlerCallback cb, void *userData );
 
 /**
  * WstCompositorSetHidePointerCallback

--- a/examples/pxScene2d/src/pxWayland.cpp
+++ b/examples/pxScene2d/src/pxWayland.cpp
@@ -138,14 +138,6 @@ void pxWayland::createDisplay(rtString displayName)
          goto exit;
       }
 
-#ifndef PXSCENE_DISABLE_WST_DECODER
-      if ( !WstCompositorSetDecoderHandleCallback( mWCtx, decoderHandleCallback, this ) )
-      {
-         error= true;
-         goto exit;
-      }
-#endif //PXSCENE_DISABLE_WST_DECODER
-
       if ( !WstCompositorSetHidePointerCallback( mWCtx, hidePointer, this ) )
       {
          error= true;
@@ -453,14 +445,6 @@ void pxWayland::handleInvalidate()
    }
 }
 
-void pxWayland::setDecoderHandle(void* handle)
-{
-    if ( mEvents )
-    {
-        mEvents->decoderHandle(handle);
-    }
-}
-
 void pxWayland::handleHidePointer( bool hide )
 {
    if ( mEvents )
@@ -613,13 +597,6 @@ void pxWayland::invalidate( WstCompositor *wctx, void *userData )
 
    pxWayland *pxw= (pxWayland*)userData;
    pxw->handleInvalidate();
-}
-
-void pxWayland::decoderHandleCallback( WstCompositor *wctx, void *userData, uint64_t decodeHandle)
-{
-   (void)wctx;
-   pxWayland *pxw= (pxWayland*)userData;
-   pxw->setDecoderHandle((void*)decodeHandle);
 }
 
 void pxWayland::hidePointer( WstCompositor *wctx, bool hide, void *userData )

--- a/examples/pxScene2d/src/pxWayland.h
+++ b/examples/pxScene2d/src/pxWayland.h
@@ -40,7 +40,6 @@ public:
   virtual ~pxWaylandEvents() {}
 
   virtual void invalidate( pxRect* /*r*/ ) {}
-  virtual void decoderHandle ( void * ) {}
   virtual void hidePointer( bool /*hide*/ ) {}
   virtual void clientStarted( int /*pid*/ ) {}  
   virtual void clientConnected( int /*pid*/ ) {}
@@ -176,13 +175,11 @@ private:
   pxMatrix4f mLastMatrix;
 
   static void invalidate( WstCompositor *wctx, void *userData );
-  static void decoderHandleCallback( WstCompositor *wctx, void *userData, uint64_t decoderHandle);
   static void hidePointer( WstCompositor *wctx, bool hide, void *userData );
   static void clientStatus( WstCompositor *wctx, int status, int pid, int detail, void *userData );
   static void remoteDisconnectedCB(void *data);
 
   void handleInvalidate();
-  void setDecoderHandle(void* handle);
   void handleHidePointer( bool hide );
   void handleClientStatus( int status, int pid, int detail );
   void launchClient();


### PR DESCRIPTION
Since Helio player is abandoned, We are reverting Helio CC supporting code changes.