### PR TITLE
fix '-Werror,-Wsign-compare' compilation errors

### DIFF
--- a/src/rtObject.cpp
+++ b/src/rtObject.cpp
@@ -72,7 +72,7 @@ rtError rtEmit::addListener(const char* eventName, rtIFunction* f)
     _rtEmitEntry& e = (*it);
     // mHash check for javscript events callback 
     // markForDelete check is added to handle scenario where same handler is deleted and added immediately in same handler
-    if (e.n == eventName && ((e.f.getPtr() == f) || ((f->hash() != -1) && (e.fnHash == f->hash()) && (false == e.markForDelete))) && !e.isProp)
+    if (e.n == eventName && ((e.f.getPtr() == f) || ((f->hash() != (size_t)-1) && (e.fnHash == f->hash()) && (false == e.markForDelete))) && !e.isProp)
     {
       found = true;
       break;


### PR DESCRIPTION
Fixes the following issues:
src/rtObject.cpp:74:65: error: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'int' [-Werror,-Wsign-compare]
    if (e.n == eventName && ((e.f.getPtr() == f) || ((f->hash() != -1) && (e.fnHash == f->hash()))) && !e.isProp)
                                                      ~~~~~~~~~ ^  ~~
src/rtObject.cpp:103:58: error: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Werror,-Wsign-compare]
    if (e.n == eventName && ((e.f.getPtr() == f) || ((-1 != e.fnHash) && (e.fnHash == f->hash()))) && !e.isProp)
                                                      ~~ ^  ~~~~~~~~