### PR TITLE
fix AddressSanitizer: alloc-dealloc-mismatch error (fixes #1227)

### DIFF
--- a/src/pxUtil.cpp
+++ b/src/pxUtil.cpp
@@ -50,10 +50,12 @@
   #include "nanosvg.h"
   #define NANOSVGRAST_IMPLEMENTATION
   #include "nanosvgrast.h"
-  
-#ifndef SAFE_DELETE
-  #define SAFE_DELETE(x)  { delete (x); (x) = NULL; }
+
+#ifdef SAFE_FREE
+#undef SAFE_FREE
 #endif
+#define SAFE_FREE(x)  do { free(x); (x) = NULL; } while(0)
+
 
 class NSVGrasterizerEx
 {
@@ -988,8 +990,6 @@ rtError pxLoadSVGImage(const char* buf, size_t buflen, pxOffscreen& o, int w /* 
   NSVGimage *image = nsvgParse( (char *) buf, "px", 96.0f); // 96 dpi (suggested defalus) 
   if (image == NULL)
   {
-    SAFE_DELETE(image)
-
     rtLogError("SVG:  Could not init decode SVG.\n");
     return RT_FAIL;
   }
@@ -1002,8 +1002,8 @@ rtError pxLoadSVGImage(const char* buf, size_t buflen, pxOffscreen& o, int w /* 
 
   if (image_w == 0 || image_h == 0)
   {
-    SAFE_DELETE(image)
-    
+    SAFE_FREE(image);
+
     rtLogError("SVG:  Bad image dimensions  WxH: %d x %d\n", image_w, image_h);
     return RT_FAIL;
   }
@@ -1040,7 +1040,7 @@ rtError pxLoadSVGImage(const char* buf, size_t buflen, pxOffscreen& o, int w /* 
 
   nsvgRasterize(rast.getPtr(), image, dx, dy, scale , (unsigned char*) o.base(), o.width(), o.height(), o.width() *4);
 
-  SAFE_DELETE(image)
+  SAFE_FREE(image);
 
   return RT_OK;
 }


### PR DESCRIPTION
Fixes the following issue:

    =================================================================
    ==12472==ERROR: AddressSanitizer: alloc-dealloc-mismatch (malloc vs operator delete) on 0x602000057c90
        #0 0x7fef91d40748 in operator delete(void*) (/lib64/libasan.so.5+0xf1748)
        #1 0xa67017 in pxLoadSVGImage(char const*, unsigned long, pxOffscreen&, int, int)
    pxLoadSVGImage(char const*, unsigned long, pxOffscreen&, int, int) /home/sw/projects/pxscene/pxCore/src/pxUtil.cpp:1005
        #2 0xa6879b in pxLoadImage(char const*, unsigned long, pxOffscreen&, int, int) /home/sw/projects/pxscene/pxCore/src/pxUtil.cpp:106
        #3 0x6bc75b in pxUtilTest::pxLoadImage3ArgsLessLengthFailureTest() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/test_pxUtil.cpp:160
        #4 0x6bc75b in pxUtilTest_pxutilsTest_Test::TestBody() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/test_pxUtil.cpp:372
        #5 0x87b623 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
        #6 0x87b623 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
        #7 0x84c7d5 in testing::Test::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2474
        #8 0x84cb37 in testing::TestInfo::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2656
        #9 0x84cef4 in testing::TestCase::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2774
        #10 0x84e361 in testing::internal::UnitTestImpl::RunAllTests() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4649
        #11 0x84eddd in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
        #12 0x84eddd in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
        #13 0x84eddd in testing::UnitTest::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4257
        #14 0x4d3591 in RUN_ALL_TESTS() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/include/gtest/gtest.h:2233
        #15 0x4d3591 in main /home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtestsmain.cpp:119
        #16 0x7fef8cb0518a in __libc_start_main ../csu/libc-start.c:308
        #17 0x5011a9 in _start (/home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtests+0x5011a9)

    0x602000057c90 is located 0 bytes inside of 16-byte region [0x602000057c90,0x602000057ca0)
    allocated by thread T0 here:
        #0 0x7fef91d3de50 in calloc (/lib64/libasan.so.5+0xeee50)
        #1 0xa5c705 in nsvg__createParser /home/sw/projects/pxscene/pxCore/src/../examples/pxScene2d/external/nanosvg/src/nanosvg.h:619
        #2 0xa5c705 in nsvgParse /home/sw/projects/pxscene/pxCore/src/../examples/pxScene2d/external/nanosvg/src/nanosvg.h:2861
        #3 0xa66e0f in pxLoadSVGImage(char const*, unsigned long, pxOffscreen&, int, int) /home/sw/projects/pxscene/pxCore/src/pxUtil.cpp:988
        #4 0xa6879b in pxLoadImage(char const*, unsigned long, pxOffscreen&, int, int) /home/sw/projects/pxscene/pxCore/src/pxUtil.cpp:106
        #5 0x6bc75b in pxUtilTest::pxLoadImage3ArgsLessLengthFailureTest() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/test_pxUtil.cpp:160
        #6 0x6bc75b in pxUtilTest_pxutilsTest_Test::TestBody() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/test_pxUtil.cpp:372
        #7 0x87b623 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
        #8 0x87b623 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
        #9 0x84c7d5 in testing::Test::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2474
        #10 0x84cb37 in testing::TestInfo::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2656
        #11 0x84cef4 in testing::TestCase::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2774
        #12 0x84e361 in testing::internal::UnitTestImpl::RunAllTests() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4649
        #13 0x84eddd in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2402
        #14 0x84eddd in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:2438
        #15 0x84eddd in testing::UnitTest::Run() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/src/gtest.cc:4257
        #16 0x4d3591 in RUN_ALL_TESTS() /home/sw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/include/gtest/gtest.h:2233
        #17 0x4d3591 in main /home/sw/projects/pxscene/pxCore/tests/pxScene2d/pxscene2dtestsmain.cpp:119
        #18 0x7fef8cb0518a in __libc_start_main ../csu/libc-start.c:308

    SUMMARY: AddressSanitizer: alloc-dealloc-mismatch (/lib64/libasan.so.5+0xf1748) in operator delete(void*)