### PR TITLE
LSA Ad Cache telemetry requires to print cache expiration print.

### DIFF
--- a/src/rtFileCache.cpp
+++ b/src/rtFileCache.cpp
@@ -245,7 +245,10 @@ rtError rtFileCache::addToCache(const rtHttpCacheData& data)
   if (true != ret)
      return RT_ERROR;
   setFileSizeAndTime(filename);
-  rtLogInfo("addToCache url(%s) filename(%s) size(%ld)", url.cString(), filename.cString(), (long) mFileSizeMap[filename]);
+
+  rtHttpCacheData tempData = data;
+  rtLogInfo("addToCache url(%s) filename(%s) size(%ld) Cache expiration(%s)", url.cString(), filename.cString(), (long) mFileSizeMap[filename], tempData.expirationDate().cString());
+
   mCacheMutex.lock();
   mCurrentSize += mFileSizeMap[filename];
   int64_t size = cleanup();

--- a/src/rtFileCache.cpp
+++ b/src/rtFileCache.cpp
@@ -246,8 +246,7 @@ rtError rtFileCache::addToCache(const rtHttpCacheData& data)
      return RT_ERROR;
   setFileSizeAndTime(filename);
 
-  rtHttpCacheData tempData = data;
-  rtLogInfo("addToCache url(%s) filename(%s) size(%ld) Cache expiration(%s)", url.cString(), filename.cString(), (long) mFileSizeMap[filename], tempData.expirationDate().cString());
+  rtLogInfo("addToCache url(%s) filename(%s) size(%ld) Cache expiration(%s)", url.cString(), filename.cString(), (long) mFileSizeMap[filename], data.expirationDate().cString());
 
   mCacheMutex.lock();
   mCurrentSize += mFileSizeMap[filename];

--- a/src/rtHttpCache.cpp
+++ b/src/rtHttpCache.cpp
@@ -153,7 +153,7 @@ void rtHttpCacheData::populateHeaderMap()
   }
 }
 
-rtString rtHttpCacheData::expirationDate()
+rtString rtHttpCacheData::expirationDate() const
 {
   char buffer[100];
   memset(buffer,0,100);

--- a/src/rtHttpCache.h
+++ b/src/rtHttpCache.h
@@ -38,7 +38,7 @@ class rtHttpCacheData
 
     ~rtHttpCacheData();
     /* returns the expiration date of the cache data in localtime */
-    rtString expirationDate();
+    rtString expirationDate() const;
     time_t expirationDateUnix() const;
 
     /* returns true if cache data is expired */


### PR DESCRIPTION
LSA Ad Cache telemetry requires to print cache expiration print along with Url, filename and size.