### PR TITLE
fix AddressSanitizer: stack-buffer-overflow (too small sscanf buffer)

### DIFF
--- a/examples/pxScene2d/src/rasterizer/pxPath.cpp
+++ b/examples/pxScene2d/src/rasterizer/pxPath.cpp
@@ -214,6 +214,8 @@ void updatePen(float px, float py)
 }
 
 #define is_relative(xx) (islower(xx))
+#define STRINGIFY_HELPER(x) #x
+#define STRINGIFY(X) STRINGIFY_HELPER(X)
 
 /*static*/ rtError pxPath::parsePath(const char *d, pxPath *p /*= NULL*/ )
 {
@@ -225,7 +227,8 @@ void updatePen(float px, float py)
   }
 //  printf("\nPath:   [%s] ", s); // DEBUG
 
-  char poly_str[16]; // 15+1 for '\0'
+# define POLY_LENGTH 15
+  char poly_str[POLY_LENGTH+1]; // 15+1 for '\0'
   
   float x0 = 0, y0 = 0, x1 = 0, y1 = 0, x2 = 0, y2 = 0, rx = 0, ry = 0, w = 0, h = 0;
   float last_x2 = 0.0, last_y2 = 0.0, xrot, r = 0;
@@ -588,7 +591,7 @@ void updatePen(float px, float py)
     }
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     else // <polygon points="200,10 250,190 160,210"/>
-    if ( sscanf(s, "%[POLYGON points:]s",&poly_str[0]) == 1)
+    if ( sscanf(s, "%" STRINGIFY(POLY_LENGTH) "[POLYGON points:]s", &poly_str[0]) == 1)
     {
       std::vector<float> points;
       float pt;


### PR DESCRIPTION
Fixes the following stack-buffer-overflow:
 ==27779==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fff59785fa0 at pc 0x7f7b354ffeda bp 0x7fff59785760 sp 0x7fff59784ee8
 WRITE of size 17 at 0x7fff59785fa0 thread T0
    #0 0x7f7b354ffed9  (/lib64/libasan.so.4+0x62ed9)
    #1 0x7f7b3550092a in vsscanf (/lib64/libasan.so.4+0x6392a)
    #2 0x7f7b35500a26 in __interceptor_sscanf (/lib64/libasan.so.4+0x63a26)
    #3 0x59f20d in pxPath::parsePath(char const*, pxPath*) /home/sw/projects/pxscene/pxCore/examples/pxScene2d/src/rasterizer/pxPath.cpp:591
    #4 0x59acf0 in pxPath::setPath(rtString) /home/sw/projects/pxscene/pxCore/examples/pxScene2d/src/rasterizer/pxPath.cpp:201
    #5 0x5a3273 in pxPath::setPath_PropSetterThunk(rtValue const&) /home/sw/projects/pxscene/pxCore/examples/pxScene2d/src/rasterizer/pxPath.h:69
    #6 0x75c8a5 in rtObject::Set(char const*, rtValue const*) /home/sw/projects/pxscene/pxCore/src/rtObject.cpp:425
    #7 0x5ae279 in pxObject::Set(char const*, rtValue const*) /home/sw/projects/pxscene/pxCore/examples/pxScene2d/src/pxScene2d.cpp:683
    #8 0x75f4a1 in rtObjectRef::Set(char const*, rtValue const*) /home/sw/projects/pxscene/pxCore/src/rtObject.cpp:589
    #9 0x52ab93 in rtObjectBase::set(char const*, rtValue const&) /home/sw/projects/pxscene/pxCore/examples/pxScene2d/src/../../../src/rtObject.h:87
    #10 0x75ccc2 in rtObjectBase::set(rtObjectRef) /home/sw/projects/pxscene/pxCore/src/rtObject.cpp:456
    #11 0x5bd097 in pxScene2d::createPath(rtObjectRef, rtObjectRef&) /home/sw/projects/pxscene/pxCore/examples/pxScene2d/src/pxScene2d.cpp:2124
    #12 0x5bb0eb in pxScene2d::create(rtObjectRef, rtObjectRef&) /home/sw/projects/pxscene/pxCore/examples/pxScene2d/src/pxScene2d.cpp:2010
    #13 0x5f2c27 in pxScene2d::create_thunk(int, rtValue const*, rtValue&) (/home/sw/projects/pxscene/pxCore/examples/pxScene2d/src/pxscene+0x5f2c27)
    #14 0x75f79f in rtObjectFunction::Send(int, rtValue const*, rtValue*) /home/sw/projects/pxscene/pxCore/src/rtObject.cpp:605
    #15 0x6eadc7 in rtScriptNodeUtils::rtFunctionWrapper::call(v8::FunctionCallbackInfo<v8::Value> const&) /home/sw/projects/pxscene/pxCore/src/rtScriptNode/rtFunctionWrapper.cpp:245
    #16 0x7f7b34158321 in v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&)) (/lib64/libnode8-shared.so.57+0x6af321)
    #17 0x7f7b341c25a5  (/lib64/libnode8-shared.so.57+0x7195a5)
    #18 0x7f7b008042fc  (<unknown module>)

 Address 0x7fff59785fa0 is located in stack of thread T0 at offset 1616 in frame
    #0 0x59ad69 in pxPath::parsePath(char const*, pxPath*) /home/sw/projects/pxscene/pxCore/examples/pxScene2d/src/rasterizer/pxPath.cpp:219

  This frame has 25 object(s):
    [32, 36) 'x0'
    [96, 100) 'y0'
    [160, 164) 'x1'
    [224, 228) 'y1'
    [288, 292) 'x2'
    [352, 356) 'y2'
    [416, 420) 'rx'
    [480, 484) 'ry'
    [544, 548) 'w'
    [608, 612) 'h'
    [672, 676) 'xrot'
    [736, 740) 'r'
    [800, 804) 'n'
    [864, 868) 'lflag'
    [928, 932) 'sflag'
    [992, 996) 'pt'
    [1056, 1064) 'it'
    [1120, 1128) '<unknown>'
    [1184, 1192) 'end'
    [1248, 1256) '<unknown>'
    [1312, 1336) 'points'
    [1376, 1424) 'c'
    [1472, 1496) 'ans'
    [1536, 1538) 'op'
    [1600, 1616) 'poly_str' <== Memory access at offset 1616 overflows this variable
 HINT: this may be a false positive if your program uses some custom stack unwind mechanism or swapcontext
      (longjmp and C++ exceptions *are* supported)
 SUMMARY: AddressSanitizer: stack-buffer-overflow (/lib64/libasan.so.4+0x62ed9)
 Shadow bytes around the buggy address:
  0x10006b2e8ba0: f2 f2 f2 f2 f2 f2 04 f2 f2 f2 f2 f2 f2 f2 00 f2
  0x10006b2e8bb0: f2 f2 f2 f2 f2 f2 00 f2 f2 f2 f2 f2 f2 f2 00 f2
  0x10006b2e8bc0: f2 f2 f2 f2 f2 f2 00 f2 f2 f2 f2 f2 f2 f2 00 00
  0x10006b2e8bd0: 00 f2 f2 f2 f2 f2 00 00 00 00 00 00 f2 f2 f2 f2
  0x10006b2e8be0: f2 f2 00 00 00 f2 f2 f2 f2 f2 02 f2 f2 f2 f2 f2
=>0x10006b2e8bf0: f2 f2 00 00[f2]f2 00 00 00 00 00 00 00 00 00 00
  0x10006b2e8c00: 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1 00 f2
  0x10006b2e8c10: f2 f2 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006b2e8c20: 00 00 00 00 00 00 f1 f1 f1 f1 00 00 f2 f2 00 00
  0x10006b2e8c30: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10006b2e8c40: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==27779==ABORTING