### PR TITLE
prefer to use built-in versions of sincos() and sincosf()

### DIFF
--- a/examples/pxScene2d/src/CMakeLists.txt
+++ b/examples/pxScene2d/src/CMakeLists.txt
@@ -114,7 +114,7 @@ elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
                   ${NODE_LIBRARIES}
                   ${DUKE_LIBRARIES}
              ${COMM_DEPS_LIBRARIES}
-             pthread rt dl)
+             pthread rt dl m)
 
     set(PXSCENE_APP_LIBRARIES ${PXSCENE_APP_LIBRARIES} pxCore rtCore_s)
 

--- a/src/pxMatrix4T.cpp
+++ b/src/pxMatrix4T.cpp
@@ -18,14 +18,22 @@
 
 // pxMatrix4T.cpp
 
+#ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+#endif
+#include <math.h>
 #include "pxMatrix4T.h"
 
+#ifndef _GLIBCXX_HAVE_SINCOS
 void sincos(double x, double *s, double *c) {
   *s = sin(x);
   *c = cos(x);
 }
+#endif
 
+#ifndef _GLIBCXX_HAVE_SINCOSF
 void sincosf(float x, float *s, float *c) {
   *s = sin(x);
   *c = cos(x);
 }
+#endif


### PR DESCRIPTION
    Backtrace before (note that it causes stack-overflow):
     (gdb) bt
     #0  sincosf (x=-6.16183472, s=s@entry=0x7fffd382066c, c=c@entry=0x7fffd3820668) at pxCore/src/pxMatrix4T.cpp:28
     #1  0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd382069c, c=c@entry=0x7fffd3820698) at pxCore/src/pxMatrix4T.cpp:28
     #2  0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd38206cc, c=c@entry=0x7fffd38206c8) at pxCore/src/pxMatrix4T.cpp:28
     #3  0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd38206fc, c=c@entry=0x7fffd38206f8) at pxCore/src/pxMatrix4T.cpp:28
     #4  0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd382072c, c=c@entry=0x7fffd3820728) at pxCore/src/pxMatrix4T.cpp:28
     #5  0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd382075c, c=c@entry=0x7fffd3820758) at pxCore/src/pxMatrix4T.cpp:28
     #6  0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd382078c, c=c@entry=0x7fffd3820788) at pxCore/src/pxMatrix4T.cpp:28
     #7  0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd38207bc, c=c@entry=0x7fffd38207b8) at pxCore/src/pxMatrix4T.cpp:28
     #8  0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd38207ec, c=c@entry=0x7fffd38207e8) at pxCore/src/pxMatrix4T.cpp:28
     #9  0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd382081c, c=c@entry=0x7fffd3820818) at pxCore/src/pxMatrix4T.cpp:28
     #10 0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd382084c, c=c@entry=0x7fffd3820848) at pxCore/src/pxMatrix4T.cpp:28
     #11 0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd382087c, c=c@entry=0x7fffd3820878) at pxCore/src/pxMatrix4T.cpp:28
     #12 0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd38208ac, c=c@entry=0x7fffd38208a8) at pxCore/src/pxMatrix4T.cpp:28
     #13 0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd38208dc, c=c@entry=0x7fffd38208d8) at pxCore/src/pxMatrix4T.cpp:28
     #14 0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd382090c, c=c@entry=0x7fffd3820908) at pxCore/src/pxMatrix4T.cpp:28
     #15 0x00000000004d0a5b in sincosf (x=<optimized out>, s=s@entry=0x7fffd382094c, c=c@entry=0x7fffd3820948) at pxCore/src/pxMatrix4T.cpp:28
     #16 0x00000000004614bc in pxMatrix4T<float>::rotateInRadians (z=1, y=0, x=0, angle=<optimized out>, this=0x7fffd3820a30) at pxCore/examples/pxScene2d/src/../../../ src/pxMatrix4T.h:209
     #17 pxMatrix4T<float>::rotateInDegrees (z=1, y=0, x=0, angle=<optimized out>, this=0x7fffd3820a30) at pxCore/examples/pxScene2d/src/../../../src/pxMatrix4T.h:180
     #18 pxObject::applyMatrix (this=0x1d3ab80, m=...) at pxCore/examples/pxScene2d/src/pxScene2d.h:499
     #19 0x000000000048b9e1 in pxObject::drawInternal (this=0x1d3ab80, maskPass=maskPass@entry=false) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1253
     #20 0x000000000048bf02 in pxObject::drawInternal (this=0x1cdc790, maskPass=<optimized out>) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1374
     #21 0x000000000048c9d8 in non-virtual thunk to pxScene2d::onDraw() () at pxCore/examples/pxScene2d/src/pxScene2d.cpp:2225
     #22 0x000000000048bad6 in pxObject::drawInternal (this=0x1d0ed70, maskPass=maskPass@entry=false) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1362
     #23 0x000000000048bf02 in pxObject::drawInternal (this=0x1cdc280, maskPass=<optimized out>) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1374
     #24 0x000000000048c9d8 in non-virtual thunk to pxScene2d::onDraw() () at pxCore/examples/pxScene2d/src/pxScene2d.cpp:2225
     #25 0x000000000048bad6 in pxObject::drawInternal (this=0x1c620b0, maskPass=maskPass@entry=false) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1362
     #26 0x000000000048bf02 in pxObject::drawInternal (this=0x1786380, maskPass=<optimized out>) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1374
     #27 0x000000000048c9d8 in non-virtual thunk to pxScene2d::onDraw() () at pxCore/examples/pxScene2d/src/pxScene2d.cpp:2225
     #28 0x00000000004b11e1 in pxWindowNative::drawFrame (this=<optimized out>) at pxCore/src/glut/pxWindowNative.cpp:823
     #29 0x0000000000486df4 in pxScene2d::onUpdate (this=0x1786190, t=1519218877) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:2289
     #30 0x00000000004affb8 in sceneWindow::onAnimationTimer (this=<optimized out>) at pxCore/examples/pxScene2d/src/pxScene.cpp:370
     #31 0x00000000004b063a in pxWindowNative::onGlutTimer (v=<optimized out>) at pxCore/src/glut/pxWindowNative.cpp:310
     #32 0x00007fba9acf92e3 in fghCheckTimers () at /usr/src/debug/freeglut-3.0.0-6.fc27.x86_64/src/fg_main.c:236
     #33 glutMainLoopEvent () at /usr/src/debug/freeglut-3.0.0-6.fc27.x86_64/src/fg_main.c:452
     #34 0x00007fba9acf93d4 in glutMainLoop () at /usr/src/debug/freeglut-3.0.0-6.fc27.x86_64/src/fg_main.c:489
     #35 0x00000000004afb98 in pxMain (argc=<optimized out>, argv=0x7fffd3821458) at pxCore/examples/pxScene2d/src/pxScene.cpp:623
     #36 0x00007fba9a02200a in __libc_start_main (main=0x45b150 <main(int, char**)>, argc=2, argv=0x7fffd3821458, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffd3821448) at ../csu/libc-start.c:308
     #37 0x000000000045b90a in _start ()
    
    Backtrace after (x86_64 platform):
    (gdb) bt
     #0  sincosf () at ../sysdeps/x86_64/fpu/s_sincosf.S:77 <-- built-in version
     #1  0x000000000046150c in pxMatrix4T<float>::rotateInRadians (z=1, y=0, x=0, angle=<optimized out>, this=0x7ffe4b7e1ff0) at pxCore/examples/pxScene2d/src/../../../ src/pxMatrix4T.h:209
     #2  pxMatrix4T<float>::rotateInDegrees (z=1, y=0, x=0, angle=<optimized out>, this=0x7ffe4b7e1ff0) at pxCore/examples/pxScene2d/src/../../../src/pxMatrix4T.h:180
     #3  pxObject::applyMatrix (this=0x340f610, m=...) at pxCore/examples/pxScene2d/src/pxScene2d.h:499
     #4  0x000000000048ba31 in pxObject::drawInternal (this=0x340f610, maskPass=maskPass@entry=false) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1253
     #5  0x000000000048bf52 in pxObject::drawInternal (this=0x3458940, maskPass=maskPass@entry=false) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1374
     #6  0x000000000048bf52 in pxObject::drawInternal (this=0x33b5c30, maskPass=<optimized out>) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1374
     #7  0x000000000048ca28 in non-virtual thunk to pxScene2d::onDraw() () at pxCore/examples/pxScene2d/src/pxScene2d.cpp:2225
     #8  0x000000000048c5f7 in pxObject::createSnapshot (this=this@entry=0x34a92f0, fbo=..., separateContext=separateContext@entry=false, antiAliasing=antiAliasing@entry=false) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1556
     #9  0x000000000048bdb3 in pxObject::drawInternal (this=0x34a92f0, maskPass=maskPass@entry=false) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1343
     #10 0x000000000048bf52 in pxObject::drawInternal (this=0x3484670, maskPass=maskPass@entry=false) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1374
     #11 0x000000000048bf52 in pxObject::drawInternal (this=0x33b5ab0, maskPass=<optimized out>) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1374
     #12 0x000000000048ca28 in non-virtual thunk to pxScene2d::onDraw() () at pxCore/examples/pxScene2d/src/pxScene2d.cpp:2225
     #13 0x000000000048bb26 in pxObject::drawInternal (this=0x3432b50, maskPass=maskPass@entry=false) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1362
     #14 0x000000000048bf52 in pxObject::drawInternal (this=0x33b51a0, maskPass=<optimized out>) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1374
     #15 0x000000000048ca28 in non-virtual thunk to pxScene2d::onDraw() () at pxCore/examples/pxScene2d/src/pxScene2d.cpp:2225
     #16 0x000000000048bb26 in pxObject::drawInternal (this=0x3396d60, maskPass=maskPass@entry=false) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1362
     #17 0x000000000048bf52 in pxObject::drawInternal (this=0x2e444b0, maskPass=<optimized out>) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:1374
     #18 0x000000000048ca28 in non-virtual thunk to pxScene2d::onDraw() () at pxCore/examples/pxScene2d/src/pxScene2d.cpp:2225
     #19 0x00000000004b1231 in pxWindowNative::drawFrame (this=<optimized out>) at pxCore/src/glut/pxWindowNative.cpp:823
     #20 0x0000000000486e44 in pxScene2d::onUpdate (this=0x2e5f7b0, t=1519220497) at pxCore/examples/pxScene2d/src/pxScene2d.cpp:2289
     #21 0x00000000004b0008 in sceneWindow::onAnimationTimer (this=<optimized out>) at pxCore/examples/pxScene2d/src/pxScene.cpp:370
     #22 0x00000000004b068a in pxWindowNative::onGlutTimer (v=<optimized out>) at pxCore/src/glut/pxWindowNative.cpp:310
     #23 0x00007f830a0c72e3 in fghCheckTimers () at /usr/src/debug/freeglut-3.0.0-6.fc27.x86_64/src/fg_main.c:236
     #24 glutMainLoopEvent () at /usr/src/debug/freeglut-3.0.0-6.fc27.x86_64/src/fg_main.c:452
     #25 0x00007f830a0c73d4 in glutMainLoop () at /usr/src/debug/freeglut-3.0.0-6.fc27.x86_64/src/fg_main.c:489
     #26 0x00000000004afbe8 in pxMain (argc=<optimized out>, argv=0x7ffe4b7e2de8) at pxCore/examples/pxScene2d/src/pxScene.cpp:623
     #27 0x00007f83093f000a in __libc_start_main (main=0x45b1a0 <main(int, char**)>, argc=2, argv=0x7ffe4b7e2de8, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7ffe4b7e2dd8) at ../csu/libc-start.c:308
     #28 0x000000000045b95a in _start ()