### PR TITLE
fix SIGSEGV in wl_egl_window_resize()

### DIFF
--- a/src/wayland_egl/pxWindowNative.cpp
+++ b/src/wayland_egl/pxWindowNative.cpp
@@ -288,12 +288,22 @@ static void shell_surface_ping(void *data,
 
 static void shell_surface_configure(void *data, struct wl_shell_surface *shell_surface, uint32_t edges, int32_t width, int32_t height)
 {
-    pxWindowNative* w = (pxWindowNative*)data;
+    struct wl_surface *surface = (struct wl_surface *)data;
 
-    if (w->getWaylandNative())
-    {
-        wl_egl_window_resize(w->getWaylandNative(), width, height, 0, 0);
-    }
+    if (surface == NULL)
+        return;
+
+    pxWindowNative *pxWindow = (pxWindowNative *)wl_surface_get_user_data(surface);
+
+    if (pxWindow == NULL)
+        return;
+
+    struct wl_egl_window *egl_window = pxWindow->getWaylandNative();
+
+    if (egl_window == NULL)
+        return;
+
+    wl_egl_window_resize(egl_window, width, height, 0, 0);
 }
 
 static void
@@ -385,7 +395,8 @@ bool exitFlag = false;
 
 pxWindowNative::pxWindowNative(): mTimerFPS(0), mLastWidth(-1), mLastHeight(-1),
     mResizeFlag(false), mLastAnimationTime(0.0), mVisible(false), mDirty(true),
-    mWaylandSurface(NULL), mWaylandBuffer(), waylandBufferIndex(0)
+    mWaylandSurface(NULL), mWaylandBuffer(), waylandBufferIndex(0),
+    mEglNativeWindow(NULL), mEglSurface(NULL)
 {
 }
 
@@ -407,6 +418,7 @@ pxError pxWindow::init(int left, int top, int width, int height)
         //mShellSurfaceListener
         mShellSurfaceListener.ping = shell_surface_ping;
         mShellSurfaceListener.configure = shell_surface_configure;
+        mShellSurfaceListener.popup_done = NULL;
 
         mLastWidth = width;
         mLastHeight = height;
@@ -645,10 +657,10 @@ struct wl_shell_surface* pxWindowNative::createWaylandSurface()
     }
 
     wl_shell_surface_add_listener(shell_surface,
-        &mShellSurfaceListener, this);
+        &mShellSurfaceListener, surface);
     wl_shell_surface_set_toplevel(shell_surface);
-    wl_shell_surface_set_user_data(shell_surface, surface);
-    wl_surface_set_user_data(surface, NULL);
+
+    wl_surface_set_user_data(surface, this);
 
     //egl stuff
     mEglNativeWindow = (struct wl_egl_window *)wl_egl_window_create(surface,
@@ -681,6 +693,7 @@ void pxWindowNative::cleanupWaylandData()
 
     eglDestroySurface(display->egl.dpy, mEglSurface);
     wl_egl_window_destroy(mEglNativeWindow);
+    mEglNativeWindow = NULL;
     //end egl stuff
 
     if (mWaylandBuffer[0].buffer)


### PR DESCRIPTION
Fixes the following crash (also observed on Broadcom Nexus implementation):

ASAN:DEADLYSIGNAL
=================================================================
==31533==ERROR: AddressSanitizer: SEGV on unknown address 0x7febe91f7148 (pc 0x7febe91f972c bp 0x7ffd07589280 sp 0x7ffd07589248 T0)
==31533==The signal is caused by a WRITE memory access.
    #0 0x7febe91f972b in wl_egl_window_resize (/lib64/libwayland-egl.so.1+0x72b)
    #1 0x66c9d4 in shell_surface_configure src/wayland_egl/pxWindowNative.cpp:295
    #2 0x7febe3f0ed1d in ffi_call_unix64 (/lib64/libffi.so.6+0x5d1d)
    #3 0x7febe3f0e68e in ffi_call (/lib64/libffi.so.6+0x568e)
    #4 0x7febe8ff2d8a  (/lib64/libwayland-client.so.0+0x8d8a)
    #5 0x7febe8fef927  (/lib64/libwayland-client.so.0+0x5927)
    #6 0x7febe8ff0be3 in wl_display_dispatch_queue_pending (/lib64/libwayland-client.so.0+0x6be3)
    #7 0x66ea35 in pxWindowNative::runEventLoop() src/wayland_egl/pxWindowNative.cpp:595
    #8 0x676ec1 in pxEventLoop::run() src/wayland_egl/pxEventLoopNative.cpp:35
    #9 0x65e747 in pxMain(int, char**) examples/pxScene2d/src/pxScene.cpp:659
    #10 0x676f3f in main src/wayland_egl/pxEventLoopNative.cpp:50
    #11 0x7febe4131f29 in __libc_start_main (/lib64/libc.so.6+0x20f29)
    #12 0x4fe579 in _start (examples/pxScene2d/src/pxscene+0x4fe579)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (/lib64/libwayland-egl.so.1+0x72b) in wl_egl_window_resize
==31533==ABORTING

Original code:

(1) wl_shell_surface_add_listener(shell_surface,
                                  &mShellSurfaceListener,
                                  this); // <- user_data

(2) wl_shell_surface_set_user_data(shell_surface,
                                   surface); // <- user_data

The problem is that 'surface' - user_data parameter in (2) overwrites
'this' - user_data parameter passed in (1) as a result 'mShellSurfaceListener'
receives pointer to wrong user_data structure.