### PR TITLE
Fix drawing of border in drawImage9Border2

### DIFF
--- a/examples/pxScene2d/src/pxContextGL.cpp
+++ b/examples/pxScene2d/src/pxContextGL.cpp
@@ -2127,70 +2127,52 @@ static void drawImage9Border2(GLfloat x, GLfloat y, GLfloat w, GLfloat h,
 
 #endif
 
-  const GLfloat verts[26][2] =
-      {
-          { ox1,oy2 },
-          { ix1,oy2 },
-          { ox1,iy2 },
-          { ix1,iy2 },
-          { ox1,iy1 },
-          { ix1,iy1 },
+  const GLfloat verts[14][2] =
+   {
+          // draw border
           { ox1,oy1 },
-          { ix1,oy1 },
           { ix1,iy1 },
-          { ix2,iy1 },
-          { ix2,oy1 },
           { ox2,oy1 },
-          { ox2,iy1 },
           { ix2,iy1 },
-          { ox2,iy2 },
-          { ix2,iy2 },
           { ox2,oy2 },
-          { ix2,oy2 },
           { ix2,iy2 },
+          { ox1,oy2 },
           { ix1,iy2 },
-          { ix1,oy2 },
-          { ix2,oy2 },
-          { ix2,iy2 },
+          { ox1,oy1 },
+          { ix1,iy1 },
+
+          // draw center
+          { ix1,iy1 },
           { ix1,iy2 },
           { ix2,iy1 },
-          { ix1,iy1 }
-      };
-
-  const GLfloat uv[26][2] =
+          { ix2,iy2 },
+   };
+ 
+   const GLfloat uv[14][2] =
       {
-          { ou1,ov1 },
-          { iu1,ov1 },
-          { ou1,iv1 },
-          { iu1,iv1 },
-          { ou1,iv2 },
-          { iu1,iv2 },
+          // draw border
           { ou1,ov2 },
-          { iu1,ov2 },
           { iu1,iv2 },
-          { iu2,iv2 },
-          { iu2,ov2 },
           { ou2,ov2 },
-          { ou2,iv2 },
           { iu2,iv2 },
-          { ou2,iv1 },
-          { iu2,iv1 },
           { ou2,ov1 },
-          { iu2,ov1 },
           { iu2,iv1 },
+          { ou1,ov1 },
           { iu1,iv1 },
-          { iu1,ov1 },
-          { iu2,ov1 },
-          { iu2,iv1 },
+          { ou1,ov2 },
+          { iu1,iv2 },
+
+          //draw center
+          { iu1,iv2 },
           { iu1,iv1 },
           { iu2,iv2 },
-          { iu1,iv2 }
+          { iu2,iv1 },
       };
 
   float colorPM[4];
   premultiply(colorPM,color);
 
-  gTextureBorderShader->draw(gResW,gResH,gMatrix.data(),gAlpha,drawCenter? 26 : 22,verts,uv,texture,pxConstantsStretch::NONE,pxConstantsStretch::NONE, colorPM);
+  gTextureBorderShader->draw(gResW,gResH,gMatrix.data(),gAlpha,drawCenter? 14 : 10,verts,uv,texture,pxConstantsStretch::NONE,pxConstantsStretch::NONE, colorPM);
 }
 
 bool gContextInit = false;


### PR DESCRIPTION
* issue with upper en lower border fixed
* issue with center border fixed

I noticed some issues in drawing those upper and lower borders, those were drawn by only 2 triangles so not fully filled. And when transparency was used, you could see some overlapping drawings in other parts of the borders..

By simplifying the drawing now by using less nodes (took it from drawRectOutline) and adding some extra nodes to also draw the inner center of the rectangle, my tests look OK now. 