### PR TITLE
fix -Wunused-parameter errors when ENABLE_LRU_TEXTURE_EJECTION is undefined

### DIFF
--- a/examples/pxScene2d/src/pxContextGL.cpp
+++ b/examples/pxScene2d/src/pxContextGL.cpp
@@ -3128,6 +3128,8 @@ int64_t pxContext::ejectTextureMemory(int64_t bytesRequested, bool forceEject)
   int64_t afterTextureMemoryUsage = context.currentTextureMemoryUsageInBytes();
   return (beforeTextureMemoryUsage-afterTextureMemoryUsage);
 #else
+  (void)bytesRequested;
+  (void)forceEject;
   return 0;
 #endif //ENABLE_LRU_TEXTURE_EJECTION
 }


### PR DESCRIPTION
Fixes:
examples/pxScene2d/src/pxContextGL.cpp:3116:47: error: unused parameter 'bytesRequested' [-Werror,-Wunused-parameter]
int64_t pxContext::ejectTextureMemory(int64_t bytesRequested, bool forceEject)
                                              ^
examples/pxScene2d/src/pxContextGL.cpp:3116:68: error: unused parameter 'forceEject' [-Werror,-Wunused-parameter]
int64_t pxContext::ejectTextureMemory(int64_t bytesRequested, bool forceEject)
                                                                   ^