### PR TITLE
Fix broken addListener() & delListener() handling.

### DIFF
--- a/remote/rtRemoteFunction.cpp
+++ b/remote/rtRemoteFunction.cpp
@@ -27,8 +27,10 @@ rtRemoteFunction::rtRemoteFunction(std::string const& id, std::string const& nam
   , m_name(name)
   , m_client(client)
   , m_timeout(client->getEnvironment()->Config->environment_request_timeout())
-  , m_Hash(0)
 {
+  std::hash<std::string> hashFn;
+  m_Hash = hashFn(name);
+
   if (!strcmp(id.c_str(), "global"))
   {
     m_client->registerKeepAliveForObject(m_name);

--- a/remote/rtRemoteValueWriter.cpp
+++ b/remote/rtRemoteValueWriter.cpp
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "rtRemoteValueWriter.h"
 #include "rtRemoteObject.h"
+#include "rtRemoteFunction.h"
 #include "rtRemoteObjectCache.h"
 #include "rtRemoteConfig.h"
 #include "rtRemoteMessage.h"
@@ -32,14 +33,26 @@ namespace
 {
 //  static std::atomic<int> sNextFunctionId;
 
-  std::string getId(rtFunctionRef const& /*ref*/)
+  std::string getId(rtFunctionRef const& ref)
   {
-    rtGuid id = rtGuid::newRandom();
+    rtFunctionCallback * obj = dynamic_cast<rtFunctionCallback *>(ref.ptr());
+    if(obj && !obj->getId().empty())
+    {
+      return obj->getId();
+    }
+    else
+    {
+      rtGuid id = rtGuid::newRandom();
 
-    std::stringstream ss;
-    ss << "func://";
-    ss << id.toString();
-    return ss.str();
+      std::stringstream ss;
+      ss << "func://";
+      ss << id.toString();
+
+      if(obj)
+        obj->setId(ss.str());
+
+      return ss.str();
+    }
   }
  
   std::string getId(rtObjectRef const& ref)

--- a/src/rtObject.h
+++ b/src/rtObject.h
@@ -31,6 +31,7 @@
 
 #include <string.h>
 #include <vector>
+#include <string>
 
 // rtIObject and rtIFunction are designed to be an
 // Abstract Binary Interface(ABI)
@@ -632,11 +633,21 @@ public:
     mContext = NULL;
   }
   
+  void setId(std::string id)
+  {
+    mId = id;
+  }
+
+  std::string getId()
+  {
+    return mId;
+  }
 
 private:  
   rtFunctionCB mCB;
   void* mContext;
   rtAtomic mRefCount;
+  std::string mId;
 };
 
 


### PR DESCRIPTION
Now every time client makes a call to delListener(), rtFunctionRef() gets new ID and server doesn't identify it when it matches it with the stored handlers.

This change will ensure at client rtFuncionRef stores the id after creation and refers that hence forth instead of creating new one everytime. And at the server side, the received
id (i.e. 'func://<uid>') is used to calculate a hash which is then used for add / del listeners