### PR TITLE
Disabled the Font/Glyph 'scaling' memory saving strategy ... Fixed

### DIFF
--- a/examples/pxScene2d/src/pxFont.cpp
+++ b/examples/pxScene2d/src/pxFont.cpp
@@ -308,11 +308,11 @@ GlyphTextureEntry pxFont::getGlyphTexture(uint32_t codePoint, float sx, float sy
   GlyphTextureEntry result;
   // Select a glyph texture better suited for rendering the glyph
   // taking pixelSize and scale into account
-  uint32_t pixelSize=(uint32_t)ceil((sx>sy?sx:sy)*mPixelSize);
+  uint32_t pixelSize=((uint32_t)ceil((sy>sx?sy:sx)*mPixelSize));
   
   //  TODO:  FIXME: Disabled for now.   Sub-Pixel rounding making some Glyphs too "wide" at certain sizes.
   //
-#if 0
+//#if 0
   if (pixelSize < 8)
   {
     pixelSize = (pixelSize + 7) & 0xfffffff8;    // next multiple of 8
@@ -322,11 +322,11 @@ GlyphTextureEntry pxFont::getGlyphTexture(uint32_t codePoint, float sx, float sy
     //pixelSize = (pixelSize + 7) & 0xfffffff8;  // next multiple of 8
     pixelSize += (pixelSize % 2);
   }
-  else
-    pixelSize = npot(pixelSize);  // else next power of two
-#else
-  pixelSize = mPixelSize; // HACK
-#endif
+//  else
+//    pixelSize = npot(pixelSize);  // else next power of two
+//#else
+//  pixelSize = mPixelSize; // HACK
+//#endif
   
   
   GlyphKey key; 


### PR DESCRIPTION
Added fix for calculating pixel size. Preference is scale X else Scale Y and Also we dont need to check pixelSize nbot for next power 2.