### PR TITLE
ThreaddSanitizer: fix data race pxWayland(mWaitingForRemoteObject)

### DIFF
--- a/examples/pxScene2d/src/pxWayland.cpp
+++ b/examples/pxScene2d/src/pxWayland.cpp
@@ -655,9 +655,7 @@ rtError pxWayland::startRemoteObjectLocator()
     rtLogError("pxWayland failed to initialize rtRemoteInit: %d", errorCode);
     if( mUseDispatchThread )
     {
-      mRemoteObjectMutex.lock();
       mWaitingForRemoteObject = false;
-      mRemoteObjectMutex.unlock();
     }
     return errorCode;
   }
@@ -709,9 +707,7 @@ rtError pxWayland::connectToRemoteObject()
         mEvents->isRemoteReady(false);
   }
 
-  mRemoteObjectMutex.lock();
   mWaitingForRemoteObject = false;
-  mRemoteObjectMutex.unlock();
 #endif //ENABLE_PX_WAYLAND_RPC
   return errorCode;
 }

--- a/examples/pxScene2d/src/pxWayland.h
+++ b/examples/pxScene2d/src/pxWayland.h
@@ -21,6 +21,7 @@
 #ifndef PX_WAYLAND_H
 #define PX_WAYLAND_H
 
+#include <atomic>
 #include <pthread.h>
 #include "pxIView.h"
 #include "pxScene2d.h"
@@ -164,7 +165,7 @@ private:
   pxIViewContainer *mContainer;
   bool mReadyEmitted;
   bool mClientMonitorStarted;
-  bool mWaitingForRemoteObject;
+  std::atomic<bool> mWaitingForRemoteObject;
   bool mUseDispatchThread;
   int mX;
   int mY;


### PR DESCRIPTION
Fixes the following data race:

WARNING: ThreadSanitizer: data race (pid=10382)
  Write of size 1 at 0x7b44001817aa by thread T31 (mutexes: write M68656):
    #0 pxWayland::connectToRemoteObject() pxCore/examples/pxScene2d/src/pxWayland.cpp:713 (pxscene+0x00000058ea65)
    #1 pxWayland::findRemoteThread(void*) pxCore/examples/pxScene2d/src/pxWayland.cpp:643 (pxscene+0x00000058e625)
    #2 <null> <null> (libtsan.so.0+0x0000000257eb)

  Previous write of size 1 at 0x7b44001817aa by main thread (mutexes: write M357):
    #0 pxWayland::terminateClient() pxCore/examples/pxScene2d/src/pxWayland.cpp:579 (pxscene+0x00000058e2c4)
    #1 pxWayland::~pxWayland() pxCore/examples/pxScene2d/src/pxWayland.cpp:94 (pxscene+0x00000058bd42)
    #2 pxWayland::~pxWayland() pxCore/examples/pxScene2d/src/pxWayland.cpp:96 (pxscene+0x00000058bdef)
    #3 pxWayland::Release() pxCore/examples/pxScene2d/src/pxWayland.h:66 (pxscene+0x00000058f8d7)
    #4 rtRef<pxIView>::asn(pxIView const*) pxCore/examples/pxScene2d/src/../../../src/rtRef.h:74 (pxscene+0x000000567ed3)
    #5 rtRef<pxIView>::operator=(pxIView const*) pxCore/examples/pxScene2d/src/../../../src/rtRef.h:58 (pxscene+0x000000564221)
    #6 pxViewContainer::setView(pxIView*) <null> (pxscene+0x000000559f65)
    #7 pxWaylandContainer::setView(pxWayland*) pxCore/examples/pxScene2d/src/pxWaylandContainer.cpp:295 (pxscene+0x000000592128)
    #8 pxWaylandContainer::dispose() pxCore/examples/pxScene2d/src/pxWaylandContainer.cpp:68 (pxscene+0x000000590605)
    #9 pxObject::dispose() pxCore/examples/pxScene2d/src/pxScene2d.cpp:529 (pxscene+0x00000053beb1)
    #10 pxScene2d::dispose() pxCore/examples/pxScene2d/src/pxScene2d.cpp:1832 (pxscene+0x000000541d21)
    #11 pxScene2d::dispose_thunk(int, rtValue const*, rtValue&) <null> (pxscene+0x00000055ff69)
    #12 rtObjectFunction::Send(int, rtValue const*, rtValue*) pxCore/src/rtObject.cpp:581 (pxscene+0x00000060e36e)
    #13 rtObjectBase::Send(char const*, int, rtValue const*) pxCore/src/rtObject.cpp:444 (pxscene+0x00000060cc80)
    #14 rtObjectBase::send(char const*) pxCore/src/rtObject.cpp:460 (pxscene+0x00000060cdf0)
    #15 pxScriptView::~pxScriptView() <null> (pxscene+0x00000055befe)
    #16 pxScriptView::~pxScriptView() <null> (pxscene+0x00000055c015)
    #17 pxScriptView::Release() <null> (pxscene+0x00000055c0ea)
    #18 rtRef<pxIView>::asn(pxIView const*) pxCore/examples/pxScene2d/src/../../../src/rtRef.h:74 (pxscene+0x000000567ed3)
    #19 rtRef<pxIView>::operator=(pxIView const*) pxCore/examples/pxScene2d/src/../../../src/rtRef.h:58 (pxscene+0x000000564221)
    #20 pxViewContainer::setView(pxIView*) <null> (pxscene+0x000000559f65)
    #21 pxSceneContainer::setScriptView(pxScriptView*) pxCore/examples/pxScene2d/src/pxScene2d.cpp:3374 (pxscene+0x00000054b2ff)
    #22 pxSceneContainer::dispose() pxCore/examples/pxScene2d/src/pxScene2d.cpp:3405 (pxscene+0x00000054b4d8)
    #23 pxObject::releaseResources() pxCore/examples/pxScene2d/src/pxScene2d.h:700 (pxscene+0x000000557e12)
    #24 pxObject::releaseResources_thunk(int, rtValue const*, rtValue&) pxCore/examples/pxScene2d/src/pxScene2d.h:207 (pxscene+0x000000552dfb)
    #25 rtObjectFunction::Send(int, rtValue const*, rtValue*) pxCore/src/rtObject.cpp:581 (pxscene+0x00000060e36e)
    #26 rtObjectBase::Send(char const*, int, rtValue const*) pxCore/src/rtObject.cpp:444 (pxscene+0x00000060cc80)
    #27 rtObjectBase::send(char const*) pxCore/src/rtObject.cpp:460 (pxscene+0x00000060cdf0)
    #28 WeakCallback pxCore/src/rtScriptNode/rtWrapperUtils.cpp:91 (pxscene+0x0000005db766)
    #29 v8::internal::GlobalHandles::PendingPhantomCallback::Invoke(v8::internal::Isolate*) ../deps/v8/src/global-handles.cc:1072 (libnode.so.48+0x00000083af5e)
    #30 rtScriptNodeUtils::rtFunctionWrapper::call(v8::FunctionCallbackInfo<v8::Value> const&) pxCore/src/rtScriptNode/rtFunctionWrapper.cpp:261 (pxscene+0x0000005d0b74)
    #31 v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&)) ../deps/v8/src/api-arguments.cc:16 (libnode.so.48+0x0000005844f2)
    #32 rtScript::pump() pxCore/src/rtScript.cpp:221 (pxscene+0x0000005bc24c)
    #33 sceneWindow::onAnimationTimer() pxCore/examples/pxScene2d/src/pxScene.cpp:373 (pxscene+0x000000599b87)
    #34 pxWindowNative::onAnimationTimerInternal() pxCore/src/wayland_egl/pxWindowNative.cpp:488 (pxscene+0x0000005a199a)
    #35 pxWindowNative::animateAndRender() pxCore/src/wayland_egl/pxWindowNative.cpp:853 (pxscene+0x0000005a2c70)
    #36 pxWindowNative::runEventLoop() pxCore/src/wayland_egl/pxWindowNative.cpp:595 (pxscene+0x0000005a1f66)
    #37 pxEventLoop::run() pxCore/src/wayland_egl/pxEventLoopNative.cpp:19 (pxscene+0x0000005a613d)
    #38 pxMain(int, char**) pxCore/examples/pxScene2d/src/pxScene.cpp:623 (pxscene+0x00000059860c)
    #39 main pxCore/src/wayland_egl/pxEventLoopNative.cpp:34 (pxscene+0x0000005a61cb)

  Location is heap block of size 320 at 0x7b4400181780 allocated by main thread:
    #0 operator new(unsigned long) <null> (libtsan.so.0+0x00000006f766)
    #1 pxScene2d::createWayland(rtObjectRef, rtObjectRef&) pxCore/examples/pxScene2d/src/pxScene2d.cpp:2142 (pxscene+0x000000543fa9)
    #2 pxScene2d::create(rtObjectRef, rtObjectRef&) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1919 (pxscene+0x000000542614)
    #3 pxScene2d::create_thunk(int, rtValue const*, rtValue&) <null> (pxscene+0x00000055d9d8)
    #4 rtObjectFunction::Send(int, rtValue const*, rtValue*) pxCore/src/rtObject.cpp:581 (pxscene+0x00000060e36e)
    #5 rtScriptNodeUtils::rtFunctionWrapper::call(v8::FunctionCallbackInfo<v8::Value> const&) pxCore/src/rtScriptNode/rtFunctionWrapper.cpp:226 (pxscene+0x0000005d0665)
    #6 v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&)) ../deps/v8/src/api-arguments.cc:16 (libnode.so.48+0x0000005844f2)
    #7 uv__queue_done <null> (pxscene+0x00000067b1da)
    #8 rtScript::pump() pxCore/src/rtScript.cpp:221 (pxscene+0x0000005bc24c)
    #9 sceneWindow::onAnimationTimer() pxCore/examples/pxScene2d/src/pxScene.cpp:373 (pxscene+0x000000599b87)
    #10 pxWindowNative::onAnimationTimerInternal() pxCore/src/wayland_egl/pxWindowNative.cpp:488 (pxscene+0x0000005a199a)
    #11 pxWindowNative::animateAndRender() pxCore/src/wayland_egl/pxWindowNative.cpp:853 (pxscene+0x0000005a2c70)
    #12 pxWindowNative::runEventLoop() pxCore/src/wayland_egl/pxWindowNative.cpp:595 (pxscene+0x0000005a1f66)
    #13 pxEventLoop::run() pxCore/src/wayland_egl/pxEventLoopNative.cpp:19 (pxscene+0x0000005a613d)
    #14 pxMain(int, char**) pxCore/examples/pxScene2d/src/pxScene.cpp:623 (pxscene+0x00000059860c)
    #15 main pxCore/src/wayland_egl/pxEventLoopNative.cpp:34 (pxscene+0x0000005a61cb)

  Mutex M68656 (0x7b4400181898) created at:
    #0 pthread_mutex_init <null> (libtsan.so.0+0x00000002971e)
    #1 rtMutexNative::rtMutexNative() pxCore/src/unix/rtMutexNative.cpp:6 (pxscene+0x000000599c10)
    #2 rtMutex::rtMutex() pxCore/src/unix/../rtMutex.h:30 (pxscene+0x0000004e6fea)
    #3 pxWayland::pxWayland(bool) pxCore/examples/pxScene2d/src/pxWayland.cpp:73 (pxscene+0x00000058baed)
    #4 pxScene2d::createWayland(rtObjectRef, rtObjectRef&) pxCore/examples/pxScene2d/src/pxScene2d.cpp:2142 (pxscene+0x000000543fb9)
    #5 pxScene2d::create(rtObjectRef, rtObjectRef&) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1919 (pxscene+0x000000542614)
    #6 pxScene2d::create_thunk(int, rtValue const*, rtValue&) <null> (pxscene+0x00000055d9d8)
    #7 rtObjectFunction::Send(int, rtValue const*, rtValue*) pxCore/src/rtObject.cpp:581 (pxscene+0x00000060e36e)
    #8 rtScriptNodeUtils::rtFunctionWrapper::call(v8::FunctionCallbackInfo<v8::Value> const&) pxCore/src/rtScriptNode/rtFunctionWrapper.cpp:226 (pxscene+0x0000005d0665)
    #9 v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&)) ../deps/v8/src/api-arguments.cc:16 (libnode.so.48+0x0000005844f2)
    #10 uv__queue_done <null> (pxscene+0x00000067b1da)
    #11 rtScript::pump() pxCore/src/rtScript.cpp:221 (pxscene+0x0000005bc24c)
    #12 sceneWindow::onAnimationTimer() pxCore/examples/pxScene2d/src/pxScene.cpp:373 (pxscene+0x000000599b87)
    #13 pxWindowNative::onAnimationTimerInternal() pxCore/src/wayland_egl/pxWindowNative.cpp:488 (pxscene+0x0000005a199a)
    #14 pxWindowNative::animateAndRender() pxCore/src/wayland_egl/pxWindowNative.cpp:853 (pxscene+0x0000005a2c70)
    #15 pxWindowNative::runEventLoop() pxCore/src/wayland_egl/pxWindowNative.cpp:595 (pxscene+0x0000005a1f66)
    #16 pxEventLoop::run() pxCore/src/wayland_egl/pxEventLoopNative.cpp:19 (pxscene+0x0000005a613d)
    #17 pxMain(int, char**) pxCore/examples/pxScene2d/src/pxScene.cpp:623 (pxscene+0x00000059860c)
    #18 main pxCore/src/wayland_egl/pxEventLoopNative.cpp:34 (pxscene+0x0000005a61cb)

  Mutex M357 (0x7b1400000550) created at:
    #0 pthread_mutex_init <null> (libtsan.so.0+0x00000002971e)
    #1 v8::internal::ThreadManager::ThreadManager() ../deps/v8/src/v8threads.cc:245 (libnode.so.48+0x000000b3fa1e)
    #2 rtScriptNode::init() pxCore/src/rtScriptNode/rtScriptNode.cpp:1025 (pxscene+0x0000005c9a49)
    #3 rtScript::init() pxCore/src/rtScript.cpp:203 (pxscene+0x0000005bc118)
    #4 pxMain(int, char**) pxCore/examples/pxScene2d/src/pxScene.cpp:526 (pxscene+0x000000598491)
    #5 main pxCore/src/wayland_egl/pxEventLoopNative.cpp:34 (pxscene+0x0000005a61cb)

  Thread T31 (tid=11324, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x000000028e03)
    #1 pxWayland::startRemoteObjectDetection() pxCore/examples/pxScene2d/src/pxWayland.cpp:628 (pxscene+0x00000058e597)
    #2 pxWayland::createDisplay(rtString) pxCore/examples/pxScene2d/src/pxWayland.cpp:197 (pxscene+0x00000058c514)
    #3 pxWayland::onInit() pxCore/examples/pxScene2d/src/pxWayland.cpp:107 (pxscene+0x00000058bf09)
    #4 pxWaylandContainer::onInit() pxCore/examples/pxScene2d/src/pxWaylandContainer.cpp:376 (pxscene+0x000000592763)
    #5 rtObject::init() pxCore/src/rtObject.cpp:321 (pxscene+0x00000060c4cf)
    #6 rtObject::init_thunk(int, rtValue const*, rtValue&) pxCore/src/rtObject.h:292 (pxscene+0x00000060ed31)
    #7 rtObjectFunction::Send(int, rtValue const*, rtValue*) pxCore/src/rtObject.cpp:581 (pxscene+0x00000060e36e)
    #8 rtObjectBase::Send(char const*, int, rtValue const*) pxCore/src/rtObject.cpp:444 (pxscene+0x00000060cc80)
    #9 rtObjectBase::send(char const*) pxCore/src/rtObject.cpp:460 (pxscene+0x00000060cdf0)
    #10 pxScene2d::createWayland(rtObjectRef, rtObjectRef&) pxCore/examples/pxScene2d/src/pxScene2d.cpp:2145 (pxscene+0x00000054402f)
    #11 pxScene2d::create(rtObjectRef, rtObjectRef&) pxCore/examples/pxScene2d/src/pxScene2d.cpp:1919 (pxscene+0x000000542614)
    #12 pxScene2d::create_thunk(int, rtValue const*, rtValue&) <null> (pxscene+0x00000055d9d8)
    #13 rtObjectFunction::Send(int, rtValue const*, rtValue*) pxCore/src/rtObject.cpp:581 (pxscene+0x00000060e36e)
    #14 rtScriptNodeUtils::rtFunctionWrapper::call(v8::FunctionCallbackInfo<v8::Value> const&) pxCore/src/rtScriptNode/rtFunctionWrapper.cpp:226 (pxscene+0x0000005d0665)
    #15 v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&)) ../deps/v8/src/api-arguments.cc:16 (libnode.so.48+0x0000005844f2)
    #16 uv__queue_done <null> (pxscene+0x00000067b1da)
    #17 rtScript::pump() pxCore/src/rtScript.cpp:221 (pxscene+0x0000005bc24c)
    #18 sceneWindow::onAnimationTimer() pxCore/examples/pxScene2d/src/pxScene.cpp:373 (pxscene+0x000000599b87)
    #19 pxWindowNative::onAnimationTimerInternal() pxCore/src/wayland_egl/pxWindowNative.cpp:488 (pxscene+0x0000005a199a)
    #20 pxWindowNative::animateAndRender() pxCore/src/wayland_egl/pxWindowNative.cpp:853 (pxscene+0x0000005a2c70)
    #21 pxWindowNative::runEventLoop() pxCore/src/wayland_egl/pxWindowNative.cpp:595 (pxscene+0x0000005a1f66)
    #22 pxEventLoop::run() pxCore/src/wayland_egl/pxEventLoopNative.cpp:19 (pxscene+0x0000005a613d)
    #23 pxMain(int, char**) pxCore/examples/pxScene2d/src/pxScene.cpp:623 (pxscene+0x00000059860c)
    #24 main pxCore/src/wayland_egl/pxEventLoopNative.cpp:34 (pxscene+0x0000005a61cb)

SUMMARY: ThreadSanitizer: data race pxCore/examples/pxScene2d/src/pxWayland.cpp:713 in pxWayland::connectToRemoteObject()