### PR TITLE
 Fix a crash during rtRemote Server shutdown

### DIFF
--- a/remote/rtRemoteObjectCache.cpp
+++ b/remote/rtRemoteObjectCache.cpp
@@ -197,7 +197,7 @@ rtRemoteObjectCache::erase(std::string const& id)
 }
 
 rtError
-rtRemoteObjectCache::removeUnused()
+rtRemoteObjectCache::removeUnused(bool expireAll)
 {
   auto now = std::chrono::steady_clock::now();
 
@@ -215,7 +215,7 @@ rtRemoteObjectCache::removeUnused()
     }
     #endif
 
-    if (!itr->second.Unevictable && !itr->second.isActive(now))
+    if (!itr->second.Unevictable && (expireAll || !itr->second.isActive(now)))
       itr = sRefMap.erase(itr);
     else
       ++itr;

--- a/remote/rtRemoteObjectCache.h
+++ b/remote/rtRemoteObjectCache.h
@@ -42,7 +42,7 @@ public:
   rtError touch(std::string const& id, std::chrono::steady_clock::time_point now);
   rtError erase(std::string const& id);
   rtError markUnevictable(std::string const& id, bool state);
-  rtError removeUnused();
+  rtError removeUnused(bool expireAll = false);
   rtError clear();
 
 private:

--- a/remote/rtRemoteServer.cpp
+++ b/remote/rtRemoteServer.cpp
@@ -443,6 +443,8 @@ rtRemoteServer::onClientStateChanged(std::shared_ptr<rtRemoteClient> const& clie
     }
   }
 
+  m_env->ObjectCache->removeUnused(true);
+
   return e;
 }
 

--- a/remote/rtRemoteStreamSelector.cpp
+++ b/remote/rtRemoteStreamSelector.cpp
@@ -71,7 +71,7 @@ rtRemoteStreamSelector::registerStream(std::shared_ptr<rtRemoteStream> const& s)
 rtError
 rtRemoteStreamSelector::shutdown()
 {
-  char buff[] = { "shudown" };
+  char buff[] = { "shutdown" };
 
   {
     std::unique_lock<std::mutex> lock(m_mutex);


### PR DESCRIPTION
- Removing all invalid objects from ObjectCache during the shutdown of any client to prevent crash when the server is shut down;
- Fix a typo.