### PR TITLE
fix error: unused variable ‘eDisplay’

### DIFF
--- a/src/essos/pxWindowNative.cpp
+++ b/src/essos/pxWindowNative.cpp
@@ -475,7 +475,6 @@ void pxWindowNative::runEventLoop()
 {
     exitFlag = false;
     displayRef dRef;
-    essosDisplay* eDisplay = dRef.getDisplay();
     std::vector<pxWindowNative*> windowVector = pxWindowNative::getNativeWindows();
 
     int framerate = ESSOS_PX_CORE_FPS;


### PR DESCRIPTION
Compiler output:
pxCore/src/essos/pxWindowNative.cpp: In static member function ‘static void pxWindowNative::runEventLoop()’:
pxCore/src/essos/pxWindowNative.cpp:478:19: error: unused variable ‘eDisplay’ [-Werror=unused-variable]
     essosDisplay* eDisplay = dRef.getDisplay();
                   ^~~~~~~~