### PR TITLE
fix delete-non-virtual-dtor compilation errors

### DIFF
--- a/src/rtScriptDuk/rtScriptDuk.cpp
+++ b/src/rtScriptDuk/rtScriptDuk.cpp
@@ -142,7 +142,7 @@ public:
   rtDukContext(rtDukContextRef clone_me);
 #endif
 
-  ~rtDukContext();
+  virtual ~rtDukContext();
 
   rtError add(const char *name, rtValue  const& val);
   rtValue get(const char *name);

--- a/src/rtScriptNode/rtScriptNode.cpp
+++ b/src/rtScriptNode/rtScriptNode.cpp
@@ -175,7 +175,7 @@ class rtScriptNode: public rtIScript
 public:
   rtScriptNode();
   rtScriptNode(bool initialize);
-  ~rtScriptNode();
+  virtual ~rtScriptNode();
 
   unsigned long AddRef()
   {


### PR DESCRIPTION
pxCore/src/rtScriptDuk/rtScriptDuk.cpp: In member function ‘virtual long unsigned int rtDukContext::Release()’:
pxCore/src/rtScriptDuk/rtScriptDuk.cpp:1359:13: error: deleting object of polymorphic class type ‘rtDukContext’ which has non-virtual destructor might cause undefined behavior [-Werror=delete-non-virtual-dtor]
      delete this;
             ^~~~
pxCore/src/rtScriptNode/rtScriptNode.cpp: In member function ‘virtual long unsigned int rtScriptNode::Release()’:
pxCore/src/rtScriptNode/rtScriptNode.cpp:961:13: error: deleting object of polymorphic class type ‘rtScriptNode’ which has non-virtual destructor might cause undefined behavior [-Werror=delete-non-virtual-dtor]
      delete this;
             ^~~~