### PR TITLE
fix reorder compilation errors

### DIFF
--- a/src/rtScriptDuk/rtObjectWrapper.cpp
+++ b/src/rtScriptDuk/rtObjectWrapper.cpp
@@ -31,7 +31,7 @@ rtObjectWrapper::~rtObjectWrapper()
 
 struct dukObjectFunctionInfo
 {
-  dukObjectFunctionInfo(void) : mIsVoid(true), mNext(NULL), mType(dukObjectFunctionInfo::eMethod) {}
+  dukObjectFunctionInfo(void) : mIsVoid(true), mType(dukObjectFunctionInfo::eMethod), mNext(NULL) {}
 
   std::string mMethodName;
   bool        mIsVoid;
@@ -474,9 +474,9 @@ void rtObjectWrapper::createFromObjectReference(duk_context *ctx, const rtObject
 
 jsObjectWrapper::jsObjectWrapper(duk_context *ctx, const std::string &name, bool isArray)
   : mRefCount(0)
+  , mIsArray(isArray)
   , mDukCtx(ctx)
   , mDukName(name)
-  , mIsArray(isArray)
 {
   duk_bool_t rt = duk_get_global_string(ctx, name.c_str());
   assert(rt);

--- a/src/rtScriptDuk/rtScriptDuk.cpp
+++ b/src/rtScriptDuk/rtScriptDuk.cpp
@@ -178,8 +178,8 @@ private:
 #endif
 
   int mRefCount;
-  rtAtomic mId;
   void* mContextifyContext;
+  rtAtomic mId;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -190,8 +190,7 @@ typedef std::map<uint32_t, rtDukContextRef> rtDukContexts;
 class rtScriptDuk: public rtIScript
 {
 public:
-  rtScriptDuk();
-  rtScriptDuk(bool initialize);
+  rtScriptDuk(bool initialize = true);
 
   virtual ~rtScriptDuk();
 
@@ -325,7 +324,7 @@ static inline bool file_exists(const char *file)
 #endif
 
 rtDukContext::rtDukContext() :
-     js_file(NULL), mRefCount(0), mContextifyContext(NULL), dukCtx(NULL), uvLoop(NULL)
+     js_file(NULL), dukCtx(NULL), uvLoop(NULL), mRefCount(0), mContextifyContext(NULL)
 {
   mId = rtAtomicInc(&sNextId);
 
@@ -334,7 +333,7 @@ rtDukContext::rtDukContext() :
 
 #ifdef USE_CONTEXTIFY_CLONES
 rtDukContext::rtDukContext(rtDukContextRef clone_me) :
-      js_file(NULL), mRefCount(0), mContextifyContext(NULL), dukCtx(NULL), uvLoop(NULL)
+      js_file(NULL), dukCtx(NULL), uvLoop(NULL), mRefCount(0), mContextifyContext(NULL)
 {
   mId = rtAtomicInc(&sNextId);
 
@@ -1035,31 +1034,17 @@ rtError rtDukContext::runFile(const char *file, rtValue* retVal /*= NULL*/, cons
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-rtScriptDuk::rtScriptDuk():mRefCount(0), duk_is_initialized(false), dukCtx(NULL)
-#ifndef RUNINMAIN
+rtScriptDuk::rtScriptDuk(bool initialize): dukCtx(NULL), duk_is_initialized(false),
 #ifdef USE_CONTEXTIFY_CLONES
-: mRefContext(), mNeedsToEnd(false), duk_is_initialized(false)
-#else
-: mNeedsToEnd(false)
+  mRefContext(),
 #endif
+  mTestGc(false),
+#ifndef RUNINMAIN
+  mNeedsToEnd(false),
 #endif
+  mRefCount(0)
 {
   rtLogInfo(__FUNCTION__);
-  mTestGc = false;
-  init();
-}
-
-rtScriptDuk::rtScriptDuk(bool initialize):mRefCount(0), duk_is_initialized(false),dukCtx(NULL)
-#ifndef RUNINMAIN
-#ifdef USE_CONTEXTIFY_CLONES
-: mRefContext(), mNeedsToEnd(false), duk_is_initialized(false)
-#else
-: mNeedsToEnd(false)
-#endif
-#endif
-{
-  rtLogInfo(__FUNCTION__);
-  mTestGc = false;
   if (true == initialize)
   {
     init();


### PR DESCRIPTION
Fixes the following errors:

pxCore/src/rtScriptDuk/rtScriptDuk.cpp: In constructor ‘rtDukContext::rtDukContext()’:
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:182:9: error: ‘rtDukContext::mContextifyContext’ will be initialized after [-Werror=reorder]
   void* mContextifyContext;
         ^~~~~~~~~~~~~~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:170:29: error:   ‘duk_context* rtDukContext::dukCtx’ [-Werror=reorder]
   duk_context              *dukCtx;
                             ^~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:327:1: error:   when initialized here [-Werror=reorder]
 rtDukContext::rtDukContext() :
 ^~~~~~~~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp: In constructor ‘rtDukContext::rtDukContext(rtDukContextRef)’:
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:182:9: error: ‘rtDukContext::mContextifyContext’ will be initialized after [-Werror=reorder]
   void* mContextifyContext;
         ^~~~~~~~~~~~~~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:170:29: error:   ‘duk_context* rtDukContext::dukCtx’ [-Werror=reorder]
   duk_context              *dukCtx;
                             ^~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:336:1: error:   when initialized here [-Werror=reorder]
 rtDukContext::rtDukContext(rtDukContextRef clone_me) :
 ^~~~~~~~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp: In constructor ‘rtScriptDuk::rtScriptDuk()’:
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:249:7: error: ‘rtScriptDuk::mRefCount’ will be initialized after [-Werror=reorder]
   int mRefCount;
       ^~~~~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:238:34: error:   ‘bool rtScriptDuk::duk_is_initialized’ [-Werror=reorder]
   bool                           duk_is_initialized;
                                  ^~~~~~~~~~~~~~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:1038:1: error:   when initialized here [-Werror=reorder]
 rtScriptDuk::rtScriptDuk():mRefCount(0), duk_is_initialized(false), dukCtx(NULL)
 ^~~~~~~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:238:34: error: ‘rtScriptDuk::duk_is_initialized’ will be initialized after [-Werror=reorder]
   bool                           duk_is_initialized;
                                  ^~~~~~~~~~~~~~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:235:34: error:   ‘duk_context* rtScriptDuk::dukCtx’ [-Werror=reorder]
   duk_context                   *dukCtx;
                                  ^~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:1038:1: error:   when initialized here [-Werror=reorder]
 rtScriptDuk::rtScriptDuk():mRefCount(0), duk_is_initialized(false), dukCtx(NULL)
 ^~~~~~~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp: In constructor ‘rtScriptDuk::rtScriptDuk(bool)’:
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:249:7: error: ‘rtScriptDuk::mRefCount’ will be initialized after [-Werror=reorder]
   int mRefCount;
       ^~~~~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:238:34: error:   ‘bool rtScriptDuk::duk_is_initialized’ [-Werror=reorder]
   bool                           duk_is_initialized;
                                  ^~~~~~~~~~~~~~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:1052:1: error:   when initialized here [-Werror=reorder]
 rtScriptDuk::rtScriptDuk(bool initialize):mRefCount(0), duk_is_initialized(false),dukCtx(NULL)
 ^~~~~~~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:238:34: error: ‘rtScriptDuk::duk_is_initialized’ will be initialized after [-Werror=reorder]
   bool                           duk_is_initialized;
                                  ^~~~~~~~~~~~~~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:235:34: error:   ‘duk_context* rtScriptDuk::dukCtx’ [-Werror=reorder]
   duk_context                   *dukCtx;
                                  ^~~~~~
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:1052:1: error:   when initialized here [-Werror=reorder]
 rtScriptDuk::rtScriptDuk(bool initialize):mRefCount(0), duk_is_initialized(false),dukCtx(NULL)
 ^~~~~~~~~~~
cc1plus: all warnings being treated as errors