### PR TITLE
fix maybe-uninitialized compilation error

### DIFF
--- a/remote/rtRemoteServer.cpp
+++ b/remote/rtRemoteServer.cpp
@@ -757,7 +757,7 @@ rtRemoteServer::onGet(std::shared_ptr<rtRemoteClient>& client, rtRemoteMessagePt
     rtError err = RT_OK;
     rtValue value;
 
-    uint32_t    index;
+    uint32_t    index = 0;
     char const* name = rtMessage_GetPropertyName(*doc);
 
     if (name)


### PR DESCRIPTION
pxCore/remote/rapidjson/document.h:508:13: error: ‘index’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
         if (!(u & 0x80000000))
             ^~~~~~~~~~~~~~~~~
pxCore/remote/rtRemoteServer.cpp:760:17: note: ‘index’ was declared here
     uint32_t    index;
                 ^~~~~