### PR TITLE
fixed duk leaks

### DIFF
--- a/src/rtScriptDuk/rtFunctionWrapper.cpp
+++ b/src/rtScriptDuk/rtFunctionWrapper.cpp
@@ -49,6 +49,16 @@ static duk_ret_t dukFunctionStub(duk_context *ctx)
 }
 
 
+static duk_ret_t dukFunctionFinalizer(duk_context *ctx) 
+{
+   bool res = duk_get_prop_string(ctx, 0, "\xff""\xff""data");
+   if (res) {
+      rtIFunction* func = (rtIFunction*)duk_require_pointer(ctx, -1);
+      func->Release();
+      duk_del_prop_string(ctx, 0, "\xff""\xff""data");
+   }
+}
+
 void rtFunctionWrapper::createFromFunctionReference(duk_context *ctx, const rtFunctionRef& func)
 {
   duk_idx_t objidx = duk_push_c_function(ctx, &dukFunctionStub, DUK_VARARGS);
@@ -59,6 +69,9 @@ void rtFunctionWrapper::createFromFunctionReference(duk_context *ctx, const rtFu
   func->AddRef();
 
   // [func]
+
+  duk_push_c_function(ctx, dukFunctionFinalizer, 1);
+  duk_set_finalizer(ctx, objidx);
 }
 
 jsFunctionWrapper::~jsFunctionWrapper()

--- a/src/rtScriptDuk/rtObjectWrapper.cpp
+++ b/src/rtScriptDuk/rtObjectWrapper.cpp
@@ -539,28 +539,8 @@ void rtObjectWrapper::createFromObjectReference(duk_context *ctx, const rtObject
     {
       rtError err = const_cast<rtObjectRef &>(ref).sendReturns<rtString>("description", desc);
 
-
-
       if (err == RT_OK && strcmp(desc.cString(), "rtPromise") == 0)
       {
-        #if 1
-        rtString val;
-        ref.get("promiseId", val);
-
-        if (!val.isEmpty()) {
-          duk_bool_t rt = duk_get_global_string(ctx, val.cString());
-
-          assert(rt);
-
-          // [js-promise]
-          assert(duk_is_object(ctx, -1));
-          return;
-        }
-        #else
-        if (!ref.get<rtString>("promiseId").isEmpty())
-          return;
-        #endif
-
         duk_bool_t rt = duk_get_global_string(ctx, "constructPromise");
         // [func] 
         assert(rt);
@@ -574,21 +554,9 @@ void rtObjectWrapper::createFromObjectReference(duk_context *ctx, const rtObject
           assert(0);
         }
 
-#if 1
-#if 1
         // [js-promise]
         assert(duk_is_object(ctx, -1));
 
-        duk_dup(ctx, -1);
-
-        // [ obj ]
-        std::string promiseObjName = rtDukPutIdentToGlobal(ctx);
- 
-        const_cast<rtObjectRef &>(ref).set("promiseId", rtString(promiseObjName.c_str()));
-#else
-        const_cast<rtObjectRef &>(ref).set("promiseId", "blah");  
-#endif
-#endif
         return;
       }
     }


### PR DESCRIPTION
I've fixed two leaks,
one of which valgrind showed as definite loss.

1) in rtFunctionWrapper.cpp
there was a leak of function reference,
became quite actual after js-proxy support
(frequent returning object methods via rtObject->Get())

2) in rtObjectWrapper.cpp there was a promise leak into global space,
old code for returning already constructed promise via promiseId
is deprecated because of proxy support (now we are wrapping promise directly via proxy
and not indirectly via promiseId variable in global namespace)

I've not added rtClearAllGlobalIdents anywhere, 
it must be called on application exit, rtScript.term() is empty inside and is not called,
so do we need to care that much for proper shutdown?

finalizer for objects under proxy is calling ok, I've checked.
