### PR TITLE
Fix for crash in pxWayland::launchAndMonitorClient

### DIFF
--- a/examples/pxScene2d/src/pxWayland.cpp
+++ b/examples/pxScene2d/src/pxWayland.cpp
@@ -91,6 +91,7 @@ pxWayland::~pxWayland()
   if ( mWCtx )
   {
      WstCompositorDestroy(mWCtx);
+     mWCtx = 0;
      terminateClient();
   }
 }

--- a/examples/pxScene2d/src/pxWayland.cpp
+++ b/examples/pxScene2d/src/pxWayland.cpp
@@ -91,7 +91,7 @@ pxWayland::~pxWayland()
   if ( mWCtx )
   {
      WstCompositorDestroy(mWCtx);
-     mWCtx = 0;
+     mWCtx = NULL;
      terminateClient();
   }
 }


### PR DESCRIPTION
Fix for crash upon going to standby or shutdown, caused by pxWayland::launchAndMonitorClient running in another thread and using the freed context pointer. The per-cautionary checks within the Westeros routines seems to don't because the pointer is not zero.