### PR TITLE
fix error: unused variable ‘listenerCountBeforeAdd’ (re-enable assert…

### DIFF
--- a/tests/pxScene2d/test_rtObject.cpp
+++ b/tests/pxScene2d/test_rtObject.cpp
@@ -56,7 +56,7 @@ class rtEmitTest : public testing::Test
       rtString event("eventone");
       size_t listenerCountBeforeAdd = mEmit->mEntries.size();
       EXPECT_TRUE (RT_OK == mEmit->addListener(event.cString(),&fnCallback));
-      //EXPECT_TRUE (listenerCountBeforeAdd == mEmit->mEntries.size());
+      EXPECT_TRUE (listenerCountBeforeAdd /* TODO: remove +1 */ + 1 == mEmit->mEntries.size());
     }
 
     void delListenerTest()


### PR DESCRIPTION
…ion)

TODO: it just fixes the compilation issue the implementation should be fixed independently

Fixes:

tests/pxScene2d/test_rtObject.cpp: In member function ‘void rtEmitTest::addListenerDuplicateEventTest()’:
tests/pxScene2d/test_rtObject.cpp:57:14: error: unused variable ‘listenerCountBeforeAdd’ [-Werror=unused-variable]
       size_t listenerCountBeforeAdd = mEmit->mEntries.size();
              ^~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors