### PR TITLE
fix parentheses compilation warning

### DIFF
--- a/tests/pxScene2d/test_rtnode.cpp
+++ b/tests/pxScene2d/test_rtnode.cpp
@@ -189,8 +189,7 @@ TEST(pxScene2dTests, rtNodeTests)
     // printf("\n createContext() - With-Clone = %f ms\n\n", t2 );
 
     // Clone create (t2) should be significantly (4 x)  faster than Reference create.
-    EXPECT_TRUE( t2 < (t1 / 4) == true);
+    EXPECT_TRUE((t2 < (t1 / 4)) == true);
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 }
-


### PR DESCRIPTION
Fixes the following warning:

pxCore/tests/pxScene2d/test_rtnode.cpp: In member function ‘virtual void pxScene2dTests_rtNodeTests_Test::TestBody()’:
pxCore/tests/pxScene2d/test_rtnode.cpp:192:21: warning: suggest parentheses around comparison in operand of ‘==’ [-Wparentheses]
     EXPECT_TRUE( t2 < (t1 / 4) == true);
                  ~~~^~~~~~~~~~
pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/include/gtest/internal/gtest-internal.h:1189:34: note: in definition of macro ‘GTEST_TEST_BOOLEAN_’
       ::testing::AssertionResult(expression)) \
                                  ^~~~~~~~~~
pxCore/tests/pxScene2d/test_rtnode.cpp:192:5: note: in expansion of macro ‘EXPECT_TRUE’
     EXPECT_TRUE( t2 < (t1 / 4) == true);
     ^~~~~~~~~~~