### PR TITLE
fix AddressSanitizer: alloc-dealloc-mismatch in ~NSVGrasterizerEx()

### DIFF
--- a/src/pxUtil.cpp
+++ b/src/pxUtil.cpp
@@ -61,7 +61,7 @@ class NSVGrasterizerEx
 {
   public:
        NSVGrasterizerEx()  {  rast = nsvgCreateRasterizer(); } // ctor
-      ~NSVGrasterizerEx()  {  delete rast;                   } // dtor
+      ~NSVGrasterizerEx()  {  SAFE_FREE(rast);               } // dtor
   
   NSVGrasterizer *getPtr() { return rast; };
   


### PR DESCRIPTION
Fixes the following issue:

=================================================================
==9455==ERROR: AddressSanitizer: alloc-dealloc-mismatch (malloc vs operator delete) on 0x60c000000280
    #0 0x7f34c8e29748 in operator delete(void*) (/lib64/libasan.so.5+0xf1748)
    #1 0x7f34c35cf66b in __run_exit_handlers /usr/src/debug/glibc-2.27-56-g50df56ca86/stdlib/exit.c:108
    #2 0x7f34c35cf79b in __GI_exit /usr/src/debug/glibc-2.27-56-g50df56ca86/stdlib/exit.c:139
    #3 0x7f34c7409e63 in Exit ../src/node.cc:2472
    #4 0x7f34c75e5059 in v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&)) ../deps/v8/src/api-arguments.cc:25
    #5 0x7f34c764ddcf in HandleApiCallHelper<false> ../deps/v8/src/builtins/builtins-api.cc:112
    #6 0x7f34c764e4a6 in Builtin_Impl_HandleApiCall ../deps/v8/src/builtins/builtins-api.cc:142
    #7 0x1e8f838842fc  (<unknown module>)

0x60c000000280 is located 0 bytes inside of 128-byte region [0x60c000000280,0x60c000000300)
allocated by thread T0 here:
    #0 0x7f34c8e26e50 in calloc (/lib64/libasan.so.5+0xeee50)
    #1 0x67c925 in nsvgCreateRasterizer /home/sw/projects/pxscene/pxCore/src/../examples/pxScene2d/external/nanosvg/src/nanosvgrast.h:149
    #2 0x499df5 in NSVGrasterizerEx::NSVGrasterizerEx() /home/sw/projects/pxscene/pxCore/src/pxUtil.cpp:63
    #3 0x499df5 in __static_initialization_and_destruction_0 /home/sw/projects/pxscene/pxCore/src/pxUtil.cpp:73
    #4 0x499df5 in _GLOBAL__sub_I_pxUtil.cpp /home/sw/projects/pxscene/pxCore/src/pxUtil.cpp:1521
    #5 0x817944 in __libc_csu_init (/home/sw/projects/pxscene/pxCore/examples/pxScene2d/src/pxscene+0x817944)