### PR TITLE
fix -Werror compilation errors

### DIFF
--- a/tests/pxScene2d/test_jsfiles.cpp
+++ b/tests/pxScene2d/test_jsfiles.cpp
@@ -1,4 +1,6 @@
+#ifndef ENABLE_RT_NODE
 #define ENABLE_RT_NODE
+#endif
 
 #include <sstream>
 
@@ -42,7 +44,7 @@ class sceneWindow : public pxWindow, public pxIViewContainer
       mHeight = h;
       pxWindow::init(x,y,w,h);
     }
-  
+
     virtual void invalidateRect(pxRect* r)
     {
       pxWindow::invalidateRect(r);
@@ -52,9 +54,9 @@ class sceneWindow : public pxWindow, public pxIViewContainer
     {
       return NULL;
     }
-    
+
     rtError setView(pxIView* v)
-    { 
+    {
       mView = v;
       if (v)
       {
@@ -63,14 +65,14 @@ class sceneWindow : public pxWindow, public pxIViewContainer
       }
       return RT_OK;
     }
-    
+
     virtual void onAnimationTimer()
     {
       if (mView)
         mView->onUpdate(pxSeconds());
       script.pump();
     }
-    
+
   private:
     pxIView* mView;
     int mWidth;


### PR DESCRIPTION
Fixes the following error:

pxCore/tests/pxScene2d/test_jsfiles.cpp:1:0: error: "ENABLE_RT_NODE" redefined [-Werror]
 #define ENABLE_RT_NODE

<command-line>:0:0: note: this is the location of the previous definition