### PR TITLE
fix -Werror=stringop-truncation compilation error

### DIFF
--- a/src/rtFileDownloader.cpp
+++ b/src/rtFileDownloader.cpp
@@ -420,7 +420,7 @@ void rtFileDownloadRequest::setHTTPError(const char* httpError)
 {
   if(httpError != NULL)
   {
-    strncpy(mHttpErrorBuffer, httpError, CURL_ERROR_SIZE);
+    strncpy(mHttpErrorBuffer, httpError, CURL_ERROR_SIZE-1);
     mHttpErrorBuffer[CURL_ERROR_SIZE-1] = '\0';
   }
 }


### PR DESCRIPTION
Fixes:
In function ‘void rtFileDownloadRequest::setHTTPError(const char*)’,
    inlined from ‘void rtFileDownloadRequest::setHTTPError(const char*)’:
src/rtFileDownloader.cpp:423:12: error: ‘char* strncpy(char*, const char*, size_t)’ specified bound 256 equals destination size [-Werror=stringop-truncation]
     strncpy(mHttpErrorBuffer, httpError, CURL_ERROR_SIZE);
     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~