### PR TITLE
fix for -Werror=misleading-indentation compilation errors

### DIFF
--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -3701,7 +3701,9 @@ rtError pxSceneContainer::setServiceContext(rtObjectRef o)
 { 
   // Only allow serviceContext to be set at construction time
   if( !mInitialized)
-    mServiceContext = o; return RT_OK;
+    mServiceContext = o;
+
+  return RT_OK;
 }
 
 rtError pxSceneContainer::setScriptView(pxScriptView* scriptView)


### PR DESCRIPTION
Fixes:
examples/pxScene2d/src/pxScene2d.cpp: In member function ‘rtError pxSceneContainer::setServiceContext(rtObjectRef)’:
examples/pxScene2d/src/pxScene2d.cpp:3703:3: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
   if( !mInitialized)
   ^~
examples/pxScene2d/src/pxScene2d.cpp:3704:26: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
     mServiceContext = o; return RT_OK;
                          ^~~~~~
cc1plus: all warnings being treated as errors