### PR TITLE
AddressSanitizer: fix alloc-dealloc-mismatch (operator new [] vs oper…

### DIFF
--- a/tests/pxScene2d/test_pxcontext.cpp
+++ b/tests/pxScene2d/test_pxcontext.cpp
@@ -45,27 +45,27 @@ class sceneWindow : public pxWindow, public pxIViewContainer
       UNUSED_PARAM(url);
       pxWindow::init(x,y,w,h);
     }
-  
+
     virtual void invalidateRect(pxRect* r)
     {
       UNUSED_PARAM(r);
     }
-    
+
     virtual void* RT_STDCALL getInterface(const char* /*t*/)
     {
       return NULL;
     }
-    
+
     rtError setView(pxIView* v)
-    { 
+    {
       UNUSED_PARAM(v);
       return RT_OK;
     }
-    
+
     virtual void onAnimationTimer()
     {
     }
-    
+
 };
 
 class pxContextTest : public testing::Test
@@ -176,7 +176,7 @@ class pxContextTest : public testing::Test
       char *buffer = new char[100*100];
       pxTextureRef alphaTexture = mContext.createTexture(100,100,100,100,buffer);
       EXPECT_TRUE (mContext.textureMemoryOverflow(alphaTexture) == 0);
-      delete buffer;
+      delete[] buffer;
     }
 
     void textureMemoryOverflowFalseTest()
@@ -187,7 +187,7 @@ class pxContextTest : public testing::Test
       pxTextureRef alphaTexture = mContext.createTexture(100,100,100,100,buffer);
       EXPECT_TRUE (mContext.textureMemoryOverflow(alphaTexture) > 0);
       mContext.setTextureMemoryLimit(oldLimit);
-      delete buffer;
+      delete[] buffer;
     }
 
     void adjustCurrentTextureMemorySizeTest()
@@ -370,23 +370,23 @@ class pxFBOTextureTest : public testing::Test
       EXPECT_TRUE(mFramebuffer->getTexture()->width() == 1280);
       EXPECT_TRUE(mFramebuffer->getTexture()->height() == 720);
     }
-    
+
     void getNativeIdTest()
     {
       EXPECT_TRUE (PX_OK == mContext.updateFramebuffer(mFramebuffer,1280,720));
       EXPECT_TRUE(mFramebuffer->getTexture()->getNativeId() != 0);
     }
-    
+
     void bindGLTextureTest()
     {
-      EXPECT_TRUE(mFramebuffer->getTexture()->bindGLTexture(0) == PX_OK);    
+      EXPECT_TRUE(mFramebuffer->getTexture()->bindGLTexture(0) == PX_OK);
     }
-    
+
     void bindGLTextureAsMaskSuccessTest()
     {
       EXPECT_TRUE(mFramebuffer->getTexture()->bindGLTextureAsMask(0) == PX_OK);
     }
-    
+
     private:
       pxContext mContext;
       pxContextFramebufferRef mFramebuffer;
@@ -470,4 +470,3 @@ TEST_F(pxAlphaTextureTest, pxAlphaTextureTests)
   bindGLTextureAsMaskUninitTest();
   bindGLTextureAsMaskTest();
 }
-


### PR DESCRIPTION
…ator delete)

==14719==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete) on 0x626000021100
    #0 0x7f45904e5fd0 in operator delete(void*) (/lib64/libasan.so.4+0xe0fd0)
    #1 0x4e1b95 in pxContextTest::textureMemoryOverflowTrueTest() pxCore/tests/pxScene2d/test_pxcontext.cpp:179
    #2 0x4e1b95 in pxContextTest_pxContextTests_Test::TestBody() pxCore/tests/pxScene2d/test_pxcontext.cpp:315
    #3 0x80ccbe in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #4 0x80ccbe in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #5 0x7d2bad in testing::Test::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2474
    #6 0x7d2d92 in testing::TestInfo::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2656
    #7 0x7d3266 in testing::TestCase::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2774
    #8 0x7d7c85 in testing::internal::UnitTestImpl::RunAllTests() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4649
    #9 0x7d82cf in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #10 0x7d82cf in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #11 0x7d82cf in testing::UnitTest::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4257
    #12 0x4b627a in RUN_ALL_TESTS() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/include/gtest/gtest.h:2233
    #13 0x4b627a in main pxCore/tests/pxScene2d/pxscene2dtestsmain.cpp:101
    #14 0x7f458a716009 in __libc_start_main (/lib64/libc.so.6+0x21009)
    #15 0x4c6df9 in _start (pxCore/tests/pxScene2d/pxscene2dtests+0x4c6df9)

0x626000021100 is located 0 bytes inside of 10000-byte region [0x626000021100,0x626000023810)
allocated by thread T0 here:
    #0 0x7f45904e5318 in operator new[](unsigned long) (/lib64/libasan.so.4+0xe0318)
    #1 0x4e182d in pxContextTest::textureMemoryOverflowTrueTest() pxCore/tests/pxScene2d/test_pxcontext.cpp:176
    #2 0x4e182d in pxContextTest_pxContextTests_Test::TestBody() pxCore/tests/pxScene2d/test_pxcontext.cpp:315
    #3 0x80ccbe in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #4 0x80ccbe in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #5 0x7d2bad in testing::Test::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2474
    #6 0x7d2d92 in testing::TestInfo::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2656
    #7 0x7d3266 in testing::TestCase::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2774
    #8 0x7d7c85 in testing::internal::UnitTestImpl::RunAllTests() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4649
    #9 0x7d82cf in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #10 0x7d82cf in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #11 0x7d82cf in testing::UnitTest::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4257
    #12 0x4b627a in RUN_ALL_TESTS() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/include/gtest/gtest.h:2233
    #13 0x4b627a in main pxCore/tests/pxScene2d/pxscene2dtestsmain.cpp:101
    #14 0x7f458a716009 in __libc_start_main (/lib64/libc.so.6+0x21009)

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch (/lib64/libasan.so.4+0xe0fd0) in operator delete(void*)