### PR TITLE
make it easier to run pxscene2dtests.sh under debugger

### DIFF
--- a/tests/pxScene2d/pxscene2dtests.sh
+++ b/tests/pxScene2d/pxscene2dtests.sh
@@ -53,7 +53,7 @@ ln -s ../../examples/pxScene2d/src/FreeSans.ttf FreeSans.ttf
 ln -s ../../examples/pxScene2d/src/package.json package.json
 ln -s ../../examples/pxScene2d/src/pxscenepermissions.conf pxscenepermissions.conf
 
-./pxscene2dtests
+${DBG} ./pxscene2dtests "$@"
 
 #remove temporary files created for running js files from unittests
 rm -rf shell.js


### PR DESCRIPTION
Example:
	$ GDB=gdb ./pxscene2dtests.sh
or
	$ GDB=ddd ./pxscene2dtests.sh