### PR TITLE
fix missing-field-initializers compilation errors

### DIFF
--- a/src/rtScriptDuk/rtScriptDuk.cpp
+++ b/src/rtScriptDuk/rtScriptDuk.cpp
@@ -640,7 +640,7 @@ static duk_ret_t duv_require(duk_context *ctx) {
 
   const duv_schema_entry schema[] = {
     { "id", duk_is_string },
-    { NULL }
+    { NULL, NULL }
   };
 
   dschema_check(ctx, schema);
@@ -737,7 +737,7 @@ static duk_ret_t duv_require(duk_context *ctx) {
 static duk_ret_t duv_mod_resolve(duk_context *ctx) {
   const duv_schema_entry schema[] = {
     { "id", duk_is_string },
-    { NULL }
+    { NULL, NULL }
   };
 
   dschema_check(ctx, schema);
@@ -754,7 +754,7 @@ static duk_ret_t duv_mod_load(duk_context *ctx) {
   const char* ext;
 
   const duv_schema_entry schema[] = {
-    { NULL }
+    { NULL, NULL }
   };
 
   dschema_check(ctx, schema);
@@ -804,7 +804,7 @@ static duk_ret_t duv_loadlib(duk_context *ctx) {
   const duv_schema_entry schema[] = {
     { "path", duk_is_string },
     { "name", duk_is_string },
-    { NULL }
+    { NULL, NULL }
   };
 
   dschema_check(ctx, schema);
@@ -830,7 +830,7 @@ static duk_ret_t duv_mod_compile(duk_context *ctx) {
   // Check the args
   const duv_schema_entry schema[] = {
     { "code", dschema_is_data },
-    { NULL }
+    { NULL, NULL }
   };
 
   dschema_check(ctx, schema);


### PR DESCRIPTION
Fixes the following errors:

pxCore/src/rtScriptDuk/rtScriptDuk.cpp: In function ‘duk_ret_t duv_require(duk_context*)’:
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:643:3: error: missing initializer for member ‘duv_schema_entry::checker’ [-Werror=missing-field-initializers]
   };
   ^
pxCore/src/rtScriptDuk/rtScriptDuk.cpp: In function ‘duk_ret_t duv_mod_resolve(duk_context*)’:
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:740:3: error: missing initializer for member ‘duv_schema_entry::checker’ [-Werror=missing-field-initializers]
   };
   ^
pxCore/src/rtScriptDuk/rtScriptDuk.cpp: In function ‘duk_ret_t duv_mod_load(duk_context*)’:
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:757:3: error: missing initializer for member ‘duv_schema_entry::checker’ [-Werror=missing-field-initializers]
   };
   ^
pxCore/src/rtScriptDuk/rtScriptDuk.cpp: In function ‘duk_ret_t duv_loadlib(duk_context*)’:
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:807:3: error: missing initializer for member ‘duv_schema_entry::checker’ [-Werror=missing-field-initializers]
   };
   ^
pxCore/src/rtScriptDuk/rtScriptDuk.cpp: In function ‘duk_ret_t duv_mod_compile(duk_context*)’:
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:833:3: error: missing initializer for member ‘duv_schema_entry::checker’ [-Werror=missing-field-initializers]
   };
   ^