### PR TITLE
fix 'unused-result' compilation error

### DIFF
--- a/src/rtScriptNode/rtScriptNode.cpp
+++ b/src/rtScriptNode/rtScriptNode.cpp
@@ -182,8 +182,8 @@ public:
     return rtAtomicInc(&mRefCount);
   }
 
-  unsigned long Release();  
-    
+  unsigned long Release();
+
   rtError init();
 
   rtString engine() { return "node/v8"; }
@@ -238,7 +238,7 @@ private:
   void init2(int argc, char** argv);
 #endif
 
-  int mRefCount;  
+  int mRefCount;
 };
 
 
@@ -401,7 +401,8 @@ void rtNodeContext::createEnvironment()
     {
       char currentPath[100];
       memset(currentPath,0,sizeof(currentPath));
-      getcwd(currentPath,sizeof(currentPath));
+      const char *rv = getcwd(currentPath,sizeof(currentPath));
+      (void)rv;
       StartDebug(mEnv, currentPath, debug_wait_connect, mPlatform);
     }
     else
@@ -564,7 +565,7 @@ void rtNodeContext::clonedEnvironment(rtNodeContextRef clone_me)
     mContextId = GetContextId(clone_local);
 
     mContext.Reset(mIsolate, clone_local); // local to persistent
-    // commenting below code as templates are isolcate specific	  
+    // commenting below code as templates are isolcate specific
 /*
     Context::Scope context_scope(clone_local);
 
@@ -655,7 +656,7 @@ rtError rtNodeContext::add(const char *name, rtValue const& val)
     rtLogDebug(" rtNodeContext::add() - ALREADY HAS '%s' ... over-writing.", name);
    // return; // Allow for "Null"-ing erasure.
   }
-  
+
   if(val.isEmpty())
   {
     rtLogDebug(" rtNodeContext::add() - rtValue is empty");
@@ -671,7 +672,7 @@ rtError rtNodeContext::add(const char *name, rtValue const& val)
   Context::Scope context_scope(local_context);
 
   local_context->Global()->Set( String::NewFromUtf8(mIsolate, name), rt2js(local_context, val));
-  
+
   return RT_OK;
 }
 
@@ -850,7 +851,7 @@ rtError rtNodeContext::runScript(const char* script, rtValue* retVal /*= NULL*/,
       // Return val
       rtWrapperError error;
       *retVal = js2rt(local_context, result, &error);
-      
+
       if(error.hasError())
       {
         rtLogError("js2rt() - return from script error");
@@ -894,7 +895,7 @@ rtError rtNodeContext::runFile(const char *file, rtValue* retVal /*= NULL*/, con
   if( js_script.empty() ) // load error
   {
     rtLogError(" %s  ... load error / not found.",__PRETTY_FUNCTION__);
-     
+
     return RT_FAIL;
   }
 


### PR DESCRIPTION
Fixes the following issue:
src/rtScriptNode/rtScriptNode.cpp:404:46: error: ignoring return value of 'char* getcwd(char*, size_t)', declared with attribute warn_unused_result [-Werror=unused-result]
|        getcwd(currentPath,sizeof(currentPath));
                                               ^