### PR TITLE
fix error: unused variable ‘i’

### DIFF
--- a/src/rtObject.cpp
+++ b/src/rtObject.cpp
@@ -95,7 +95,7 @@ rtError rtEmit::delListener(const char* eventName, rtIFunction* f)
 {
   if (!eventName || !f)
     return RT_ERROR;
-  int i = 0;
+
   for (vector<_rtEmitEntry>::iterator it = mEntries.begin(); 
        it != mEntries.end(); it++)
   {


### PR DESCRIPTION
Fixes:

pxCore/src/rtObject.cpp: In member function ‘rtError rtEmit::delListener(const char*, rtIFunction*)’:
pxCore/src/rtObject.cpp:98:7: error: unused variable ‘i’ [-Werror=unused-variable]
   int i = 0;
       ^
cc1plus: all warnings being treated as errors