### PR TITLE
Do not call checkStretch in setResource

### DIFF
--- a/examples/pxScene2d/src/pxImage.cpp
+++ b/examples/pxScene2d/src/pxImage.cpp
@@ -192,7 +192,7 @@ float pxImage::getOnscreenHeight()
 void pxImage::draw() {
   //rtLogDebug("pxImage::draw() mw=%f mh=%f\n", mw, mh);
   static pxTextureRef nullMaskRef;
-  if (getImageResource() != NULL)
+  if (getImageResource() != NULL && getImageResource()->isInitialized())
   {
     context.drawImage(0, 0,
                       getOnscreenWidth(),
@@ -208,13 +208,14 @@ void pxImage::draw() {
 }
 void pxImage::resourceReady(rtString readyResolution)
 {
-  checkStretchX();
-  checkStretchY();
+
   //rtLogDebug("pxImage::resourceReady(%s) mInitialized=%d for \"%s\"\n",readyResolution.cString(),mInitialized,getImageResource()->getUrl().cString());
   if( !readyResolution.compare("resolve"))
   {
     imageLoaded = true; 
     pxObject::onTextureReady();
+    checkStretchX();
+    checkStretchY();
     // Now that image is loaded, must force redraw;
     // dimensions could have changed.
     mScene->mDirty = true;
@@ -244,7 +245,7 @@ void pxImage::dispose(bool pumpJavascript)
 void pxImage::checkStretchX()
 {
   rtImageResource* imageResource = getImageResource();
-  if (mStretchX == pxConstantsStretch::REPEAT && imageResource != NULL)
+  if (mStretchX == pxConstantsStretch::REPEAT && imageResource != NULL && imageResource->isInitialized())
   {
     pxTextureRef texture = imageResource->getTexture();
     if (texture.getPtr() != NULL && (!isPowerOfTwo(texture->width()) || !isPowerOfTwo(texture->height())))
@@ -257,7 +258,7 @@ void pxImage::checkStretchX()
 void pxImage::checkStretchY()
 {
   rtImageResource* imageResource = getImageResource();
-  if (mStretchY == pxConstantsStretch::REPEAT && imageResource != NULL)
+  if (mStretchY == pxConstantsStretch::REPEAT && imageResource != NULL && imageResource->isInitialized())
   {
     pxTextureRef texture = imageResource->getTexture();
     if (texture.getPtr() != NULL && (!isPowerOfTwo(texture->width()) || !isPowerOfTwo(texture->height())))

--- a/examples/pxScene2d/src/pxImage.cpp
+++ b/examples/pxScene2d/src/pxImage.cpp
@@ -91,8 +91,6 @@ rtError pxImage::setResource(rtObjectRef o)
       pxObject::createNewPromise();
       mListenerAdded = true;
       getImageResource()->addListener(this);
-      checkStretchX();
-      checkStretchY();
     }
     return RT_OK; 
   } 

--- a/examples/pxScene2d/src/pxImage9.cpp
+++ b/examples/pxScene2d/src/pxImage9.cpp
@@ -158,7 +158,7 @@ float pxImage9::getOnscreenHeight()
 
 
 void pxImage9::draw() {
-  if (getImageResource() != NULL)
+  if (getImageResource() != NULL && getImageResource()->isInitialized())
   {
     context.drawImage9(mw, mh, mInsetLeft, mInsetTop, mInsetRight, mInsetBottom, getImageResource()->getTexture());
   }

--- a/examples/pxScene2d/src/pxImage9Border.cpp
+++ b/examples/pxScene2d/src/pxImage9Border.cpp
@@ -40,7 +40,7 @@ pxImage9Border::~pxImage9Border()
 }
 
 void pxImage9Border::draw() {
-  if (getImageResource() != NULL)
+  if (getImageResource() != NULL && getImageResource()->isInitialized())
   {
     context.drawImage9Border(mw, mh, mBorderLeft, mBorderTop, mBorderRight, mBorderBottom, mInsetLeft, mInsetTop, mInsetRight, mInsetBottom,
                              mDrawCenter, mMaskColor, getImageResource()->getTexture());

--- a/examples/pxScene2d/src/pxImageA.cpp
+++ b/examples/pxScene2d/src/pxImageA.cpp
@@ -237,10 +237,6 @@ rtError pxImageA::setResource(rtObjectRef o)
       pxObject::createNewPromise();
       mListenerAdded = true;
       getImageAResource()->addListener(this);
-#if 0
-      checkStretchX();
-      checkStretchY();
-#endif //0
     }
     return RT_OK;
   }

--- a/examples/pxScene2d/src/pxResource.cpp
+++ b/examples/pxScene2d/src/pxResource.cpp
@@ -317,9 +317,9 @@ rtError rtImageResource::h(int32_t& v) const
   return RT_OK; 
 }
 
-pxTextureRef rtImageResource::getTexture()
+pxTextureRef rtImageResource::getTexture(bool initializing)
 {
-  if (!mTexture.getPtr())
+  if (!mTexture.getPtr() && (isInitialized() || initializing))
   {
     mTextureMutex.lock();
     if (mCompressedData != NULL)
@@ -370,7 +370,7 @@ void rtImageResource::clearDownloadedData()
 
 void rtImageResource::setupResource()
 {
-  getTexture();
+  getTexture(true);
   init();
 }
 

--- a/examples/pxScene2d/src/pxResource.h
+++ b/examples/pxScene2d/src/pxResource.h
@@ -144,7 +144,7 @@ public:
   virtual int32_t h() const;
   virtual rtError h(int32_t& v) const; 
 
-  pxTextureRef getTexture();
+  pxTextureRef getTexture(bool initializing = false);
   void setTextureData(pxOffscreen& imageOffscreen, const char* data, const size_t dataSize);
   virtual void setupResource();
   void clearDownloadedData();


### PR DESCRIPTION
checkStretchX/Y should be protected by null checks, but it's too soon to try calling them in setResource.