### PR TITLE
add support for node8 (>v8.9.0) (tracing-controller fix)

### DIFF
--- a/src/rtScriptNode/rtScriptNode.cpp
+++ b/src/rtScriptNode/rtScriptNode.cpp
@@ -44,6 +44,10 @@
 #include "node_javascript.h"
 #include "node_contextify_mods.h"
 
+#if NODE_VERSION_AT_LEAST(8,9,0)
+#include "tracing/agent.h"
+#endif
+
 #include "env.h"
 #include "env-inl.h"
 
@@ -1179,6 +1183,10 @@ void rtScriptNode::init2(int argc, char** argv)
    Platform* platform = platform::CreateDefaultPlatform();
    mPlatform = platform;
    V8::InitializePlatform(platform);
+#if NODE_VERSION_AT_LEAST(8,9,0)
+   // behaves as --trace-events-enabled command line option were not used
+   tracing::TraceEventHelper::SetTracingController(new v8::TracingController());
+#endif
    V8::Initialize();
    Isolate::CreateParams params;
    array_buffer_allocator = new ArrayBufferAllocator();


### PR DESCRIPTION
fixes the crash when tracing controller wasn't initialized:
 Thread 1 "pxscene" received signal SIGSEGV, Segmentation fault.
 0x00007fc0537acb76 in node::GetCategoryGroupEnabled (category_group=0x7b080000cba0 "node.async_hooks") at ../src/node_trace_events.cc:22
 (gdb) bt
 #0  0x00007fc0537acb76 in node::GetCategoryGroupEnabled (category_group=0x7b080000cba0 "node.async_hooks") at ../src/node_trace_events.cc:22
 #1  0x00007fc0537acf33 in node::CategoryGroupEnabled (args=...) at ../src/node_trace_events.cc:131
 #2  0x00007fc053924322 in v8::internal::FunctionCallbackArguments::Call (this=this@entry=0x7ffcdfdbeb70, f=f@entry=0x7fc0537acef0 <node::CategoryGroupEnabled(v8::FunctionCallbackInfo<v8::Value> const&)>) at ../deps/v8/src/api-arguments.cc:25
 #3  0x00007fc05398dfb6 in v8::internal::(anonymous namespace)::HandleApiCallHelper<false> (isolate=isolate@entry=0x7ba800000000, function=..., function@entry=..., new_target=..., new_target@entry=..., fun_data=..., receiver=..., receiver@entry=..., args=...) at ../deps/v8/src/builtins/builtins-api.cc:112
 #4  0x00007fc05398e7be in v8::internal::Builtin_Impl_HandleApiCall (args=..., isolate=0x7ba800000000) at ../deps/v8/src/builtins/builtins-api.cc:142
 #5  0x00007fc021c842fd in ?? ()