### PR TITLE
fix 'clobbered' compilation errors

### DIFF
--- a/src/pxUtil.cpp
+++ b/src/pxUtil.cpp
@@ -1042,7 +1042,16 @@ rtError pxLoadPNGImage(const char *imageData, size_t imageDataSize,
       }
       e = RT_OK;
     }
+    else
+    {
+      e = RT_FAIL;
+    }
   }
+  else
+  {
+    e = RT_FAIL;
+  }
+
 
   if (e == RT_OK)
   {


### PR DESCRIPTION
pxCore/src/pxUtil.cpp: In function ‘rtError pxLoadPNGImage(const char*, size_t, pxOffscreen&)’:
pxCore/src/pxUtil.cpp:948:11: error: variable ‘e’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Werror=clobbered]
   rtError e = RT_FAI