### PR TITLE
fix error: ‘gWaylandAppsConfigLoaded’ defined but not used

### DIFF
--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -146,7 +146,9 @@ bool gApplicationIsClosing = false;
 map<string, string> gWaylandAppsMap;
 map<string, string> gWaylandRegistryAppsMap;
 map<string, string> gPxsceneWaylandAppsMap;
+#if !(defined(ENABLE_DFB) || defined(DISABLE_WAYLAND))
 static bool gWaylandAppsConfigLoaded = false;
+#endif
 #define DEFAULT_WAYLAND_APP_CONFIG_FILE "./waylandregistry.conf"
 #define DEFAULT_ALL_APPS_CONFIG_FILE "./pxsceneappregistry.conf"
 


### PR DESCRIPTION
Fixes:

pxCore/examples/pxScene2d/src/pxScene2d.cpp:149:13: error: ‘gWaylandAppsConfigLoaded’ defined but not used [-Werror=unused-variable]
 static bool gWaylandAppsConfigLoaded = false;
             ^~~~~~~~~~~~~~~~~~~~~~~~