### PR TITLE
AddressSanitizer: fix heap-use-after-free crash in disableCacheTest()

### DIFF
--- a/tests/pxScene2d/test_imagecache.cpp
+++ b/tests/pxScene2d/test_imagecache.cpp
@@ -885,12 +885,16 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
     void disableCacheTest()
     {
       rtFileCache::instance()->clearCache();
-      addDataToCache("http://fileserver/file_notfound.jpeg",getHeader(),getBodyData(),fixedData.length());
-      rtFileDownloadRequest* request = new rtFileDownloadRequest("http://fileserver/file_notfound.jpeg",this);
+      const char *url = "http://fileserver/file_notfound.jpeg";
+      rtFileDownloadRequest* request = new rtFileDownloadRequest(url,this);
       request->setCacheEnabled(false);
       request->setCallbackFunction(NULL);
       rtFileDownloader::instance()->downloadFile(request);
-      EXPECT_TRUE (request->isDataCached() == false);
+      // Once downloadFile() finished 'request' is deleted
+      // EXPECT_TRUE (request->isDataCached() == false);
+      rtHttpCacheData cachedData(url);
+      rtError ret = rtFileCache::instance()->httpCacheData(url, cachedData);
+      EXPECT_TRUE(ret == RT_ERROR);
     }
 
     void startFileDownloadInBackgroundTest()


### PR DESCRIPTION
Fixes the following heap-use-after-free crash:

==21739==ERROR: AddressSanitizer: heap-use-after-free on address 0x61400003c8f1 at pc 0x000000825f62 bp 0x7fffc21a8990 sp 0x7fffc21a8980
READ of size 1 at 0x61400003c8f1 thread T0
    #0 0x825f61 in rtFileDownloadRequest::isDataCached() /home/sw/projects/pxscene/pxCore/src/rtFileDownloader.cpp:366
    #1 0x665424 in rtFileDownloaderTest::disableCacheTest() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/test_imagecache.cpp:893
    #2 0x64dd3b in rtFileDownloaderTest_checkCacheTests_Test::TestBody() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/test_imagecache.cpp:1229
    #3 0x7ad278 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtests+0x7ad278)
    #4 0x7a0938 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #5 0x75d4cd in testing::Test::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2474
    #6 0x75e7b9 in testing::TestInfo::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2656
    #7 0x75f332 in testing::TestCase::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2774
    #8 0x76fed0 in testing::internal::UnitTestImpl::RunAllTests() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4649
    #9 0x7afcb7 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #10 0x7a2a97 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtests+0x7a2a97)
    #11 0x76d0d9 in testing::UnitTest::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4257
    #12 0x5299db in RUN_ALL_TESTS() (/home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtests+0x5299db)
    #13 0x5295c7 in main /home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtestsmain.cpp:101
    #14 0x7f1b7c57f009 in __libc_start_main (/lib64/libc.so.6+0x21009)
    #15 0x5293c9 in _start (/home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtests+0x5293c9)

0x61400003c8f1 is located 177 bytes inside of 448-byte region [0x61400003c840,0x61400003ca00)
freed by thread T0 here:
    #0 0x7f1b8234efd0 in operator delete(void*) (/lib64/libasan.so.4+0xe0fd0)
    #1 0x8272ca in rtFileDownloader::downloadFile(rtFileDownloadRequest*) /home/sw/projects/pxscene/pxCore/src/rtFileDownloader.cpp:630
    #2 0x665415 in rtFileDownloaderTest::disableCacheTest() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/test_imagecache.cpp:892
    #3 0x64dd3b in rtFileDownloaderTest_checkCacheTests_Test::TestBody() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/test_imagecache.cpp:1229
    #4 0x7ad278 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtests+0x7ad278)
    #5 0x7a0938 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #6 0x75d4cd in testing::Test::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2474
    #7 0x75e7b9 in testing::TestInfo::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2656
    #8 0x75f332 in testing::TestCase::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2774
    #9 0x76fed0 in testing::internal::UnitTestImpl::RunAllTests() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4649
    #10 0x7afcb7 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #11 0x7a2a97 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtests+0x7a2a97)
    #12 0x76d0d9 in testing::UnitTest::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4257
    #13 0x5299db in RUN_ALL_TESTS() (/home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtests+0x5299db)
    #14 0x5295c7 in main /home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtestsmain.cpp:101
    #15 0x7f1b7c57f009 in __libc_start_main (/lib64/libc.so.6+0x21009)

previously allocated by thread T0 here:
    #0 0x7f1b8234e158 in operator new(unsigned long) (/lib64/libasan.so.4+0xe0158)
    #1 0x6653b0 in rtFileDownloaderTest::disableCacheTest() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/test_imagecache.cpp:889
    #2 0x64dd3b in rtFileDownloaderTest_checkCacheTests_Test::TestBody() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/test_imagecache.cpp:1229
    #3 0x7ad278 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtests+0x7ad278)
    #4 0x7a0938 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #5 0x75d4cd in testing::Test::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2474
    #6 0x75e7b9 in testing::TestInfo::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2656
    #7 0x75f332 in testing::TestCase::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2774
    #8 0x76fed0 in testing::internal::UnitTestImpl::RunAllTests() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4649
    #9 0x7afcb7 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #10 0x7a2a97 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtests+0x7a2a97)
    #11 0x76d0d9 in testing::UnitTest::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4257
    #12 0x5299db in RUN_ALL_TESTS() (/home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtests+0x5299db)
    #13 0x5295c7 in main /home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtestsmain.cpp:101
    #14 0x7f1b7c57f009 in __libc_start_main (/lib64/libc.so.6+0x21009)

SUMMARY: AddressSanitizer: heap-use-after-free /home/sw/projects/pxscene/pxCore/src/rtFileDownloader.cpp:366 in rtFileDownloadRequest::isDataCached()
Shadow bytes around the buggy address:
  0x0c287ffff8c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c287ffff8d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c287ffff8e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c287ffff8f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c287ffff900: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
=>0x0c287ffff910: fd fd fd fd fd fd fd fd fd fd fd fd fd fd[fd]fd
  0x0c287ffff920: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c287ffff930: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c287ffff940: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c287ffff950: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c287ffff960: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==21739==ABORTING