### PR TITLE
fix write-strings compilation errors

### DIFF
--- a/src/rtFile.cpp
+++ b/src/rtFile.cpp
@@ -44,7 +44,7 @@ rtError rtData::init(size_t length) {
   else return RT_FAIL;
 }
 
-rtError rtData::init(uint8_t* data, size_t length) {
+rtError rtData::init(const uint8_t* data, size_t length) {
   rtError e = RT_FAIL;
   if (init(length) == RT_OK) {
     memcpy(mData, data, length);
@@ -63,7 +63,7 @@ rtError rtStoreFile(const char* f, rtData& data)
 	// use fopen fwrite fclose from stdio.h
 	FILE * fd = fopen(f, "wb");
 	if (fd)
-	{  
+	{
 		if (data.length() > 0)
 			e = (fwrite((void*)data.data(), 1, data.length(), fd) == data.length()) ? RT_OK : RT_FAIL;
 		else

--- a/src/rtFile.h
+++ b/src/rtFile.h
@@ -28,7 +28,7 @@
 /**
 rtData is a wrapper that encapsulated an allocated buffer of bytes and owns the lifetime of those bytes.
 */
-class rtData 
+class rtData
 {
  public:
   rtData();
@@ -36,7 +36,7 @@ class rtData
 
   // TODO copy constructor and assignment
   rtError init(size_t length);
-  rtError init(uint8_t* data, size_t length);
+  rtError init(const uint8_t* data, size_t length);
 
   rtError term();
 

--- a/src/rtFileDownloader.cpp
+++ b/src/rtFileDownloader.cpp
@@ -87,18 +87,18 @@ static size_t HeaderCallback(void *contents, size_t size, size_t nmemb, void *us
 {
   size_t downloadSize = size * nmemb;
   struct MemoryStruct *mem = (struct MemoryStruct *)userp;
-  
+
   mem->headerBuffer = (char*)realloc(mem->headerBuffer, mem->headerSize + downloadSize + 1);
   if(mem->headerBuffer == NULL) {
-    /* out of memory! */ 
+    /* out of memory! */
     cout << "out of memory when downloading image\n";
     return 0;
   }
- 
+
   memcpy(&(mem->headerBuffer[mem->headerSize]), contents, downloadSize);
   mem->headerSize += downloadSize;
   mem->headerBuffer[mem->headerSize] = 0;
-  
+
   return downloadSize;
 }
 
@@ -111,15 +111,15 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
 
   mem->contentsBuffer = (char*)realloc(mem->contentsBuffer, mem->contentsSize + downloadSize + 1);
   if(mem->contentsBuffer == NULL) {
-    /* out of memory! */ 
+    /* out of memory! */
     cout << "out of memory when downloading image\n";
     return 0;
   }
- 
+
   memcpy(&(mem->contentsBuffer[mem->contentsSize]), contents, downloadSize);
   mem->contentsSize += downloadSize;
   mem->contentsBuffer[mem->contentsSize] = 0;
-  
+
   return downloadSize;
 }
 
@@ -147,7 +147,7 @@ void onDownloadHandleCheck()
   }
 }
 
-rtFileDownloadRequest::rtFileDownloadRequest(const char* imageUrl, void* callbackData) 
+rtFileDownloadRequest::rtFileDownloadRequest(const char* imageUrl, void* callbackData)
       : mFileUrl(imageUrl), mProxyServer(),
     mErrorString(), mHttpStatusCode(0), mCallbackFunction(NULL), mDownloadProgressCallbackFunction(NULL), mDownloadProgressUserPtr(NULL),
     mDownloadedData(0), mDownloadedDataSize(), mDownloadStatusCode(0) ,mCallbackData(callbackData),
@@ -162,7 +162,7 @@ rtFileDownloadRequest::rtFileDownloadRequest(const char* imageUrl, void* callbac
   memset(mHttpErrorBuffer, 0, sizeof(mHttpErrorBuffer));
 #endif
 }
-        
+
 rtFileDownloadRequest::~rtFileDownloadRequest()
 {
   if (mDownloadedData  != NULL)
@@ -178,30 +178,30 @@ rtFileDownloadRequest::~rtFileDownloadRequest()
   mAdditionalHttpHeaders.clear();
   mHeaderOnly = false;
 }
-  
+
 void rtFileDownloadRequest::setFileUrl(const char* imageUrl) { mFileUrl = imageUrl; }
 rtString rtFileDownloadRequest::fileUrl() const { return mFileUrl; }
-    
+
 void rtFileDownloadRequest::setProxy(const char* proxyServer)
 {
   mProxyServer = proxyServer;
 }
-    
+
 rtString rtFileDownloadRequest::proxy() const
 {
   return mProxyServer;
 }
-  
+
 void rtFileDownloadRequest::setErrorString(const char* errorString)
 {
   mErrorString = errorString;
 }
-    
+
 rtString rtFileDownloadRequest::errorString()
 {
   return mErrorString;
 }
-  
+
 void rtFileDownloadRequest::setCallbackFunction(void (*callbackFunction)(rtFileDownloadRequest*))
 {
   mCallbackFunction = callbackFunction;
@@ -219,17 +219,17 @@ void rtFileDownloadRequest::setCallbackFunctionThreadSafe(void (*callbackFunctio
   mCallbackFunction = callbackFunction;
   mCallbackFunctionMutex.unlock();
 }
-  
+
 long rtFileDownloadRequest::httpStatusCode()
 {
   return mHttpStatusCode;
 }
-  
+
 void rtFileDownloadRequest::setHttpStatusCode(long statusCode)
 {
   mHttpStatusCode = statusCode;
 }
-    
+
 bool rtFileDownloadRequest::executeCallback(int statusCode)
 {
   mDownloadStatusCode = statusCode;
@@ -253,24 +253,24 @@ bool rtFileDownloadRequest::executeDownloadProgressCallback(void * ptr, size_t s
   }
   return false;
 }
-  
+
 void rtFileDownloadRequest::setDownloadedData(char* data, size_t size)
 {
   mDownloadedData = data;
   mDownloadedDataSize = size;
 }
-  
+
 void rtFileDownloadRequest::downloadedData(char*& data, size_t& size)
 {
   data = mDownloadedData;
-  size = mDownloadedDataSize; 
+  size = mDownloadedDataSize;
 }
-  
+
 char* rtFileDownloadRequest::downloadedData()
 {
   return mDownloadedData;
 }
-  
+
 size_t rtFileDownloadRequest::downloadedDataSize()
 {
   return mDownloadedDataSize;
@@ -307,17 +307,17 @@ void rtFileDownloadRequest::setDownloadStatusCode(int statusCode)
 {
   mDownloadStatusCode = statusCode;
 }
-  
+
 int rtFileDownloadRequest::downloadStatusCode()
 {
   return mDownloadStatusCode;
 }
-  
+
 void* rtFileDownloadRequest::callbackData()
 {
   return mCallbackData;
 }
-  
+
 void rtFileDownloadRequest::setCallbackData(void* callbackData)
 {
   mCallbackData = callbackData;
@@ -411,7 +411,7 @@ bool rtFileDownloadRequest::isHTTPFailOnError()
   return mHTTPFailOnError;
 }
 
-void rtFileDownloadRequest::setHTTPError(char* httpError)
+void rtFileDownloadRequest::setHTTPError(const char* httpError)
 {
   if(httpError != NULL)
   {
@@ -445,7 +445,7 @@ rtString rtFileDownloadRequest::origin()
   return mOrigin;
 }
 
-rtFileDownloader::rtFileDownloader() 
+rtFileDownloader::rtFileDownloader()
     : mNumberOfCurrentDownloads(0), mDefaultCallbackFunction(NULL), mDownloadHandles(), mReuseDownloadHandles(false), mCaCertFile(CA_CERTIFICATE)
 {
 #ifdef PX_REUSE_DOWNLOAD_HANDLES
@@ -588,7 +588,7 @@ void rtFileDownloader::downloadFile(rtFileDownloadRequest* downloadRequest)
                                      downloadRequest->headerData(),
                                      downloadRequest->downloadedData(),
                                      downloadRequest->downloadedDataSize());
-      
+
       if (downloadedData.isWritableToCache())
       {
         if (NULL == rtFileCache::instance())
@@ -676,9 +676,9 @@ bool rtFileDownloader::downloadFromNetwork(rtFileDownloadRequest* downloadReques
     curl_easy_setopt(curl_handle, CURLOPT_TCP_KEEPIDLE, 60);
     curl_easy_setopt(curl_handle, CURLOPT_TCP_KEEPINTVL, 30);
 #endif //!PX_PLATFORM_GENERIC_DFB && !PX_PLATFORM_DFB_NON_X11
-    
+
     int downloadHandleExpiresTime = downloadRequest->downloadHandleExpiresTime();
-    
+
     vector<rtString>& additionalHttpHeaders = downloadRequest->additionalHttpHeaders();
     struct curl_slist *list = NULL;
     for (unsigned int headerOption = 0;headerOption < additionalHttpHeaders.size();headerOption++)
@@ -727,10 +727,10 @@ bool rtFileDownloader::downloadFromNetwork(rtFileDownloadRequest* downloadReques
         downloadRequest->setHTTPError(errorBuffer);
 
     /* check for errors */
-    if (res != CURLE_OK) 
+    if (res != CURLE_OK)
     {
         stringstream errorStringStream;
-        
+
         errorStringStream << "Download error for: " << downloadRequest->fileUrl().cString()
                 << ".  Error code : " << res << ".  Using proxy: ";
         if (useProxy)
@@ -741,17 +741,17 @@ bool rtFileDownloader::downloadFromNetwork(rtFileDownloadRequest* downloadReques
         {
             errorStringStream << "false";
         }
-        
+
         downloadRequest->setErrorString(errorStringStream.str().c_str());
         rtFileDownloader::instance()->releaseDownloadHandle(curl_handle, downloadHandleExpiresTime);
-        
+
         //clean up contents on error
         if (chunk.contentsBuffer != NULL)
         {
             free(chunk.contentsBuffer);
             chunk.contentsBuffer = NULL;
         }
-        
+
         if (chunk.headerBuffer != NULL)
         {
             free(chunk.headerBuffer);
@@ -841,9 +841,9 @@ void rtFileDownloader::downloadFileInBackground(rtFileDownloadRequest* downloadR
     {
       downloadRequest->setDownloadHandleExpiresTime(kDefaultDownloadHandleExpiresTime);
     }
-    
+
     rtThreadTask* task = new rtThreadTask(startFileDownloadInBackground, (void*)downloadRequest, downloadRequest->fileUrl());
-    
+
     mainThreadPool->executeTask(task);
 }
 

--- a/src/rtFileDownloader.h
+++ b/src/rtFileDownloader.h
@@ -91,7 +91,7 @@ public:
   bool isProgressMeterSwitchOff();
   void setHTTPFailOnError(bool val);
   bool isHTTPFailOnError();
-  void setHTTPError(char* httpError);
+  void setHTTPError(const char* httpError);
   char* httpErrorBuffer(void);
   void setCurlDefaultTimeout(bool val);
   bool isCurlDefaultTimeoutSet();

--- a/tests/pxScene2d/CMakeLists.txt
+++ b/tests/pxScene2d/CMakeLists.txt
@@ -149,7 +149,7 @@ endif (PXSCENE_TEST_PERMISSIONS_CHECK)
 
 set(TEST_SOURCE_FILES ${TEST_SOURCE_FILES} ${EXTDIR}/gtest/googletest/src/gtest-all.cc ${EXTDIR}/gtest/googlemock/src/gmock-all.cc)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fpermissive -g -Wall -Wno-attributes -Wall -Wextra -Wno-write-strings -Wno-format-security -std=c++11 -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fpermissive -g -Wall -Wno-attributes -Wall -Wextra -Wno-format-security -std=c++11 -O3")
 
 if (BUILD_UNIT_TEST GREATER 0)
     link_directories(${PXSCENETEST_LINK_DIRECTORIES})

--- a/tests/pxScene2d/test_api.cpp
+++ b/tests/pxScene2d/test_api.cpp
@@ -43,7 +43,7 @@ class pxApiTest : public testing::Test
     }
 
 private:
-    void startJsFile(char *jsfile)
+    void startJsFile(const char *jsfile)
     {
       mUrl  = jsfile;
       mView = new pxScriptView(mUrl,"");
@@ -83,4 +83,3 @@ TEST_F(pxApiTest, apiTest)
 {
    runApiTests();
 }
-

--- a/tests/pxScene2d/test_imagecache.cpp
+++ b/tests/pxScene2d/test_imagecache.cpp
@@ -331,7 +331,7 @@ class rtHttpCacheTest : public testing::Test, public commonTestFns
     {
     }
 
-    void populateCacheHeader (rtString& outheader, char* cacheControl, bool isEtagPresent=true, bool isExpired=false)
+    void populateCacheHeader (rtString& outheader, const char* cacheControl, bool isEtagPresent=true, bool isExpired=false)
     {
       outheader.append(defaultCacheHeader);
       if (isEtagPresent)
@@ -481,8 +481,8 @@ class rtHttpCacheTest : public testing::Test, public commonTestFns
       const char* cacheData = "abcde";
       rtHttpCacheData data("http://fileserver/test.jpeg",cacheHeader.cString(),cacheData,strlen(cacheData));
       rtData newData;
-      char* newcontents = "pqrstu";
-      newData.init((uint8_t*)newcontents,strlen(newcontents));
+      const char* newcontents = "pqrstu";
+      newData.init((const uint8_t *)newcontents,strlen(newcontents));
       data.setData(newData);
       rtData& storedData = data.contentsData();
       EXPECT_TRUE ( strcmp("pqrstu",(const char*)storedData.data()) == 0);
@@ -1070,14 +1070,14 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
       //todo more actions once clearFileCache() is implemented
       rtFileDownloader::instance()->clearFileCache();
     }
-   
+
     void setHTTPFailOnErrorTest()
     {
       rtFileDownloadRequest req("http://fileserver/notfound",NULL);
       req.setHTTPFailOnError(true);
       EXPECT_TRUE (req.isHTTPFailOnError() == true);
     }
-  
+
     void setHTTPErrorTest()
     {
       rtFileDownloadRequest req("http://fileserver/notfound",NULL);
@@ -1091,7 +1091,7 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
       req.setCurlDefaultTimeout(true);
       EXPECT_TRUE (req.isCurlDefaultTimeoutSet() == true);
     }
- 
+
     // download progress test begins
     void setDownloadProgressCallbackFunctionTest()
     {
@@ -1101,7 +1101,7 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
       EXPECT_TRUE (request.mDownloadProgressCallbackFunction == &rtFileDownloaderTest::downloadProgressCallback);
       EXPECT_TRUE (request.mDownloadProgressUserPtr == this);
     }
- 
+
     void executeDownloadProgressCallbackPresentTest()
     {
       rtFileCache::instance()->clearCache();
@@ -1109,14 +1109,14 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
       request.setDownloadProgressCallbackFunction(rtFileDownloaderTest::downloadProgressCallback, this);
       EXPECT_TRUE (true == request.executeDownloadProgressCallback(NULL, 0, 0));
     }
- 
+
     void executeDownloadProgressCallbackAbsentTest()
     {
       rtFileCache::instance()->clearCache();
       rtFileDownloadRequest request("https://px-apps.sys.comcast.net/pxscene-samples/images/tiles/008.jpg",this);
       EXPECT_TRUE (false == request.executeDownloadProgressCallback(NULL, 0, 0));
     }
- 
+
     void setDataIsCachedTest()
     {
       rtFileCache::instance()->clearCache();

--- a/tests/pxScene2d/test_jsfiles.cpp
+++ b/tests/pxScene2d/test_jsfiles.cpp
@@ -111,7 +111,7 @@ class jsFilesTest : public testing::Test
     {
     }
 
-    void test(char* file, float timeout)
+    void test(const char* file, float timeout)
     {
       script.collectGarbage();
       int oldpxCount = pxObjectCount;
@@ -131,7 +131,7 @@ class jsFilesTest : public testing::Test
 
 private:
 
-    void startJsFile(char *jsfile)
+    void startJsFile(const char *jsfile)
     {
       mUrl = jsfile;
       mView = new pxScriptView(mUrl,"");

--- a/tests/pxScene2d/test_memoryleak.cpp
+++ b/tests/pxScene2d/test_memoryleak.cpp
@@ -85,7 +85,7 @@ class pxSceneContainerLeakTest : public testing::Test
 
 private:
 
-    void startJsFile(char *jsfile)
+    void startJsFile(const char *jsfile)
     {
       mUrl = jsfile;
       mView = new pxScriptView(mUrl,"");

--- a/tests/pxScene2d/test_rtError.cpp
+++ b/tests/pxScene2d/test_rtError.cpp
@@ -21,26 +21,26 @@ class rtErrorTest : public ::testing::TestWithParam<rtError>
   public:
     virtual void SetUp()
     {
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_OK, "RT_OK"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_FAIL, "RT_FAIL"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_NOT_ENOUGH_ARGS, "RT_ERROR_NOT_ENOUGH_ARGS"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_INVALID_ARG, "RT_ERROR_INVALID_ARG"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_PROP_NOT_FOUND, "RT_PROP_NOT_FOUND"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_OBJECT_NOT_INITIALIZED, "RT_OBJECT_NOT_INITIALIZED"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_PROPERTY_NOT_FOUND, "RT_PROPERTY_NOT_FOUND"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_OBJECT_NO_LONGER_AVAILABLE, "RT_OBJECT_NO_LONGER_AVAILABLE"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_RESOURCE_NOT_FOUND, "RT_RESOURCE_NOT_FOUND"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_NO_CONNECTION, "RT_NO_CONNECTION"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_NOT_IMPLEMENTED, "RT_ERROR_NOT_IMPLEMENTED"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_TYPE_MISMATCH, "RT_ERROR_TYPE_MISMATCH"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_TIMEOUT, "RT_ERROR_TIMEOUT"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_DUPLICATE_ENTRY, "RT_ERROR_DUPLICATE_ENTRY"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_OBJECT_NOT_FOUND, "RT_ERROR_OBJECT_NOT_FOUND"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_PROTOCOL_ERROR, "RT_ERROR_PROTOCOL_ERROR"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_INVALID_OPERATION, "RT_ERROR_INVALID_OPERATION"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_IN_PROGRESS, "RT_ERROR_IN_PROGRESS"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_QUEUE_EMPTY, "RT_ERROR_QUEUE_EMPTY"));
-      rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_STREAM_CLOSED, "RT_ERROR_STREAM_CLOSED"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_OK, "RT_OK"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_FAIL, "RT_FAIL"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_ERROR_NOT_ENOUGH_ARGS, "RT_ERROR_NOT_ENOUGH_ARGS"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_ERROR_INVALID_ARG, "RT_ERROR_INVALID_ARG"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_PROP_NOT_FOUND, "RT_PROP_NOT_FOUND"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_OBJECT_NOT_INITIALIZED, "RT_OBJECT_NOT_INITIALIZED"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_PROPERTY_NOT_FOUND, "RT_PROPERTY_NOT_FOUND"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_OBJECT_NO_LONGER_AVAILABLE, "RT_OBJECT_NO_LONGER_AVAILABLE"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_RESOURCE_NOT_FOUND, "RT_RESOURCE_NOT_FOUND"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_NO_CONNECTION, "RT_NO_CONNECTION"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_ERROR_NOT_IMPLEMENTED, "RT_ERROR_NOT_IMPLEMENTED"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_ERROR_TYPE_MISMATCH, "RT_ERROR_TYPE_MISMATCH"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_ERROR_TIMEOUT, "RT_ERROR_TIMEOUT"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_ERROR_DUPLICATE_ENTRY, "RT_ERROR_DUPLICATE_ENTRY"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_ERROR_OBJECT_NOT_FOUND, "RT_ERROR_OBJECT_NOT_FOUND"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_ERROR_PROTOCOL_ERROR, "RT_ERROR_PROTOCOL_ERROR"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_ERROR_INVALID_OPERATION, "RT_ERROR_INVALID_OPERATION"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_ERROR_IN_PROGRESS, "RT_ERROR_IN_PROGRESS"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_ERROR_QUEUE_EMPTY, "RT_ERROR_QUEUE_EMPTY"));
+      rtBuiltinErrors.insert (std::pair <const int, const char*> (RT_ERROR_STREAM_CLOSED, "RT_ERROR_STREAM_CLOSED"));
     }
 
     virtual void TearDown()


### PR DESCRIPTION
Excerpt of fixed issues:

pxCore/tests/pxScene2d/test_api.cpp:40:44: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       startJsFile("onescene_with_parent.js");
                                            ^
cc1plus: all warnings being treated as errors
make[2]: *** [tests/pxScene2d/CMakeFiles/pxscene2dtests.dir/build.make:111: tests/pxScene2d/CMakeFiles/pxscene2dtests.dir/test_api.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
pxCore/tests/pxScene2d/test_memoryleak.cpp: In member function ‘void pxSceneContainerLeakTest::withParentRemovedGCNotHappenedTest()’:
pxCore/tests/pxScene2d/test_memoryleak.cpp:36:44: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       startJsFile("onescene_with_parent.js");
                                            ^
pxCore/tests/pxScene2d/test_memoryleak.cpp: In member function ‘void pxSceneContainerLeakTest::withParentRemovedGCHappenedTest()’:
pxCore/tests/pxScene2d/test_memoryleak.cpp:49:44: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       startJsFile("onescene_with_parent.js");
                                            ^
pxCore/tests/pxScene2d/test_memoryleak.cpp: In member function ‘void pxSceneContainerLeakTest::withoutParentRemovedGCNotHappenedTest()’:
pxCore/tests/pxScene2d/test_memoryleak.cpp:64:44: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       startJsFile("onescene_with_parent.js");
                                            ^
pxCore/tests/pxScene2d/test_memoryleak.cpp: In member function ‘void pxSceneContainerLeakTest::withoutParentRemovedGCHappenedTest()’:
pxCore/tests/pxScene2d/test_memoryleak.cpp:76:44: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       startJsFile("onescene_with_parent.js");

pxCore/tests/pxScene2d/test_api.cpp:40:44: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       startJsFile("onescene_with_parent.js");
                                            ^
cc1plus: all warnings being treated as errors

pxCore/tests/pxScene2d/test_rtError.cpp: In member function ‘virtual void rtErrorTest::SetUp()’:
pxCore/tests/pxScene2d/test_rtError.cpp:24:69: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_OK, "RT_OK"));
                                                                     ^
pxCore/tests/pxScene2d/test_rtError.cpp:25:73: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_FAIL, "RT_FAIL"));
                                                                         ^
pxCore/tests/pxScene2d/test_rtError.cpp:26:107: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_NOT_ENOUGH_ARGS, "RT_ERROR_NOT_ENOUGH_ARGS"));
                                                                                                           ^
pxCore/tests/pxScene2d/test_rtError.cpp:27:99: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_INVALID_ARG, "RT_ERROR_INVALID_ARG"));
                                                                                                   ^
pxCore/tests/pxScene2d/test_rtError.cpp:28:93: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_PROP_NOT_FOUND, "RT_PROP_NOT_FOUND"));
                                                                                             ^
pxCore/tests/pxScene2d/test_rtError.cpp:29:109: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_OBJECT_NOT_INITIALIZED, "RT_OBJECT_NOT_INITIALIZED"));
                                                                                                             ^
pxCore/tests/pxScene2d/test_rtError.cpp:30:101: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_PROPERTY_NOT_FOUND, "RT_PROPERTY_NOT_FOUND"));
                                                                                                     ^
pxCore/tests/pxScene2d/test_rtError.cpp:31:117: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_OBJECT_NO_LONGER_AVAILABLE, "RT_OBJECT_NO_LONGER_AVAILABLE"));
                                                                                                                     ^
pxCore/tests/pxScene2d/test_rtError.cpp:32:101: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_RESOURCE_NOT_FOUND, "RT_RESOURCE_NOT_FOUND"));
                                                                                                     ^
pxCore/tests/pxScene2d/test_rtError.cpp:33:91: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_NO_CONNECTION, "RT_NO_CONNECTION"));
                                                                                           ^
pxCore/tests/pxScene2d/test_rtError.cpp:34:107: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_NOT_IMPLEMENTED, "RT_ERROR_NOT_IMPLEMENTED"));
                                                                                                           ^
pxCore/tests/pxScene2d/test_rtError.cpp:35:103: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_TYPE_MISMATCH, "RT_ERROR_TYPE_MISMATCH"));
                                                                                                       ^
pxCore/tests/pxScene2d/test_rtError.cpp:36:91: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_TIMEOUT, "RT_ERROR_TIMEOUT"));
                                                                                           ^
pxCore/tests/pxScene2d/test_rtError.cpp:37:107: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_DUPLICATE_ENTRY, "RT_ERROR_DUPLICATE_ENTRY"));
                                                                                                           ^
pxCore/tests/pxScene2d/test_rtError.cpp:38:109: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_OBJECT_NOT_FOUND, "RT_ERROR_OBJECT_NOT_FOUND"));
                                                                                                             ^
pxCore/tests/pxScene2d/test_rtError.cpp:39:105: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_PROTOCOL_ERROR, "RT_ERROR_PROTOCOL_ERROR"));
                                                                                                         ^
pxCore/tests/pxScene2d/test_rtError.cpp:40:111: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_INVALID_OPERATION, "RT_ERROR_INVALID_OPERATION"));
                                                                                                               ^
pxCore/tests/pxScene2d/test_rtError.cpp:41:99: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_IN_PROGRESS, "RT_ERROR_IN_PROGRESS"));
                                                                                                   ^
pxCore/tests/pxScene2d/test_rtError.cpp:42:99: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_QUEUE_EMPTY, "RT_ERROR_QUEUE_EMPTY"));
                                                                                                   ^
pxCore/tests/pxScene2d/test_rtError.cpp:43:103: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
       rtBuiltinErrors.insert (std::pair <int, char*> (RT_ERROR_STREAM_CLOSED, "RT_ERROR_STREAM_CLOSED"));

pxCore/tests/pxScene2d/test_jsfiles.cpp: In member function ‘virtual void jsFilesTest_jsTests_Test::TestBody()’:
pxCore/tests/pxScene2d/test_jsfiles.cpp:168:88: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
   test("shell.js?url=http://www.pxscene.org/examples/px-reference/gallery/fancy.js",5.0);
                                                                                        ^
pxCore/tests/pxScene2d/test_jsfiles.cpp:169:94: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
   test("shell.js?url=http://www.pxscene.org/examples/px-reference/gallery/picturepile.js",5.0);
                                                                                              ^
pxCore/tests/pxScene2d/test_jsfiles.cpp:170:91: error: ISO C++ forbids converting a string constant to ‘char*’ [-Werror=write-strings]
   test("shell.js?url=http://www.pxscene.org/examples/px-reference/gallery/gallery.js",20.0);
                                                                                           ^
cc1plus: all warnings being treated as errors