### PR TITLE
AddressSanitizer: fix heap-use-after-free in setDefaultCallbackFuncti…

### DIFF
--- a/tests/pxScene2d/test_imagecache.cpp
+++ b/tests/pxScene2d/test_imagecache.cpp
@@ -970,15 +970,20 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
 
     void setDefaultCallbackFunctionNullTest()
     {
+      const char *url = "http://fileserver/file.jpeg";
       rtFileCache::instance()->clearCache();
-      addDataToCache("http://fileserver/file.jpeg",getHeader(),getBodyData(),fixedData.length());
+      addDataToCache(url,getHeader(),getBodyData(),fixedData.length());
       void (*callbackFunction)(rtFileDownloadRequest*);
       callbackFunction = rtFileDownloader::instance()->mDefaultCallbackFunction;
-      rtFileDownloadRequest* request = new rtFileDownloadRequest("http://fileserver/file.jpeg",this);
+      rtFileDownloadRequest* request = new rtFileDownloadRequest(url,this);
       request->setCallbackFunction(NULL);
       rtFileDownloader::instance()->setDefaultCallbackFunction(NULL);
       rtFileDownloader::instance()->downloadFile(request);
-      EXPECT_TRUE (true == request->isDataCached());
+      // Once downloadFile() finished 'request' is deleted
+      // EXPECT_TRUE (true == request->isDataCached());
+      rtHttpCacheData cachedData(url);
+      rtError ret = rtFileCache::instance()->httpCacheData(url, cachedData);
+      EXPECT_TRUE(ret == RT_OK);
       rtFileDownloader::instance()->setDefaultCallbackFunction(callbackFunction);
     }
 


### PR DESCRIPTION
…onNullTest()

Fixes the following heap-use-after-free crash:

==5418==ERROR: AddressSanitizer: heap-use-after-free on address 0x6140000794f1 at pc 0x000000825a0a bp 0x7fff539d2fb0 sp 0x7fff539d2fa0
READ of size 1 at 0x6140000794f1 thread T0
    #0 0x825a09 in rtFileDownloadRequest::isDataCached() pxCore/src/rtFileDownloader.cpp:366
    #1 0x6680e5 in rtFileDownloaderTest::setDefaultCallbackFunctionNullTest() pxCore/tests/pxScene2d/test_imagecache.cpp:985
    #2 0x64ddef in rtFileDownloaderTest_checkCacheTests_Test::TestBody() pxCore/tests/pxScene2d/test_imagecache.cpp:1250
    #3 0x7acd20 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (pxCore/tests/pxScene2d/pxscene2dtests+0x7acd20)
    #4 0x7a03e0 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #5 0x75cf75 in testing::Test::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2474
    #6 0x75e261 in testing::TestInfo::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2656
    #7 0x75edda in testing::TestCase::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2774
    #8 0x76f978 in testing::internal::UnitTestImpl::RunAllTests() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4649
    #9 0x7af75f in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #10 0x7a253f in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (pxCore/tests/pxScene2d/pxscene2dtests+0x7a253f)
    #11 0x76cb81 in testing::UnitTest::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4257
    #12 0x5299db in RUN_ALL_TESTS() (pxCore/tests/pxScene2d/pxscene2dtests+0x5299db)
    #13 0x5295c7 in main pxCore/tests/pxScene2d/pxscene2dtestsmain.cpp:101
    #14 0x7f7b361a7009 in __libc_start_main (/lib64/libc.so.6+0x21009)
    #15 0x5293c9 in _start (pxCore/tests/pxScene2d/pxscene2dtests+0x5293c9)

0x6140000794f1 is located 177 bytes inside of 448-byte region [0x614000079440,0x614000079600)
freed by thread T0 here:
    #0 0x7f7b3bf76fd0 in operator delete(void*) (/lib64/libasan.so.4+0xe0fd0)
    #1 0x826d72 in rtFileDownloader::downloadFile(rtFileDownloadRequest*) pxCore/src/rtFileDownloader.cpp:630
    #2 0x6680d6 in rtFileDownloaderTest::setDefaultCallbackFunctionNullTest() pxCore/tests/pxScene2d/test_imagecache.cpp:984
    #3 0x64ddef in rtFileDownloaderTest_checkCacheTests_Test::TestBody() pxCore/tests/pxScene2d/test_imagecache.cpp:1250
    #4 0x7acd20 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (pxCore/tests/pxScene2d/pxscene2dtests+0x7acd20)
    #5 0x7a03e0 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #6 0x75cf75 in testing::Test::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2474
    #7 0x75e261 in testing::TestInfo::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2656
    #8 0x75edda in testing::TestCase::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2774
    #9 0x76f978 in testing::internal::UnitTestImpl::RunAllTests() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4649
    #10 0x7af75f in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #11 0x7a253f in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (pxCore/tests/pxScene2d/pxscene2dtests+0x7a253f)
    #12 0x76cb81 in testing::UnitTest::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4257
    #13 0x5299db in RUN_ALL_TESTS() (pxCore/tests/pxScene2d/pxscene2dtests+0x5299db)
    #14 0x5295c7 in main pxCore/tests/pxScene2d/pxscene2dtestsmain.cpp:101
    #15 0x7f7b361a7009 in __libc_start_main (/lib64/libc.so.6+0x21009)

previously allocated by thread T0 here:
    #0 0x7f7b3bf76158 in operator new(unsigned long) (/lib64/libasan.so.4+0xe0158)
    #1 0x668073 in rtFileDownloaderTest::setDefaultCallbackFunctionNullTest() pxCore/tests/pxScene2d/test_imagecache.cpp:981
    #2 0x64ddef in rtFileDownloaderTest_checkCacheTests_Test::TestBody() pxCore/tests/pxScene2d/test_imagecache.cpp:1250
    #3 0x7acd20 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (pxCore/tests/pxScene2d/pxscene2dtests+0x7acd20)
    #4 0x7a03e0 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
    #5 0x75cf75 in testing::Test::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2474
    #6 0x75e261 in testing::TestInfo::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2656
    #7 0x75edda in testing::TestCase::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2774
    #8 0x76f978 in testing::internal::UnitTestImpl::RunAllTests() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4649
    #9 0x7af75f in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
    #10 0x7a253f in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (pxCore/tests/pxScene2d/pxscene2dtests+0x7a253f)
    #11 0x76cb81 in testing::UnitTest::Run() pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4257
    #12 0x5299db in RUN_ALL_TESTS() (pxCore/tests/pxScene2d/pxscene2dtests+0x5299db)
    #13 0x5295c7 in main pxCore/tests/pxScene2d/pxscene2dtestsmain.cpp:101
    #14 0x7f7b361a7009 in __libc_start_main (/lib64/libc.so.6+0x21009)

SUMMARY: AddressSanitizer: heap-use-after-free pxCore/src/rtFileDownloader.cpp:366 in rtFileDownloadRequest::isDataCached()
Shadow bytes around the buggy address:
  0x0c2880007240: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2880007250: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2880007260: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2880007270: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c2880007280: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
=>0x0c2880007290: fd fd fd fd fd fd fd fd fd fd fd fd fd fd[fd]fd
  0x0c28800072a0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c28800072b0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c28800072c0: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x0c28800072d0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c28800072e0: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca^[[1m
  Right alloca redzone:    cb
==5418==ABORTING