### PR TITLE
Exposes git version info to the pxscene runtime

### DIFF
--- a/examples/pxScene2d/src/CMakeLists.txt
+++ b/examples/pxScene2d/src/CMakeLists.txt
@@ -287,6 +287,21 @@ else ()
     add_definitions(-DPX_SCENE_VERSION=${PXSCENE_VERSION})
 endif("${PXSCENE_VERSION}" STREQUAL "")
 
+execute_process(
+  COMMAND git describe --tags --always --long --dirty
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  RESULT_VARIABLE GIT_DESCRIBE_RES
+  OUTPUT_VARIABLE GIT_PXSCENE_VERSION
+  ERROR_QUIET
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(GIT_DESCRIBE_RES EQUAL 0)
+  message("Settings pxscene version to: ${GIT_PXSCENE_VERSION}")
+  add_definitions("-DGIT_PXSCENE_VERSION=${GIT_PXSCENE_VERSION}")
+endif()
+
+
 set(TARGETINCLUDE "")
 set(PXSCENE_LINK_DIRECTORIES ${PXSCENE_LINK_DIRECTORIES} ${EXTDIR}/breakpad/src/client/linux)
 

--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -1738,6 +1738,19 @@ rtDefineObject(pxRoot,pxObject);
 
 int gTag = 0;
 
+static std::vector<std::string> split(const std::string& input, char delimiter)
+{
+  std::string::size_type b = 0;
+  std::vector<std::string> result;
+
+  while ((b = input.find_first_not_of(delimiter, b)) != std::string::npos) {
+      auto e = input.find_first_of(delimiter, b);
+      result.push_back(input.substr(b, e-b));
+      b = e;
+  }
+  return result;
+}
+
 pxScene2d::pxScene2d(bool top, pxScriptView* scriptView)
   : start(0), sigma_draw(0), sigma_update(0), end2(0), frameCount(0), mWidth(0), mHeight(0), mStopPropagation(false), mContainer(NULL), mShowDirtyRectangle(false),
     mInnerpxObjects(),

--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -1803,11 +1803,57 @@ pxScene2d::pxScene2d(bool top, pxScriptView* scriptView)
 #ifdef ENABLE_RT_NODE
   mInfo.set("engine", script.engine());
 #endif
-  
-    rtObjectRef build = new rtMapObject;
-    build.set("date", xstr(__DATE__));
-    build.set("time", xstr(__TIME__));
-  
+
+  rtObjectRef build = new rtMapObject;
+  build.set("date", xstr(__DATE__));
+  build.set("time", xstr(__TIME__));
+
+  std::string pxsceneVersion;
+
+#ifdef GIT_PXSCENE_VERSION
+  pxsceneVersion = xstr(GIT_PXSCENE_VERSION);
+#else
+  pxsceneVersion = "0.0.0.0-0-0000000000-dirty";
+#endif
+
+  auto macroChunks = split(pxsceneVersion, '-');
+  auto versionChunks = split(macroChunks[0], '.');
+
+  rtValue pxTag   (macroChunks[0].c_str());
+  rtValue pxOffset(macroChunks[1].c_str());
+  rtValue pxHash  (macroChunks[2].c_str());
+  rtValue pxDirty;
+
+  if(versionChunks.size() == 4)
+  {
+    rtValue pxMajor(versionChunks[0].c_str());
+    rtValue pxMinor(versionChunks[1].c_str());
+    rtValue pxMicro(versionChunks[2].c_str());
+    rtValue pxNano( versionChunks[3].c_str());
+
+    build.set("major", pxMajor);
+    build.set("minor", pxMinor);
+    build.set("micro", pxMicro);
+    build.set("nano",  pxNano);
+  }
+  else
+  {
+    build.set("major", "0");
+    build.set("minor", "0");
+    build.set("micro", "0");
+    build.set("nano" , "0");
+  }
+
+  if(macroChunks.size() > 3)
+    pxDirty = rtValue(macroChunks[3] == "dirty");
+  else
+    pxDirty = false;
+
+  build.set("tag",    pxTag);
+  build.set("offset", pxOffset);
+  build.set("hash",   pxHash);
+  build.set("dirty",  pxDirty);
+
   mInfo.set("build", build);
   mInfo.set("gfxmemory", context.currentTextureMemoryUsageInBytes());
 }


### PR DESCRIPTION
The exposed information is derived from `git describe --tag --always
--long --dirty`, which will expose information in the form of:
`tag-offset-hash(-dirty)?`.  This is broken then loaded into the
scene.info.build variable as:
  - major
  - minor
  - micro
  - nano
  - tag
  - offset
  - hash
  - dirty

The major / minor / micro / nano are formed from the four period
separated values in the tag, or zeros if it can't be parsed.

In the case that the GIT_PXSCENE_VERSION variable isn't provided, it
will default to `0.0.0.0-0-0000000000-dirty`.

This will help developers to determine the environment that their
application has run against down to the commit.