### PR TITLE
fix 'overloaded-virtual' compilation errors

### DIFF
--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -513,14 +513,18 @@ public:
       return RT_PROP_NOT_FOUND;
   }
 
-  virtual rtError Set(const char* /*name*/, const rtValue* /*value*/)
+  virtual rtError Set(const char* name, const rtValue* value)
   {
+    std::ignore = name;
+    std::ignore = value;
     // readonly property
     return RT_PROP_NOT_FOUND;
   }
 
-  virtual rtError Set(uint32_t /*i*/, const rtValue* /*value*/)
+  virtual rtError Set(uint32_t i, const rtValue* value)
   {
+    std::ignore = i;
+    std::ignore = value;
     // readonly property
     return RT_PROP_NOT_FOUND;
   }
@@ -657,6 +661,14 @@ rtError pxObject::setFocus(bool v)
     return mScene->setFocus(NULL);
   }
 
+}
+
+rtError pxObject::Set(uint32_t i, const rtValue* value)
+{
+  std::ignore = i;
+  std::ignore = value;
+  rtLogError("pxObject::Set(uint32_t, const rtValue*) - not implemented");
+  return RT_ERROR_NOT_IMPLEMENTED;
 }
 
 rtError pxObject::Set(const char* name, const rtValue* value)

--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -255,7 +255,8 @@ public:
     return RT_OK;
   }
 
-  virtual rtError Set(const char* name, const rtValue* value);
+  virtual rtError Set(uint32_t i, const rtValue* value) override;
+  virtual rtError Set(const char* name, const rtValue* value) override;
 
   rtError getChild(uint32_t i, rtObjectRef& r) const
   {
@@ -1647,10 +1648,10 @@ class pxScene2dRef: public rtRef<pxScene2d>, public rtObjectBase
   pxScene2dRef& operator=(pxScene2d* s) { asn(s); return *this; }
   
  private:
-  virtual rtError Get(const char* name, rtValue* value) const;
-  virtual rtError Get(uint32_t i, rtValue* value) const;
-  virtual rtError Set(const char* name, const rtValue* value);
-  virtual rtError Set(uint32_t i, const rtValue* value);
+  virtual rtError Get(const char* name, rtValue* value) const override;
+  virtual rtError Get(uint32_t i, rtValue* value) const override;
+  virtual rtError Set(const char* name, const rtValue* value) override;
+  virtual rtError Set(uint32_t i, const rtValue* value) override;
 };
 
 

--- a/examples/pxScene2d/src/pxText.h
+++ b/examples/pxScene2d/src/pxText.h
@@ -73,7 +73,15 @@ public:
   virtual void update(double t);
   virtual void onInit();
   
-  virtual rtError Set(const char* name, const rtValue* value)
+  virtual rtError Set(uint32_t i, const rtValue* value) override
+  {
+    std::ignore = i;
+    std::ignore = value;
+    rtLogError("pxText::Set(uint32_t, const rtValue*) - not implemented");
+    return RT_ERROR_NOT_IMPLEMENTED;
+  }
+
+  virtual rtError Set(const char* name, const rtValue* value) override
   {
     //rtLogInfo("pxText::Set %s\n",name);
 #if 1

--- a/examples/pxScene2d/src/pxTextBox.h
+++ b/examples/pxScene2d/src/pxTextBox.h
@@ -246,7 +246,15 @@ public:
   rtMethodNoArgAndReturn("measureText", measureText, rtObjectRef);
   rtError measureText(rtObjectRef& o); 
 
-  virtual rtError Set(const char* name, const rtValue* value)
+  virtual rtError Set(uint32_t i, const rtValue* value) override
+  {
+    std::ignore = i;
+    std::ignore = value;
+    rtLogError("pxTextBox::Set(uint32_t, const rtValue*) - not implemented");
+    return RT_ERROR_NOT_IMPLEMENTED;
+  }
+
+  virtual rtError Set(const char* name, const rtValue* value) override
   {
 	  //rtLogDebug("pxTextBox Set for %s\n", name );
 

--- a/src/rtObject.h
+++ b/src/rtObject.h
@@ -312,7 +312,7 @@ public:
 
   virtual rtError Get(uint32_t /*i*/, rtValue* /*value*/) const;
   virtual rtError Get(const char* name, rtValue* value) const;
-  virtual rtError Set(uint32_t /*i*/, const rtValue* /*value*/);
+  virtual rtError Set(uint32_t i, const rtValue* value);
   virtual rtError Set(const char* name, const rtValue* value);
 
 protected:

--- a/tests/pxScene2d/test_pxImage.cpp
+++ b/tests/pxScene2d/test_pxImage.cpp
@@ -23,8 +23,10 @@ class MockImageResource : public rtImageResource {
 
     MockImageResource(const char* url = 0) { setUrl(IMAGE_URL); UNUSED_PARAM(url); }
 
-    rtError w(int32_t& v) const { v = IMAGE_WIDTH; return RT_OK;}
-    rtError h(int32_t& v) const { v = IMAGE_HEIGHT; return RT_OK; }
+    rtError w(int32_t& v) const override { v = IMAGE_WIDTH; return RT_OK;}
+    rtError h(int32_t& v) const override { v = IMAGE_HEIGHT; return RT_OK; }
+    int32_t w() const override { return IMAGE_WIDTH;}
+    int32_t h() const override { return IMAGE_HEIGHT;}
     rtError description(rtString& d) const { d = "rtImageResource"; return RT_OK; }
 };
 


### PR DESCRIPTION
Log excerpt:

In file included from pxCore/examples/pxScene2d/src/pxScene2d.h:42:0,
                 from pxCore/examples/pxScene2d/src/pxFont.h:31,
                 from pxCore/examples/pxScene2d/src/pxFont.cpp:22:
pxCore/examples/pxScene2d/src/../../../src/rtObject.h:315:19: error: ‘virtual rtError rtObject::Set(uint32_t, const rtValue*)’ was hidden [-Werror=overloaded-virtual]
   virtual rtError Set(uint32_t /*i*/, const rtValue* /*value*/);
                   ^~~
In file included from pxCore/examples/pxScene2d/src/pxFont.cpp:24:0:
pxCore/examples/pxScene2d/src/pxText.h:75:19: error:   by ‘virtual rtError pxText::Set(const char*, const rtValue*)’ [-Werror=overloaded-virtual]
   virtual rtError Set(const char* name, const rtValue* value)
                   ^~~
cc1plus: all warnings being treated as errors
make[2]: *** [examples/pxScene2d/src/CMakeFiles/pxscene_app.dir/build.make:135: examples/pxScene2d/src/CMakeFiles/pxscene_app.dir/pxFont.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from pxCore/examples/pxScene2d/src/pxScene2d.h:42:0,
                 from pxCore/examples/pxScene2d/src/pxText.h:30,
                 from pxCore/examples/pxScene2d/src/pxText.cpp:21:
pxCore/examples/pxScene2d/src/../../../src/rtObject.h:315:19: error: ‘virtual rtError rtObject::Set(uint32_t, const rtValue*)’ was hidden [-Werror=overloaded-virtual]
   virtual rtError Set(uint32_t /*i*/, const rtValue* /*value*/);
                   ^~~
In file included from pxCore/examples/pxScene2d/src/pxText.cpp:21:0:
pxCore/examples/pxScene2d/src/pxText.h:75:19: error:   by ‘virtual rtError pxText::Set(const char*, const rtValue*)’ [-Werror=overloaded-virtual]
   virtual rtError Set(const char* name, const rtValue* value)
                   ^~~
cc1plus: all warnings being treated as errors
make[2]: *** [examples/pxScene2d/src/CMakeFiles/pxscene_app.dir/build.make:159: examples/pxScene2d/src/CMakeFiles/pxscene_app.dir/pxText.cpp.o] Error 1
In file included from pxCore/examples/pxScene2d/src/pxConstants.h:27:0,
                 from pxCore/examples/pxScene2d/src/pxTextBox.cpp:21:
pxCore/examples/pxScene2d/src/../../../src/rtObject.h:315:19: error: ‘virtual rtError rtObject::Set(uint32_t, const rtValue*)’ was hidden [-Werror=overloaded-virtual]
   virtual rtError Set(uint32_t /*i*/, const rtValue* /*value*/);
                   ^~~
In file included from pxCore/examples/pxScene2d/src/pxTextBox.cpp:22:0:
pxCore/examples/pxScene2d/src/pxText.h:75:19: error:   by ‘virtual rtError pxText::Set(const char*, const rtValue*)’ [-Werror=overloaded-virtual]
   virtual rtError Set(const char* name, const rtValue* value)