### PR TITLE
AddressSanitizer: fix heap-buffer-overflow (caused by base64_decode())

### DIFF
--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -337,16 +337,23 @@ unsigned char *base64_decode(const unsigned char *data,
                              size_t input_length,
                              size_t *output_length) {
 
-    if (decoding_table == NULL) build_decoding_table();
+    if (decoding_table == NULL)
+        build_decoding_table();
 
-    if (input_length % 4 != 0) return NULL;
+    if (output_length)
+        *output_length = input_length / 4 * 3;
 
-    *output_length = input_length / 4 * 3;
-    if (data[input_length - 1] == '=') (*output_length)--;
-    if (data[input_length - 2] == '=') (*output_length)--;
+    if ((input_length == 0) || (input_length % 4 != 0))
+        return NULL;
+
+    if (data[input_length - 1] == '=')
+        (*output_length)--;
+    if (data[input_length - 2] == '=')
+        (*output_length)--;
 
     unsigned char *decoded_data = (unsigned char*)malloc(*output_length);
-    if (decoded_data == NULL) return NULL;
+    if (decoded_data == NULL)
+        return NULL;
 
     for (uint32_t i = 0, j = 0; i < input_length;) {
 
@@ -513,7 +520,7 @@ void pxObject::dispose()
     {
       if ((*it).promise)
       {
-	if(!gApplicationIsClosing)	  
+	if(!gApplicationIsClosing)
           (*it).promise.send("reject",this);
 	else
 	  (*it).promise.send("reject",nullValue);
@@ -645,7 +652,7 @@ rtError pxObject::animateToObj(rtObjectRef props, double duration,
     }
   }
   if (NULL != animateObj.getPtr())
-    ((pxAnimate*)animateObj.getPtr())->setStatus(pxConstantsAnimation::STATUS_INPROGRESS);  
+    ((pxAnimate*)animateObj.getPtr())->setStatus(pxConstantsAnimation::STATUS_INPROGRESS);
   return RT_OK;
 }
 
@@ -735,14 +742,14 @@ rtError pxObject::moveToBack()
   parent->repaint();
   parent->repaintParents();
   mScene->mDirty = true;
-  
+
   return RT_OK;
 }
 
 /**
- * moveForward: Move this child in front of its next closest sibling in z-order, which means 
- *              moving it toward end of array because last item is at top of z-order 
- **/ 
+ * moveForward: Move this child in front of its next closest sibling in z-order, which means
+ *              moving it toward end of array because last item is at top of z-order
+ **/
 rtError pxObject::moveForward()
 {
   pxObject* parent = this->parent();
@@ -768,15 +775,15 @@ rtError pxObject::moveForward()
 
   parent->repaint();
   parent->repaintParents();
-  mScene->mDirty = true;  
+  mScene->mDirty = true;
 
   return RT_OK;
 }
 
 /**
- * moveBackward: Move this child behind its next closest sibling in z-order, which means 
- *               moving it toward beginning of array because first item is at bottom of z-order 
- **/ 
+ * moveBackward: Move this child behind its next closest sibling in z-order, which means
+ *               moving it toward beginning of array because first item is at bottom of z-order
+ **/
 rtError pxObject::moveBackward()
 {
   pxObject* parent = this->parent();
@@ -800,11 +807,11 @@ rtError pxObject::moveBackward()
 
   parent->repaint();
   parent->repaintParents();
-  mScene->mDirty = true; 
+  mScene->mDirty = true;
 
   return RT_OK;
 }
-  
+
 rtError pxObject::animateTo(const char* prop, double to, double duration,
                              uint32_t interp, uint32_t options,
                             int32_t count, rtObjectRef promise)
@@ -838,7 +845,7 @@ void pxObject::cancelAnimation(const char* prop, bool fastforward, bool rewind, 
     if (!a.cancelled && a.prop == prop)
     {
       pxAnimate* pAnimateObj = (pxAnimate*) a.animateObj.getPtr();
-      
+
       // Fastforward or rewind, if specified
       if( fastforward)
         set(prop, a.to);
@@ -854,7 +861,7 @@ void pxObject::cancelAnimation(const char* prop, bool fastforward, bool rewind, 
         if (a.promise)
         {
           a.promise.send(resolve ? "resolve" : "reject", this);
-          
+
           if (NULL != pAnimateObj)
           {
             pAnimateObj->setStatus(pxConstantsAnimation::STATUS_CANCELLED);
@@ -908,9 +915,9 @@ void pxObject::animateToInternal(const char* prop, double to, double duration,
   a.animateObj = animateObj;
 
   mAnimations.push_back(a);
-  
+
   pxAnimate *animObj = (pxAnimate *)a.animateObj.getPtr();
-  
+
   if (NULL != animObj)
   {
     animObj->update(prop, &a, pxConstantsAnimation::STATUS_INPROGRESS);
@@ -1207,7 +1214,7 @@ const float alphaEpsilon = (1.0f/255.0f);
 void pxObject::drawInternal(bool maskPass)
 {
   //rtLogInfo("pxObject::drawInternal mw=%f mh=%f\n", mw, mh);
-  
+
   if (!drawEnabled() && !maskPass)
   {
     return;
@@ -1363,7 +1370,7 @@ void pxObject::drawInternal(bool maskPass)
           continue;
         }
         context.pushState();
-        //rtLogInfo("calling drawInternal() mw=%f mh=%f\n", (*it)->mw, (*it)->mh);                
+        //rtLogInfo("calling drawInternal() mw=%f mh=%f\n", (*it)->mw, (*it)->mh);
         (*it)->drawInternal();
 #ifdef PX_DIRTY_RECTANGLES
         int left = (*it)->mScreenCoordinates.left();
@@ -1796,18 +1803,18 @@ pxScene2d::pxScene2d(bool top, pxScriptView* scriptView)
   mPointerHotSpotY= 16;
   mPointerResource= pxImageManager::getImage("cursor.png");
   #endif
-  
+
   mInfo = new rtMapObject;
   mInfo.set("version", xstr(PX_SCENE_VERSION));
 
 #ifdef ENABLE_RT_NODE
   mInfo.set("engine", script.engine());
 #endif
-  
+
     rtObjectRef build = new rtMapObject;
     build.set("date", xstr(__DATE__));
     build.set("time", xstr(__TIME__));
-  
+
   mInfo.set("build", build);
   mInfo.set("gfxmemory", context.currentTextureMemoryUsageInBytes());
 }
@@ -1925,7 +1932,7 @@ rtError pxScene2d::create(rtObjectRef p, rtObjectRef& o)
     return RT_FAIL;
   }
 
-  // Handle psuedo property here for children.  Probably should make this 
+  // Handle psuedo property here for children.  Probably should make this
   rtObjectRef c = p.get<rtObjectRef>("c");
   if (c)
   {
@@ -1997,7 +2004,7 @@ rtError pxScene2d::createPath(rtObjectRef p, rtObjectRef& o)
     mCanvas.set("y",0);
     mCanvas.set("w",mWidth);
     mCanvas.set("h",mHeight);
-    
+
     mCanvas.send("init");
   }
 
@@ -2071,7 +2078,7 @@ rtError pxScene2d::createScene(rtObjectRef p, rtObjectRef& o)
 
 rtError pxScene2d::logDebugMetrics()
 {
-#ifdef ENABLE_DEBUG_METRICS 
+#ifdef ENABLE_DEBUG_METRICS
     script.collectGarbage();
     rtLogInfo("pxobjectcount is [%d]",pxObjectCount);
 #ifdef PX_PLATFORM_MAC
@@ -3044,7 +3051,7 @@ rtError pxScene2d::getService(const char* name, const rtObjectRef& ctx, rtObject
     {
       rtValue result;
       rtError e;
-      
+
       reentered = this;
       e = (*i).sendReturns<rtValue>(name, ctx, result);
       reentered = NULL;
@@ -3102,7 +3109,7 @@ rtError pxScene2d::getService(const char* name, const rtObjectRef& ctx, rtObject
   }
   else
   {
-    // TODO JRJR should move this to top level container only... 
+    // TODO JRJR should move this to top level container only...
 
   #ifdef ENABLE_PERMISSIONS_CHECK
     if (!mPermissions.allows(name, rtPermissions::SERVICE))

--- a/tests/pxScene2d/test_screenshot.cpp
+++ b/tests/pxScene2d/test_screenshot.cpp
@@ -47,20 +47,23 @@ public:
 
   void test_base64_encode_decode()
   {
-    for (int i = 0; i<100; i++)
+    for (size_t i = 0; i<100; i++)
     {
       rtData pngData2;
       pngData2.init(i);
       size_t l;
       char* d = base64_encode(pngData2.data(), pngData2.length(), &l);
-      EXPECT_TRUE (i == 0 || (NULL != d && *d != 0));
-      if (NULL != d && *d != 0)
+      EXPECT_EQ (l, 4*((i+2)/3));
+      EXPECT_TRUE (l == 0 || NULL != d);
+
+      if (NULL != d)
       {
         size_t l2;
         unsigned char *d2 = base64_decode((const unsigned char *)d, l, &l2);
-        EXPECT_TRUE (NULL != d2);
+        EXPECT_TRUE (l < 4 || NULL != d2);
         if (d2)
         {
+          EXPECT_EQ (pngData2.length(), l2);
           int eq = memcmp(pngData2.data(), d2, pngData2.length());
           EXPECT_EQ (eq, 0);
           free(d2);


### PR DESCRIPTION
Fixes the followg memory overflow eror:

==14924==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000114f2f at pc 0x7f9a07e6aed2 bp 0x7fff38e88bb0 sp 0x7fff38e88ba0
READ of size 1 at 0x602000114f2f thread T0
    #0 0x7f9a07e6aed1 in base64_decode(unsigned char const*, unsigned long, unsigned long*) pxCore/examples/pxScene2d/src/pxScene2d.cpp:345
    #1 0x627b36 in screenshotTest::test_base64_encode_decode() pxCore/tests/pxScene2d/test_screenshot.cpp:60
    #2 0x627b36 in screenshotTest_screenshotTests_Test::TestBody() pxCore/tests/pxScene2d/test_screenshot.cpp:183
    #3 0x80ccbe in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #4 0x80ccbe in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #5 0x7d2bad in testing::Test::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2474
    #6 0x7d2d92 in testing::TestInfo::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2656
    #7 0x7d3266 in testing::TestCase::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2774
    #8 0x7d7c85 in testing::internal::UnitTestImpl::RunAllTests() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4649
    #9 0x7d82cf in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #10 0x7d82cf in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #11 0x7d82cf in testing::UnitTest::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4257
    #12 0x4b627a in RUN_ALL_TESTS() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/include/gtest/gtest.h:2233
    #13 0x4b627a in main pxCore/tests/pxScene2d/pxscene2dtestsmain.cpp:101
    #14 0x7f9a02ab4009 in __libc_start_main (/lib64/libc.so.6+0x21009)
    #15 0x4c6df9 in _start (pxCore/tests/pxScene2d/pxscene2dtests+0x4c6df9)

0x602000114f2f is located 1 bytes to the left of 1-byte region [0x602000114f30,0x602000114f31)
allocated by thread T0 here:
    #0 0x7f9a08881850 in malloc (/lib64/libasan.so.4+0xde850)
    #1 0x7f9a07e6a915 in base64_encode(unsigned char const*, unsigned long, unsigned long*) pxCore/examples/pxScene2d/src/pxScene2d.cpp:311
    #2 0x627809 in screenshotTest::test_base64_encode_decode() pxCore/tests/pxScene2d/test_screenshot.cpp:55
    #3 0x627809 in screenshotTest_screenshotTests_Test::TestBody() pxCore/tests/pxScene2d/test_screenshot.cpp:183
    #4 0x80ccbe in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #5 0x80ccbe in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #6 0x7d2bad in testing::Test::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2474
    #7 0x7d2d92 in testing::TestInfo::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2656
    #8 0x7d3266 in testing::TestCase::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2774
    #9 0x7d7c85 in testing::internal::UnitTestImpl::RunAllTests() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4649
    #10 0x7d82cf in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #11 0x7d82cf in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #12 0x7d82cf in testing::UnitTest::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4257
    #13 0x4b627a in RUN_ALL_TESTS() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/include/gtest/gtest.h:2233
    #14 0x4b627a in main pxCore/tests/pxScene2d/pxscene2dtestsmain.cpp:101
    #15 0x7f9a02ab4009 in __libc_start_main (/lib64/libc.so.6+0x21009)

SUMMARY: AddressSanitizer: heap-buffer-overflow pxCore/examples/pxScene2d/src/pxScene2d.cpp:345 in base64_decode(unsigned char const*, unsigned long, unsigned long*)
Shadow bytes around the buggy address:
  0x0c048001a990: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048001a9a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048001a9b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048001a9c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c048001a9d0: fa fa fa fa fa fa fd fd fa fa fa fa fa fa fa fa
=>0x0c048001a9e0: fa fa fa fa fa[fa]01 fa fa fa fd fd fa fa fa fa
  0x0c048001a9f0: fa fa 01 fa fa fa fd fd fa fa fd fd fa fa fd fd
  0x0c048001aa00: fa fa fd fa fa fa fd fd fa fa fd fd fa fa fd fd
  0x0c048001aa10: fa fa fd fa fa fa fd fa fa fa fd fa fa fa^[[0m fd fa
  0x0c048001aa20: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
  0x0c048001aa30: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==14924==ABORTING