### PR TITLE
fix misleading-indentation compilation error

### DIFF
--- a/src/rtValue.cpp
+++ b/src/rtValue.cpp
@@ -299,8 +299,9 @@ rtError rtValue::getBool(bool& v) const
     case RT_doubleType:   v = (mValue.doubleValue==0.0) ? false:true; break;
     case RT_stringType:
     {
-      if (mValue.stringValue)
-        v = (*mValue.stringValue=="")?false:true; break;
+      if (mValue.stringValue) {
+        v = (*mValue.stringValue=="")?false:true;
+      }
     }
     break;
     case RT_objectType: v = mValue.objectValue?     true:false; break;


### PR DESCRIPTION
Fixes the following error:

pxCore/src/rtValue.cpp: In member function ‘rtError rtValue::getBool(bool&) const’:
pxCore/src/rtValue.cpp:302:7: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
       if (mValue.stringValue)
       ^~
pxCore/src/rtValue.cpp:303:51: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
         v = (*mValue.stringValue=="")?false:true; break;
                                                   ^~~~~