### PR TITLE
Correct work and shutdown rtRemoteServer even if pipe was not opened

### DIFF
--- a/remote/rtRemoteServer.h
+++ b/remote/rtRemoteServer.h
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <atomic>
 
 #include <stdint.h>
 #include <netinet/in.h>
@@ -110,6 +111,7 @@ private:
 
   std::unique_ptr<std::thread>  m_thread;
   mutable std::mutex            m_mutex;
+  mutable std::atomic<bool>     m_terminated;
   CommandHandlerMap             m_command_handlers;
 
   rtRemoteIResolver*            m_resolver;


### PR DESCRIPTION
If pipe was not opened in constructor rtRemote still works.
But it tries to read the unopened pipe and can't send a shutdown signal to the listener thread.

This change fixes usage of the pipe and offers an alternative way to shutdown the listener thread.