### PR TITLE
fix error reorder when PX_DIRTY_RECTANGLES is enabled

### DIFF
--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -1618,11 +1618,11 @@ public:
   {
      mPointerHidden= hide;
   }
-  bool mDirty;
   #ifdef PX_DIRTY_RECTANGLES
   pxRect mDirtyRect;
   pxRect mLastFrameDirtyRect;
   #endif //PX_DIRTY_RECTANGLES
+  bool mDirty;
   testView* mTestView;
   bool mDisposed;
   std::vector<rtFunctionRef> mServiceProviders;


### PR DESCRIPTION
Fixes the following compilation errors:

pxCore/examples/pxScene2d/src/pxScene2d.h: In constructor ‘pxScene2d::pxScene2d(bool, pxScriptView*)’:
pxCore/examples/pxScene2d/src/pxScene2d.h:1624:10: error: ‘pxScene2d::mLastFrameDirtyRect’ will be initialized after [-Werror=reorder]
   pxRect mLastFrameDirtyRect;
          ^~~~~~~~~~~~~~~~~~~
pxCore/examples/pxScene2d/src/pxScene2d.h:1621:8: error:   ‘bool pxScene2d::mDirty’ [-Werror=reorder]
   bool mDirty;
        ^~~~~~
pxCore/examples/pxScene2d/src/pxScene2d.cpp:1748:1: error:   when initialized here [-Werror=reorder]
 pxScene2d::pxScene2d(bool top, pxScriptView* scriptView)
 ^~~~~~~~~