### PR TITLE
add AppVeyor artifacts management

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,12 +35,15 @@ init:
   - git config --system core.longpaths true
   - ps: "ls \"C:/\""
 
+before_build:
+  - cd %S%
+  - call ci/appveyor-custodian.bat
+
 build_script:
   - echo build_script...
   - cd %S%
   - call ci/build_win32.bat
 
 test: off
-
 
 # validator: https://ci.appveyor.com/tools/validate-yaml

--- a/ci/appveyor-custodian.bat
+++ b/ci/appveyor-custodian.bat
@@ -1,0 +1,6 @@
+git clone https://github.com/dwrobel/appveyor-client.git
+cd appveyor-client
+git checkout delete-build-support
+python setup.py install --user
+cd ..
+python ci/appveyor-custodian.py

--- a/ci/appveyor-custodian.py
+++ b/ci/appveyor-custodian.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#   Author: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
+#
+#   Appvoyer-custodian
+#
+#   Takes care of number of build artifacts
+#   to make sure we will not exceed available quota.
+#
+#
+#   Environment variables:
+#
+#   Required
+#     <API_TOKEN=AppVeyor-api-token>
+#
+#   Optional if runs in AppVeyor environment, otherwise required
+#     APPVEYOR_ACCOUNT_NAME=your-account-name
+#     APPVEYOR_PROJECT_NAME=project-name
+#
+#   Optional (default is 20)
+#     BUILDS_TO_KEEP=number-of-builds-to-keep
+#
+
+import os
+import sys
+import logging
+import traceback
+
+from appveyor_client import AppveyorClient
+
+def get_env_or_exit(name, default_value = None, exit_code = 0):
+    try:
+        val = os.environ[name]
+    except KeyError:
+        val = default_value
+
+    if val is None:
+        logging.error("Environment variable %s is not defined.", name)
+        logging.info("Please define to continue. Exiting with code: %d.", exit_code)
+        sys.exit(exit_code)
+
+    #logging.debug("Environment[\'%s\']: %s", name, val)
+
+    return val
+
+logging.basicConfig(format='Appveyor-custodian[%(levelname)7s]: %(message)s', level=logging.DEBUG)
+
+# based on https://www.appveyor.com/docs/environment-variables/
+api_key = get_env_or_exit('API_TOKEN')
+account_name = get_env_or_exit('APPVEYOR_ACCOUNT_NAME')
+repo_name = get_env_or_exit('APPVEYOR_PROJECT_NAME')
+
+try:
+    logging.info("API client initialization...")
+    client = AppveyorClient(api_key)
+
+    # Get list of projects builds
+    logging.info("Fetching list of builds...")
+    builds = client.projects.history(account_name, repo_name, records_per_page=99999)
+
+    builds_num = len(builds["builds"])
+    logging.info("Builds: %d" % (builds_num))
+
+    keep_builds_num = int(get_env_or_exit('BUILDS_TO_KEEP', default_value = 20))
+
+    to_delete_num = 0
+
+    if builds_num - keep_builds_num > 0:
+        to_delete_num = builds_num - keep_builds_num
+
+    logging.info("Builds to delete: %d" % (to_delete_num))
+
+    for i in range(to_delete_num):
+        b = builds["builds"][builds_num - (i + 1)]
+        buildId = b["buildId"]
+        logging.info("Deleting build: version: %s, id: %d" % (b["version"], buildId))
+        client.builds.delete(account_name, buildId)
+except:
+    logging.error("Unexpected error:" + str(sys.exc_info()[0]))
+    traceback.print_exc(file=sys.stdout)
+
+logging.info("Done")
+
+sys.exit(0)

--- a/ci/build_win32.bat
+++ b/ci/build_win32.bat
@@ -25,6 +25,7 @@ call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary
 @rem build dependencies
 cd examples/pxScene2d/external
 call buildWindows.bat
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 @rem Avoid using link.exe from that paths
 set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
@@ -39,10 +40,26 @@ cd build-win32
 @rem build pxScene
 cmake -DCMAKE_VERBOSE_MAKEFILE=ON ..
 cmake --build . --config Release -- /m
+if %errorlevel% neq 0 exit /b %errorlevel%
+
 cpack .
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 @rem create standalone archive
 cd _CPack_Packages/win32/NSIS
 7z a -y pxscene-setup.zip pxscene-setup
 
 cd %ORIG_DIR%
+
+@rem deploy artifacts
+@rem based on: https://www.appveyor.com/docs/build-worker-api/#push-artifact
+if "%APPVEYOR%"=="True" (
+    if "%DEPLOY_ARTIFACTS%"=="True" (
+        @rem NSIS based installer
+        appveyor PushArtifact "build-win32\\_CPack_Packages\\win32\\NSIS\\pxscene-setup.exe" -DeploymentName "installer" -Type "Auto" -Verbosity "Normal"
+
+        @rem Standalone (requires no installation)
+        appveyor PushArtifact "build-win32\\_CPack_Packages\\win32\\NSIS\\pxscene-setup.zip" -DeploymentName "portable" -Type "Zip" -Verbosity "Normal"
+    )
+)
+


### PR DESCRIPTION
Adds Appveyor-custodian script which manages number of builds
to make sure we will not exceed available quota.

To use it with AppVeyro CI infrastructure please add in:
  Projects->Settings->Environment->Environment variables

  API_TOKEN variable.

Token can be found on API token page under your AppVeyor account.