### PR TITLE
fix unused-but-set-variable and unused-variable compilation errors

### DIFF
--- a/tests/pxScene2d/pxscene2dtestsmain.cpp
+++ b/tests/pxScene2d/pxscene2dtestsmain.cpp
@@ -47,7 +47,6 @@ int main(int argc, char **argv) {
   gargc = argc;
   gargv = argv;
 #ifdef ENABLE_DEBUG_MODE
-  int urlIndex  = -1;
   bool isDebugging = false;
   g_argv = (char**)malloc((argc+2) * sizeof(char*));
   int size  = 0;
@@ -59,13 +58,6 @@ int main(int argc, char **argv) {
       if (strstr(argv[i],"--debug"))
       {
         isDebugging = true;
-      }
-    }
-    else
-    {
-      if (strstr(argv[i],".js"))
-      {
-        urlIndex = i;
       }
     }
   }

--- a/tests/pxScene2d/test_pxUtil.cpp
+++ b/tests/pxScene2d/test_pxUtil.cpp
@@ -103,8 +103,10 @@ class pxUtilTest : public testing::Test
       if (false == mDownloadImageFailed)
       {
         sysRet = system("rm -rf supportfiles/apngimage.png");
+        EXPECT_TRUE (sysRet == 0);
       }
       sysRet = system("rm -rf supportfiles/wrong.png supportfiles/generatedflower.png");
+      EXPECT_TRUE (sysRet == 0);
       mDownloadImageFailed = true;
     }
 
@@ -112,6 +114,7 @@ class pxUtilTest : public testing::Test
     {
       rtData d;
       rtError loadImageSuccess = rtLoadFile("supportfiles/status_bg.png", d);
+      EXPECT_TRUE (loadImageSuccess == RT_OK);
       rtError ret = pxLoadImage((const char*) d.data(), d.length(), mPngData);
       EXPECT_TRUE (ret == RT_OK);
     }
@@ -229,6 +232,7 @@ class pxUtilTest : public testing::Test
     {
       rtData d;
       rtError loadImageSuccess = rtLoadFile("supportfiles/status_bg.png", d);
+      EXPECT_TRUE (loadImageSuccess == RT_OK);
       failPngCreateReadStruct = true;
       rtError ret = pxLoadPNGImage((const char*)d.data(), d.length(), mPngData);
       failPngCreateReadStruct = false;
@@ -273,6 +277,7 @@ class pxUtilTest : public testing::Test
       {
         rtData d;
         rtError loadImageSuccess = rtLoadFile("supportfiles/apngimage.png", d);
+        EXPECT_TRUE (loadImageSuccess == RT_OK);
         rtError ret = pxLoadAImage((const char*) d.data(), d.length(), mAnimatedPngData);
         EXPECT_TRUE (ret == RT_OK);
       }

--- a/tests/pxScene2d/test_rtZip.cpp
+++ b/tests/pxScene2d/test_rtZip.cpp
@@ -31,7 +31,7 @@ class rtZipTest : public testing::Test
     {
       rtData  buffer;
       rtError ret = rtLoadFile("supportfiles/sample.zip", buffer);
-      
+
       ret = mData.initFromBuffer(buffer.data(), buffer.length());
       EXPECT_TRUE(ret == RT_OK);
     }
@@ -47,10 +47,10 @@ class rtZipTest : public testing::Test
     {
       rtData  buffer;
       rtError ret;
-      
+
       ret = rtLoadFile("supportfiles/sample.zip", buffer);
       EXPECT_TRUE(ret == RT_OK);
-      
+
       ret = mData.initFromBuffer(buffer.data(), buffer.length());
       EXPECT_TRUE(ret == RT_OK);
 
@@ -109,10 +109,12 @@ class rtZipTest : public testing::Test
     {
       rtData  buffer;
       rtError ret = rtLoadFile("supportfiles/test.html", buffer);
+      EXPECT_TRUE(ret == RT_OK);
 
       EXPECT_FALSE( rtZip::isZip(buffer.data(), buffer.length()) );
 
       ret = rtLoadFile("supportfiles/sample.zip", buffer);
+      EXPECT_TRUE(ret == RT_OK);
 
       EXPECT_TRUE( rtZip::isZip(buffer.data(), buffer.length()) );
     }
@@ -134,4 +136,3 @@ TEST_F(rtZipTest, rtZipTests)
 
   isZipTest();
 }
-


### PR DESCRIPTION
Fixes the following errors:

unused-but-set-variable errors:
-------------------------------

pxCore/tests/pxScene2d/test_pxUtil.cpp: In member function ‘virtual void pxUtilTest::TearDown()’:
pxCore/tests/pxScene2d/test_pxUtil.cpp:102:12: error: variable ‘sysRet’ set but not used [-Werror=unused-but-set-variable]
       bool sysRet;
            ^~~~~~
pxCore/tests/pxScene2d/test_pxUtil.cpp: In member function ‘void pxUtilTest::pxLoadImage3ArgsPngSuccessTest()’:
pxCore/tests/pxScene2d/test_pxUtil.cpp:114:15: warning: unused variable ‘loadImageSuccess’ [-Wunused-variable]
       rtError loadImageSuccess = rtLoadFile("supportfiles/status_bg.png", d);
               ^~~~~~~~~~~~~~~~
pxCore/tests/pxScene2d/test_pxUtil.cpp: In member function ‘void pxUtilTest::pxLoadPNGImage3ArgsCreateReadStructFailTest()’:
pxCore/tests/pxScene2d/test_pxUtil.cpp:231:15: warning: unused variable ‘loadImageSuccess’ [-Wunused-variable]
       rtError loadImageSuccess = rtLoadFile("supportfiles/status_bg.png", d);
               ^~~~~~~~~~~~~~~~
pxCore/tests/pxScene2d/test_pxUtil.cpp: In member function ‘void pxUtilTest::pxLoadAPngSuccessTest()’:
pxCore/tests/pxScene2d/test_pxUtil.cpp:275:17: warning: unused variable ‘loadImageSuccess’ [-Wunused-variable]
         rtError loadImageSuccess = rtLoadFile("supportfiles/apngimage.png", d);
                 ^~~~~~~~~~~~~~~~

pxCore/tests/pxScene2d/test_rtZip.cpp: In member function ‘void rtZipTest::isZipTest()’:
pxCore/tests/pxScene2d/test_rtZip.cpp:111:15: error: variable ‘ret’ set but not used [-Werror=unused-but-set-variable]
       rtError ret = rtLoadFile("supportfiles/test.html", buffer);
               ^~~

pxCore/tests/pxScene2d/pxscene2dtestsmain.cpp:50:7: error: variable ‘urlIndex’ set but not used [-Werror=unused-but-set-variable]
   int urlIndex  = -1;
       ^~~~~~~~

unused-variable errors:
-----------------------

pxCore/tests/pxScene2d/test_pxUtil.cpp: In member function ‘void pxUtilTest::pxLoadImage3ArgsPngSuccessTest()’:
pxCore/tests/pxScene2d/test_pxUtil.cpp:116:15: warning: unused variable ‘loadImageSuccess’ [-Wunused-variable]
       rtError loadImageSuccess = rtLoadFile("supportfiles/status_bg.png", d);
               ^~~~~~~~~~~~~~~~
pxCore/tests/pxScene2d/test_pxUtil.cpp: In member function ‘void pxUtilTest::pxLoadPNGImage3ArgsCreateReadStructFailTest()’:
pxCore/tests/pxScene2d/test_pxUtil.cpp:233:15: warning: unused variable ‘loadImageSuccess’ [-Wunused-variable]
       rtError loadImageSuccess = rtLoadFile("supportfiles/status_bg.png", d);
               ^~~~~~~~~~~~~~~~
pxCore/tests/pxScene2d/test_pxUtil.cpp: In member function ‘void pxUtilTest::pxLoadAPngSuccessTest()’:
pxCore/tests/pxScene2d/test_pxUtil.cpp:277:17: warning: unused variable ‘loadImageSuccess’ [-Wunused-variable]
         rtError loadImageSuccess = rtLoadFile("supportfiles/apngimage.png", d);
                 ^~~~~~~~~~~~~~~~