### PR TITLE
fix -Werror=sign-compare in rtScriptDuk.cpp

### DIFF
--- a/src/rtScriptDuk/rtScriptDuk.cpp
+++ b/src/rtScriptDuk/rtScriptDuk.cpp
@@ -1145,7 +1145,7 @@ rtError rtScriptDuk::pump()
 #ifndef RUNINMAIN
   return RT_OK;
 #else
-  for (int i = 0; i < uvLoops.size(); ++i) {
+  for (size_t i = 0; i < uvLoops.size(); ++i) {
     uv_run(uvLoops[i], UV_RUN_NOWAIT);
   }
 #endif // RUNINMAIN


### PR DESCRIPTION
Fixes:
src/rtScriptDuk/rtScriptDuk.cpp: In member function ‘virtual rtError rtScriptDuk::pump()’:
src/rtScriptDuk/rtScriptDuk.cpp:1148:21: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   for (int i = 0; i < uvLoops.size(); ++i) {
                   ~~^~~~~~~~~~~~~~~~