### PR TITLE
fix 'uninitialized' & 'maybe-uninitialized' compilation errors

### DIFF
--- a/examples/pxScene2d/src/pxFont.cpp
+++ b/examples/pxScene2d/src/pxFont.cpp
@@ -334,6 +334,8 @@ const GlyphCacheEntry* pxFont::getGlyph(uint32_t codePoint)
 void pxFont::measureTextInternal(const char* text, uint32_t size,  float sx, float sy, 
                          float& w, float& h) 
 {
+  w = 0; h = 0;
+
   // TODO ignoring sx and sy now
   sx = 1.0;
   sy = 1.0;
@@ -344,8 +346,7 @@ void pxFont::measureTextInternal(const char* text, uint32_t size,  float sx, flo
   }
 
   setPixelSize(size);
-  
-  w = 0; h = 0;
+
   if (!text) 
     return;
     

--- a/examples/pxScene2d/src/pxImage9Border.h
+++ b/examples/pxScene2d/src/pxImage9Border.h
@@ -45,8 +45,9 @@ public:
   rtError borderBottom(float& v) const { v = mBorderBottom; return RT_OK; }
   rtError setBorderBottom(float v) { mBorderBottom = v; return RT_OK; }
 
-  rtError maskColor(uint32_t& /*c*/) const
+  rtError maskColor(uint32_t& c) const
   {
+    c = 0;
     rtLogWarn("maskColor get not available");
     return RT_OK;
   }

--- a/examples/pxScene2d/src/pxRectangle.h
+++ b/examples/pxScene2d/src/pxRectangle.h
@@ -41,10 +41,11 @@ public:
   }
 
   virtual void onInit() {mReady.send("resolve",this);}
-  
-  rtError fillColor(uint32_t& /*c*/) const 
+
+  rtError fillColor(uint32_t& c) const
   {
     // TODO
+    c = 0;
     rtLogWarn("fillColor not implemented");
     return RT_OK;
   }
@@ -58,9 +59,10 @@ public:
     return RT_OK;
   }
 
-  rtError lineColor(uint32_t& /*c*/) const 
+  rtError lineColor(uint32_t& c) const
   {
     // TODO
+    c = 0;
     rtLogWarn("lineColor not implemented");
     return RT_OK;
   }

--- a/examples/pxScene2d/src/pxText.h
+++ b/examples/pxScene2d/src/pxText.h
@@ -46,8 +46,9 @@ public:
   rtError text(rtString& s) const;
   virtual rtError setText(const char* text);
 
-  rtError textColor(uint32_t& /*c*/) const {
-    
+  rtError textColor(uint32_t& c) const {
+    c = 0;
+    rtLogWarn("textColor not implemented");
     return RT_OK;
   }
 


### PR DESCRIPTION
Excerpt of fixed issues:

In file included from pxCore/examples/pxScene2d/src/pxScene2d.h:41:0,
                 from pxCore/examples/pxScene2d/src/pxRectangle.h:24,
                 from pxCore/examples/pxScene2d/src/pxRectangle.cpp:21:
pxCore/examples/pxScene2d/src/../../../src/rtValue.h: In member function ‘rtError pxRectangle::fillColor_PropGetterThunk(rtValue&) const’:
pxCore/examples/pxScene2d/src/../../../src/rtValue.h:237:56: error: ‘pv’ is used uninitialized in this function [-Werror=uninitialized]
   void asn(uint32_t v)                      { setUInt32(v);   }
                                               ~~~~~~~~~^~~
In file included from pxCore/examples/pxScene2d/src/../../../src/rtObject.h:29:0,
                 from pxCore/examples/pxScene2d/src/pxScene2d.h:42,
                 from pxCore/examples/pxScene2d/src/pxRectangle.h:24,
                 from pxCore/examples/pxScene2d/src/pxRectangle.cpp:21:
pxCore/examples/pxScene2d/src/../../../src/rtObjectMacros.h:218:73: note: ‘pv’ was declared here
     rtError getterMethod##_PropGetterThunk(rtValue& v) const { propType pv;  rtError e = getterMethod(pv); v.assign<propType>(pv); return e;}
                                                                         ^
pxCore/examples/pxScene2d/src/../../../src/rtObjectMacros.h:227:5: note: in expansion of macro ‘rtThunkProperty’
     rtThunkProperty(getMethod, setMethod, propType); \
     ^~~~~~~~~~~~~~~
pxCore/examples/pxScene2d/src/pxRectangle.h:30:3: note: in expansion of macro ‘rtProperty’
   rtProperty(fillColor, fillColor, setFillColor, uint32_t);
   ^~~~~~~~~~
In file included from pxCore/examples/pxScene2d/src/pxScene2d.h:41:0,
                 from pxCore/examples/pxScene2d/src/pxRectangle.h:24,
                 from pxCore/examples/pxScene2d/src/pxRectangle.cpp:21:
pxCore/examples/pxScene2d/src/../../../src/rtValue.h: In member function ‘rtError pxRectangle::lineColor_PropGetterThunk(rtValue&) const’:
pxCore/examples/pxScene2d/src/../../../src/rtValue.h:237:56: error: ‘pv’ is used uninitialized in this function [-Werror=uninitialized]
   void asn(uint32_t v)                      { setUInt32(v);   }
                                               ~~~~~~~~~^~~
In file included from pxCore/examples/pxScene2d/src/../../../src/rtObject.h:29:0,
                 from pxCore/examples/pxScene2d/src/pxScene2d.h:42,
                 from pxCore/examples/pxScene2d/src/pxRectangle.h:24,
                 from pxCore/examples/pxScene2d/src/pxRectangle.cpp:21:
pxCore/examples/pxScene2d/src/../../../src/rtObjectMacros.h:218:73: note: ‘pv’ was declared here
     rtError getterMethod##_PropGetterThunk(rtValue& v) const { propType pv;  rtError e = getterMethod(pv); v.assign<propType>(pv); return e;}
                                                                         ^
pxCore/examples/pxScene2d/src/../../../src/rtObjectMacros.h:227:5: note: in expansion of macro ‘rtThunkProperty’
     rtThunkProperty(getMethod, setMethod, propType); \
     ^~~~~~~~~~~~~~~
pxCore/examples/pxScene2d/src/pxRectangle.h:31:3: note: in expansion of macro ‘rtProperty’
   rtProperty(lineColor, lineColor, setLineColor, uint32_t);
   ^~~~~~~~~~

pxCore/examples/pxScene2d/src/pxFont.cpp: In member function ‘rtError pxFont::measureText(uint32_t, rtString, rtObjectRef&)’:
pxCore/examples/pxScene2d/src/pxFont.cpp:518:16: error: ‘h’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   measure->setH(h);
   ~~~~~~~~~~~~~^~~
pxCore/examples/pxScene2d/src/pxFont.cpp:517:16: error: ‘w’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   measure->setW(w);
   ~~~~~~~~~~~~~^~~
cc1plus: all warnings being treated as errors
make[2]: *** [examples/pxScene2d/src/CMakeFiles/pxscene_static.dir/build.make:135: examples/pxScene2d/src/CMakeFiles/pxscene_static.dir/pxFont.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from pxCore/examples/pxScene2d/src/pxScene2d.h:41:0,
                 from pxCore/examples/pxScene2d/src/pxText.h:30,
                 from pxCore/examples/pxScene2d/src/pxText.cpp:21:
pxCore/examples/pxScene2d/src/../../../src/rtValue.h: In member function ‘rtError pxText::textColor_PropGetterThunk(rtValue&) const’:
pxCore/examples/pxScene2d/src/../../../src/rtValue.h:237:56: error: ‘pv’ is used uninitialized in this function [-Werror=uninitialized]
   void asn(uint32_t v)                      { setUInt32(v);   }
                                               ~~~~~~~~~^~~
In file included from pxCore/examples/pxScene2d/src/../../../src/rtObject.h:29:0,
                 from pxCore/examples/pxScene2d/src/pxScene2d.h:42,
                 from pxCore/examples/pxScene2d/src/pxText.h:30,
                 from pxCore/examples/pxScene2d/src/pxText.cpp:21:
pxCore/examples/pxScene2d/src/../../../src/rtObjectMacros.h:218:73: note: ‘pv’ was declared here
     rtError getterMethod##_PropGetterThunk(rtValue& v) const { propType pv;  rtError e = getterMethod(pv); v.assign<propType>(pv); return e;}
                                                                         ^
pxCore/examples/pxScene2d/src/../../../src/rtObjectMacros.h:227:5: note: in expansion of macro ‘rtThunkProperty’
     rtThunkProperty(getMethod, setMethod, propType); \
     ^~~~~~~~~~~~~~~
pxCore/examples/pxScene2d/src/pxText.h:39:3: note: in expansion of macro ‘rtProperty’
   rtProperty(textColor, textColor, setTextColor, uint32_t);
   ^~~~~~~~~~
cc1plus: all warnings being treated as errors

In file included from pxCore/examples/pxScene2d/src/pxScene2d.h:41:0,
                 from pxCore/examples/pxScene2d/src/pxImage9Border.cpp:23:
pxCore/examples/pxScene2d/src/../../../src/rtValue.h: In member function ‘rtError pxImage9Border::maskColor_PropGetterThunk(rtValue&) const’:
pxCore/examples/pxScene2d/src/../../../src/rtValue.h:237:56: error: ‘pv’ is used uninitialized in this function [-Werror=uninitialized]
   void asn(uint32_t v)                      { setUInt32(v);   }
                                               ~~~~~~~~~^~~
In file included from pxCore/examples/pxScene2d/src/../../../src/rtObject.h:29:0,
                 from pxCore/examples/pxScene2d/src/pxScene2d.h:42,
                 from pxCore/examples/pxScene2d/src/pxImage9Border.cpp:23:
pxCore/examples/pxScene2d/src/../../../src/rtObjectMacros.h:218:73: note: ‘pv’ was declared here
     rtError getterMethod##_PropGetterThunk(rtValue& v) const { propType pv;  rtError e = getterMethod(pv); v.assign<propType>(pv); return e;}
                                                                         ^
pxCore/examples/pxScene2d/src/../../../src/rtObjectMacros.h:227:5: note: in expansion of macro ‘rtThunkProperty’
     rtThunkProperty(getMethod, setMethod, propType); \
     ^~~~~~~~~~~~~~~
pxCore/examples/pxScene2d/src/pxImage9Border.h:33:3: note: in expansion of macro ‘rtProperty’
   rtProperty(maskColor, maskColor, setMaskColor, uint32_t);
   ^~~~~~~~~~