### PR TITLE
Make move a no op if child is already in that position

### DIFF
--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -829,6 +829,14 @@ rtError pxObject::moveToFront()
 
   if(!parent) return RT_OK;
 
+  // If this pxObject is already at the front (last child),
+  // make this a no-op
+  uint32_t size = parent->mChildren.size();
+  rtRef<pxObject> lastChild = parent->mChildren[size-1];
+  if( lastChild.getPtr() == this) {
+    return RT_OK;
+  }
+
   remove();
   setParent(parent);
 
@@ -844,6 +852,13 @@ rtError pxObject::moveToBack()
   pxObject* parent = this->parent();
 
   if(!parent) return RT_OK;
+
+  // If this pxObject is already at the back (first child),
+  // make this a no-op
+  rtRef<pxObject> firstChild = parent->mChildren[0];
+  if( firstChild.getPtr() == this) {
+    return RT_OK;
+  }
 
   remove();
   mParent = parent;


### PR DESCRIPTION
Existing tests already cover this scenario.