### PR TITLE
fix 'strict-aliasing' compilation errors and typo in pxClamp usage

### DIFF
--- a/examples/pxScene2d/src/rasterizer/pxRasterizer.cpp
+++ b/examples/pxScene2d/src/rasterizer/pxRasterizer.cpp
@@ -1,9 +1,25 @@
 #include "pxTimer.h"
 #include "pxRasterizer.h"
 
-#include "xs_Core.h"
-#include "xs_Float.h"
+#ifdef XS_CODE_ENABLED
+#  include "xs_Core.h"
+#  include "xs_Float.h"
+#else
+#  include <cstdint>
+#  include <math.h>
+   inline int32_t xs_RoundToInt(const double d)
+   {
+     return floor(d + 0.5);
+   }
+
+   inline int32_t xs_CRoundToInt(const double d)
+   {
+     return ceil(d);
+   }
+#endif
+
 //#include "rtLog.h"
+
 
 #include <algorithm>
 
@@ -2374,7 +2390,7 @@ inline pxPixel* pxRasterizer::getTextureSample(int32_t maxU, int32_t maxV, int32
     else
     {
       texU = pxClamp<int32_t>(curU, 0, maxU);
-      texV = pxClamp<int32>(curV, 0, maxV);
+      texV = pxClamp<int32_t>(curV, 0, maxV);
       texU = texU>>UVFIXEDSHIFT;
       texV = texV>>UVFIXEDSHIFT;
     }


### PR DESCRIPTION
Compiler output:
  pxCore/examples/pxScene2d/src/rasterizer/xs_code/xs_Float.h: In function ‘int32 xs_CRoundToInt(real64, real64)’:
  pxCore/examples/pxScene2d/src/rasterizer/xs_code/xs_Float.h:349:33: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
    return ((int32*)&val)[_xs_iman_];
                                 ^
Note: The 'xs_code' seems to be complete broken e.g.

  typedef long uint32; // <- uint32 will not have 32-bits on x86-64!!!

then uses something like the following:

  double val;
  return ((int32*)&val)[1]; // <- on 64-bit Big Endian platforms it will read random memory

thus it seems to be simpler to not use 'xs_code' at all.

The fix adds XS_CODE_ENABLED which, by default do not use implementation
from 'xs_code' and, provides equivalent implementation of two function
which were effectively used from the 'xs_code':

  int32_t xs_RoundToInt(const double d);
  int32_t xs_CRoundToInt(const double d);