### PR TITLE
fix error: control reaches end of non-void function -Werror=return-type

### DIFF
--- a/src/pxUtil.cpp
+++ b/src/pxUtil.cpp
@@ -1474,6 +1474,7 @@ rtString imageType2str(pxImageType t)
     case PX_IMAGE_WEBP:     return rtString("PX_IMAGE_WEBP");
     case PX_IMAGE_ICO:      return rtString("PX_IMAGE_ICO");
     case PX_IMAGE_SVG:      return rtString("PX_IMAGE_SVG");
+    default:
     case PX_IMAGE_INVALID:  return rtString("PX_IMAGE_INVALID");
   }
 }


### PR DESCRIPTION
Fixes error at: pxscene/pxCore/src/pxUtil.cpp:1479:1: error: control reaches end of non-void function [-Werror=return-type]