### PR TITLE
fix 'pessimizing-move' compiler errors

### DIFF
--- a/remote/rtRemoteConfigGen.cpp
+++ b/remote/rtRemoteConfigGen.cpp
@@ -165,7 +165,7 @@ static std::set<ConfigItem> buildConfigItems(rapidjson::Value const& configParam
       configItems.insert(item);
     }
   });
-  return std::move(configItems);
+  return configItems;
 }
 
 


### PR DESCRIPTION
pxCore/remote/rtRemoteConfigGen.cpp:168:10: error: moving a local object in a return statement prevents copy elision [-Werror,-Wpessimizing-move]
  return std::move(configItems);
         ^