### PR TITLE
Fix _rtEmitEntry intilization bug

### DIFF
--- a/src/rtObject.cpp
+++ b/src/rtObject.cpp
@@ -54,6 +54,8 @@ rtError rtEmit::setListener(const char* eventName, rtIFunction* f)
     e.n = eventName;
     e.f = f;
     e.isProp = true;
+    e.markForDelete = false;
+    e.fnHash = f->hash();
     mEntries.push_back(e);      
   }
   


### PR DESCRIPTION
Fix bug caused by commit:
a969b568

All members of the entry were not being initialized when
calling setListener causing undefined behaviour like all
entries being deleted after the first call to emit send.