### PR TITLE
local access file - 2nd generation

### DIFF
--- a/examples/pxScene2d/src/CMakeLists.txt
+++ b/examples/pxScene2d/src/CMakeLists.txt
@@ -290,7 +290,7 @@ elseif (WIN32)
     set(PLATFORM_LIBRARIES pxCore.lib)
     set(PLATFORM_LIBRARIES ${PLATFORM_LIBRARIES} ${COMM_DEPS_LIBRARIES} ${NODE_LIBRARIES} ${V8_LIBRARIES} ${DUKE_LIBRARIES})
     set(PLATFORM_LIBRARIES ${PLATFORM_LIBRARIES}
-        pthreadVC2.lib opengl32.lib Winmm.lib
+        pthreadVC2.lib opengl32.lib Winmm.lib Shlwapi.lib
         Ws2_32.lib Wldap32.lib msvcrt.lib psapi.lib
         iphlpapi.lib userenv.lib rtCore_s.lib common.lib
         crash_generation_client.lib exception_handler.lib)

--- a/examples/pxScene2d/src/Spark.cpp
+++ b/examples/pxScene2d/src/Spark.cpp
@@ -481,6 +481,8 @@ int pxMain(int argc, char* argv[])
 
 #endif
 
+  rtModuleDirs::instance();
+
   rtString settingsPath;
   if (RT_OK == rtGetHomeDirectory(settingsPath))
   {

--- a/src/rtPathUtils.cpp
+++ b/src/rtPathUtils.cpp
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #if defined WIN32
 #include <direct.h>
+#include <shlwapi.h>
 #else
 #include <unistd.h>
 #endif
@@ -95,3 +96,113 @@ rtValue rtGetEnvAsValue(const char* name, const char* defaultValue)
 {
   return rtGetEnvAsString(name, defaultValue);
 }
+
+bool rtIsPathAbsolute(const char *path)
+{
+  if (!path)
+    return false;
+
+# ifdef WIN32
+    return !PathIsRelativeA(path);
+# else
+    return path[0] == '/';
+# endif
+}
+
+bool rtIsPathAbsolute(const rtString &path)
+{
+  if (path.isEmpty())
+    return false;
+
+ const char *str = path.cString();
+
+ return rtIsPathAbsolute(str);
+}
+
+const char *rtModuleDirSeparator()
+{
+# ifdef WIN32
+    return ";";
+# else
+    return ":";
+# endif
+}
+
+rtError rtPathUtilPutEnv(const char *name, const char * value)
+{
+# ifdef WIN32
+    return _putenv_s(name, value != NULL ? value : "") == 0 ? RT_OK : RT_ERROR;
+# else
+    if (value != NULL)
+      return setenv(name, value, 1) == 0 ? RT_OK : RT_ERROR;
+    else
+      return unsetenv(name) == 0 ? RT_OK : RT_ERROR;
+# endif
+}
+
+std::string rtConcatenatePath(const std::string &dir, const std::string &file)
+{
+  rtString path = dir.c_str();
+  rtEnsureTrailingPathSeparator(path);
+  path.append(file.c_str());
+
+  return std::string(path.cString());
+}
+
+std::string rtGetRootModulePath(const char *file)
+{
+  rtModuleDirs *dirs = rtModuleDirs::instance();
+  const std::string rootDir = *dirs->iterator().first;
+  return rtConcatenatePath(rootDir, file != NULL ? file : "");
+}
+
+rtModuleDirs::rtModuleDirs(const char *env_name) {
+  rtString cwd;
+  rtGetCurrentDirectory(cwd);
+
+  rtString rt_env = rtGetEnvAsString(env_name, cwd.cString());
+  std::string env = rt_env.cString();
+
+  const std::string sep = rtModuleDirSeparator();
+
+  while (env.size())
+  {
+    const size_t index = env.find(sep);
+
+    if (index != std::string::npos)
+    {
+      mModuleDirs.push_back(env.substr(0, index));
+      env = env.substr(index + sep.size());
+
+      if (env.size() == 0)
+        mModuleDirs.push_back(env);
+    } else
+    {
+      mModuleDirs.push_back(env);
+      env = "";
+    }
+  }
+}
+
+rtModuleDirs *rtModuleDirs::instance(const char *env_name)
+{
+  if (NULL == mModuleInstance)
+    mModuleInstance = new rtModuleDirs(env_name);
+
+  return mModuleInstance;
+}
+
+void rtModuleDirs::destroy()
+{
+  if (NULL != mModuleInstance)
+    delete mModuleInstance;
+
+  mModuleInstance = NULL;
+}
+
+rtModuleDirs::iter rtModuleDirs::iterator()
+{
+  return std::make_pair(mModuleDirs.begin(), mModuleDirs.end());
+}
+
+rtModuleDirs *rtModuleDirs::mModuleInstance = NULL;

--- a/src/rtPathUtils.h
+++ b/src/rtPathUtils.h
@@ -21,10 +21,14 @@
 #ifndef _RT_PATH_UTILS
 #define _RT_PATH_UTILS
 
+#include <string>
+#include <vector>
+
 #include "rtCore.h"
 #include "rtString.h"
 #include "rtValue.h"
 
+rtError rtEnsureTrailingPathSeparator(rtString& d);
 rtError rtGetCurrentDirectory(rtString& d);
 rtError rtGetHomeDirectory(rtString& d);
 
@@ -33,5 +37,33 @@ rtString rtGetEnvAsString(const char* name, const char* defaultValue = "");
 rtValue rtGetEnvAsValue(const char* name, const char* defaultValue = "");
 
 bool rtFileExists(const char* f);
+
+bool rtIsPathAbsolute(const char *path);
+bool rtIsPathAbsolute(const rtString &path);
+
+const char *rtModuleDirSeparator();
+
+rtError rtPathUtilPutEnv(const char *name, const char * value);
+
+std::string rtConcatenatePath(const std::string &dir, const std::string &file);
+
+std::string rtGetRootModulePath(const char *file = "");
+
+class rtModuleDirs {
+
+public:
+  static rtModuleDirs* instance(const char *env_name = "NODE_PATH");
+  static void destroy();
+  typedef std::pair<std::vector<std::string>::iterator,
+                    std::vector<std::string>::iterator> iter;
+  iter iterator();
+
+private:
+  rtModuleDirs(const char *env_name);
+  std::vector<std::string> mModuleDirs;
+  static rtModuleDirs *mModuleInstance;
+};
+
+void rtPathUtilsInit();
 
 #endif

--- a/src/rtScriptDuk/rtScriptDuk.cpp
+++ b/src/rtScriptDuk/rtScriptDuk.cpp
@@ -98,6 +98,7 @@ extern "C" {
 #include "rtAtomic.h"
 
 #include "rtScript.h"
+#include "rtPathUtils.h"
 
 // TODO eliminate std::string
 #include <string>
@@ -1301,17 +1302,7 @@ rtDukContextRef rtScriptDuk::createContext(bool ownThread)
     assert(uvLoops.size() == 1);
     mRefContext->uvLoop = uvLoops[0];
 
-    static std::string sandbox_path;
-
-    if(sandbox_path.empty()) // only once.
-    {
-      char *nodePath = ::getenv("NODE_PATH");
-      if (NULL != nodePath)
-      {
-        const std::string NODE_PATH = nodePath;
-        sandbox_path = NODE_PATH + "/" + SANDBOX_JS;
-      }
-    }
+    static std::string sandbox_path = rtGetRootModulePath(SANDBOX_JS);
 
     // Populate 'sandbox' vars in JS...
     if(fileExists(sandbox_path.c_str()))

--- a/src/rtScriptV8/rtScriptNode.cpp
+++ b/src/rtScriptV8/rtScriptNode.cpp
@@ -67,6 +67,7 @@
 #include "rtValue.h"
 #include "rtAtomic.h"
 #include "rtScript.h"
+#include "rtPathUtils.h"
 
 
 
@@ -1304,17 +1305,7 @@ rtNodeContextRef rtScriptNode::createContext(bool ownThread)
     mRefContext = new rtNodeContext(mIsolate,mPlatform);
     ctxref = mRefContext;
 
-    static std::string sandbox_path;
-
-    if(sandbox_path.empty()) // only once.
-    {
-      char *nodePath = ::getenv("NODE_PATH");
-      if (NULL != nodePath)
-      {
-        const std::string NODE_PATH = nodePath;
-        sandbox_path = NODE_PATH + "/" + SANDBOX_JS;
-      }
-    }
+    static std::string sandbox_path = rtGetRootModulePath(SANDBOX_JS);
 
     // Populate 'sandbox' vars in JS...
     if(fileExists(sandbox_path.c_str()))

--- a/tests/pxScene2d/CMakeLists.txt
+++ b/tests/pxScene2d/CMakeLists.txt
@@ -157,7 +157,7 @@ set(TEST_SOURCE_FILES pxscene2dtestsmain.cpp  test_example.cpp test_api.cpp  tes
     test_pxAnimate.cpp test_rtFile.cpp test_rtZip.cpp test_rtString.cpp test_rtValue.cpp test_pxImage.cpp test_pxOffscreen.cpp test_pxMatrix4T.cpp test_rtObject.cpp
     test_pxWindowUtil.cpp test_pxTexture.cpp test_pxWindow.cpp test_ioapi.cpp test_rtLog.cpp test_pxTimerNative.cpp
     test_rtUrlUtils.cpp test_pxArchive.cpp test_pxPixel_h.cpp test_pxFont.cpp test_rtThreadPool.cpp test_utf8.cpp
-    test_rtSettings.cpp test_cors.cpp  test_external.cpp test_pxScene2d.cpp test_oscillate.cpp
+    test_rtSettings.cpp test_cors.cpp  test_external.cpp test_pxScene2d.cpp test_oscillate.cpp test_rtPathUtils.cpp
     ${PLATFORM_TEST_FILES} ${TEST_WAYLAND_SOURCE_FILES})
 
 if (DEFINED ENV{USE_HTTP_CACHE})

--- a/tests/pxScene2d/test_rtPathUtils.cpp
+++ b/tests/pxScene2d/test_rtPathUtils.cpp
@@ -1,0 +1,154 @@
+/*
+
+Copyright 2018 Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+#include <sstream>
+
+#define private public
+#define protected public
+
+#include "rtPathUtils.h"
+
+#include "test_includes.h" // Needs to be included last
+
+using namespace std;
+
+class rtPathUtilsTest : public testing::Test
+{
+  public:
+    virtual void SetUp()
+    {
+    }
+
+    virtual void TearDown()
+    {
+    }
+
+    void concatenatePath()
+    {
+      std::string s1 = rtConcatenatePath("foo", "bar");
+      rtString s2 = "foo";
+
+      rtError rv = rtEnsureTrailingPathSeparator(s2);
+      EXPECT_EQ(rv, RT_OK);
+      s2.append("bar");
+
+      EXPECT_EQ(0, s1.compare(s2));
+    }
+
+    void getPutEnv()
+    {
+      rtString env = rtGetEnvAsString(env_name);
+      EXPECT_EQ(0, strcmp(env, ""));
+
+      const char *env_sample_value = "SampleValue";
+      rtError rv = rtPathUtilPutEnv(env_name, env_sample_value);
+      EXPECT_EQ(rv, RT_OK);
+
+      env = rtGetEnvAsString(env_name);
+      EXPECT_EQ(0, strcmp(env, env_sample_value));
+
+      rv = rtPathUtilPutEnv(env_name, "");
+      EXPECT_EQ(rv, RT_OK);
+    }
+
+    void defaultValue()
+    {
+      rtModuleDirs::destroy(); // destroys any existing environment
+      const int rv = rtPathUtilPutEnv(env_name, NULL);
+
+      EXPECT_EQ(0, rv);
+
+      rtString cwd;
+      rtError rv1 = rtGetCurrentDirectory(cwd);
+
+      EXPECT_EQ(0, rv1);
+      EXPECT_EQ(false, cwd.isEmpty());
+
+      int num_entries = 0;
+      rtModuleDirs *p = rtModuleDirs::instance(env_name); // creates new environment
+
+      for (rtModuleDirs::iter it = p->iterator(); it.first != it.second; it.first++)
+      {
+        const std::string s = *it.first;
+
+        EXPECT_EQ(0, s.compare(cwd.cString()));
+        num_entries++;
+      }
+
+      EXPECT_EQ(1, num_entries);
+
+      rtModuleDirs::destroy(); // destroys environment
+
+      rtModuleDirs::instance(); // re-creates environment
+    }
+
+    void basicTest()
+    {
+      const char *dir_entries[] = {
+#       ifdef WIN32
+        "e:\\foo",
+#       endif
+        "/bar",
+        "baz/",
+        "/qux/"
+      };
+
+      std::string env_str;
+
+      for (size_t i = 0; i < sizeof (dir_entries) / sizeof(dir_entries[0]); i++)
+      {
+        if (i > 0)
+          env_str += rtModuleDirSeparator();
+
+        env_str += dir_entries[i];
+      }
+
+      rtModuleDirs::destroy(); // destroys any existing environment
+      const int rv = rtPathUtilPutEnv(env_name, env_str.c_str());
+
+      EXPECT_EQ(0, rv);
+
+      size_t num_entries = 0;
+      rtModuleDirs *p = rtModuleDirs::instance(env_name); // creates new environment
+
+      for (rtModuleDirs::iter it = p->iterator(); it.first != it.second; it.first++)
+      {
+        const std::string s = *it.first;
+        EXPECT_EQ(0, s.compare(dir_entries[num_entries]));
+        num_entries++;
+      }
+
+      EXPECT_EQ(sizeof (dir_entries) / sizeof(dir_entries[0]), num_entries);
+
+      rtModuleDirs::destroy(); // destroys environment
+
+      rtModuleDirs::instance(); // re-creates environment
+    }
+
+    private:
+      const char *env_name = "_pxscene_nie_calkiem_przypadkowy_env";
+};
+
+TEST_F(rtPathUtilsTest, rtPathUtilsTest)
+{
+  concatenatePath();
+  getPutEnv();
+  defaultValue();
+  basicTest();
+}
+


### PR DESCRIPTION
Allow NODE_PATH environment variable to contain multiple directories
separated by:
  - ';' on windows platform,
  - ':' on any other.

Notes:
  - The first entry in NODE_PATH is used to load SANDBOX_JS file
    (this preserves backward compatibility).

  - If NODE_PATH is not defined then the default value is obtained
    from getcwd(3).