### PR TITLE
fix -Wsign-compare (and some of -Wunused-parameter) errors

### DIFF
--- a/src/rtError.h
+++ b/src/rtError.h
@@ -64,7 +64,7 @@
 #define RT_ERROR_CORS_NO_HEADER 2001
 #define RT_ERROR_CORS_ORIGIN_MISMATCH 2002
 
-typedef uint32_t rtError;
+typedef int rtError;
 
 const char* rtStrError(rtError e);
 

--- a/src/rtObject.cpp
+++ b/src/rtObject.cpp
@@ -109,7 +109,7 @@ rtError rtEmit::delListener(const char* eventName, rtIFunction* f)
        it != mEntries.end(); it++)
   {
     _rtEmitEntry& e = (*it);
-    if (e.n == eventName && ((e.f.getPtr() == f) || ((-1 != e.fnHash) && (e.fnHash == f->hash()))) && !e.isProp)
+    if (e.n == eventName && ((e.f.getPtr() == f) || (((size_t)-1 != e.fnHash) && (e.fnHash == f->hash()))) && !e.isProp)
     {
       // if no events is being processed currently, remove the event entries
       if (!mProcessingEvents)

--- a/tests/pxScene2d/test_jsfiles.cpp
+++ b/tests/pxScene2d/test_jsfiles.cpp
@@ -61,6 +61,7 @@ class sceneWindow : public pxWindow, public pxIViewContainer
       mWidth = w;
       mHeight = h;
       pxWindow::init(x,y,w,h);
+      std::ignore = url;
     }
 
     virtual void invalidateRect(pxRect* r)


### PR DESCRIPTION
tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/include/gtest/gtest.h:1392:11: error: comparison of integers of different signs: 'const unsigned int' and 'const int' [-Werror,-Wsign-compare]
  if (lhs == rhs) {
      ~~~ ^  ~~~
tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/include/gtest/gtest.h:1421:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<unsigned int, int>' requested here
    return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
           ^
tests/pxScene2d/test_api.cpp:84:7: note: in instantiation of function template specialization 'testing::internal::EqHelper<false>::Compare<unsigned int, int>' requested here
      EXPECT_EQ(err1, RT_ERROR_INVALID_ARG);
      ^
tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/include/gtest/gtest.h:1924:63: note: expanded from macro 'EXPECT_EQ'
                      EqHelper<GTEST_IS_NULL_LITERAL_(val1)>::Compare, \
                                                              ^

tests/pxScene2d/test_jsfiles.cpp:59:55: error: unused parameter 'url' [-Werror,-Wunused-parameter]
    void init(int x, int y, int w, int h, const char* url = NULL)
                                                      ^