### PR TITLE
fix error: invalid new-expression of abstract class type ‘rtRemoteFun…

### DIFF
--- a/remote/rtRemoteFunction.cpp
+++ b/remote/rtRemoteFunction.cpp
@@ -9,6 +9,7 @@ rtRemoteFunction::rtRemoteFunction(std::string const& id, std::string const& nam
   , m_name(name)
   , m_client(client)
   , m_timeout(client->getEnvironment()->Config->environment_request_timeout())
+  , m_Hash(0)
 {
   if (!strcmp(id.c_str(), "global"))
   {
@@ -53,4 +54,16 @@ rtRemoteFunction::Release()
 
   // TODO: send deref here
   return n;
+}
+
+size_t
+rtRemoteFunction::hash()
+{
+  return m_Hash;
+}
+
+void
+rtRemoteFunction::setHash(size_t hash)
+{
+  m_Hash = hash;
 }

--- a/remote/rtRemoteFunction.h
+++ b/remote/rtRemoteFunction.h
@@ -26,12 +26,16 @@ public:
   inline std::string const& getName() const
     { return m_name; }
 
+  virtual size_t hash();
+  virtual void setHash(size_t hash);
+
 private:
   rtAtomic                          m_ref_count;
   std::string                       m_id;
   std::string                       m_name;
   std::shared_ptr<rtRemoteClient>   m_client;
   uint32_t                          m_timeout;
+  size_t                            m_Hash;
 };
 
 #endif


### PR DESCRIPTION
…ction’

Fixes:

remote/rtRemoteValueReader.cpp: In static member function ‘static rtError rtRemoteValueReader::read(rtRemoteEnvironment*, rtValue&, const Value&, const std::shared_ptr<rtRemoteClient>&)’:
remote/rtRemoteValueReader.cpp:169:75: error: invalid new-expression of abstract class type ‘rtRemoteFunction’
           to.setFunction(new rtRemoteFunction(objectId, functionId, client));
                                                                           ^
In file included from remote/rtRemoteValueReader.cpp:5:0:
remote/rtRemoteFunction.h:11:7: note:   because the following virtual functions are pure within ‘rtRemoteFunction’:
 class rtRemoteFunction : public rtIFunction
       ^~~~~~~~~~~~~~~~
In file included from remote/rtRemoteObjectCache.h:8:0,
                 from remote/rtRemoteValueReader.cpp:2:
remote/../src/rtObject.h:63:20: note: 	virtual size_t rtIFunction::hash()
     virtual size_t hash() = 0;
                    ^~~~
remote/../src/rtObject.h:64:18: note: 	virtual void rtIFunction::setHash(size_t)
     virtual void setHash(size_t) = 0;
                  ^~~~~~~