### PR TITLE
Reject promise when animation is invoked after dispose

### DIFF
--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -689,6 +689,9 @@ rtError pxObject::animateToP2(rtObjectRef props, double duration,
 {
   if (mIsDisposed)
   {
+    promise = new rtPromise();
+    rtValue nullValue;
+    promise.send("reject",nullValue);
     return RT_OK;
   }
 
@@ -739,7 +742,8 @@ rtError pxObject::animateToObj(rtObjectRef props, double duration,
   animateObj = new pxAnimate(props, interp, (pxConstantsAnimation::animationOptions)options, duration, count, promise, this);
   if (mIsDisposed)
   {
-    promise.send("reject",this);
+    rtValue nullValue;
+    promise.send("reject",nullValue);
     return RT_OK;
   }
 


### PR DESCRIPTION
Reject the animation promises, when invoked on object after dispose. Else, no promise object is created and js file is accessing then method on empty object. This is causing js file to hung and all the opened variables in that js file to get leaked.