### PR TITLE
Fix sanitizer issues with test_cors

### DIFF
--- a/tests/pxScene2d/test_cors.cpp
+++ b/tests/pxScene2d/test_cors.cpp
@@ -171,19 +171,20 @@ public:
       "expires: Tue, 10 Jul 2018 14:33:54 GMT\r\n"
       "connection: close"
     ;
-    char* rawHeaderData_str = new char[rawHeaderData.byteLength()];
+    char* rawHeaderData_str = (char*)malloc(rawHeaderData.byteLength()+1);
+    memset(rawHeaderData_str, 0, rawHeaderData.byteLength()+1);
     strcpy(rawHeaderData_str, rawHeaderData.cString());
     request.setHeaderData(rawHeaderData_str, rawHeaderData.byteLength());
     rtString downloadedData;
     downloadedData =
       "data"
     ;
-    char* downloadedData_str = new char[downloadedData.byteLength()];
+    char* downloadedData_str = (char*)malloc(downloadedData.byteLength()+1);
+    memset(downloadedData_str, 0, downloadedData.byteLength()+1);
     strcpy(downloadedData_str, downloadedData.cString());
     request.setDownloadedData(downloadedData_str, downloadedData.byteLength());
     EXPECT_FALSE (NULL == request.downloadedData());
     EXPECT_EQ ((int)downloadedData.byteLength(), (int)request.downloadedDataSize());
-
     cors.updateResponseForAccessControl(&request);
 
     int statusCode = request.downloadStatusCode();


### PR DESCRIPTION
Two issues seen here:
1,We are allocating the amount of memory same as content length and extra memory for '\0' not got allocated and so during strcpy, null character allocation is creating problem. 
2,Later on end of test, request variable will go out of scope and it's destruction will delete header data with free() call. Since memory is allocated with new, but clearance is happening with free, allo-dealloc mismatch error came from sanitizer.

Addressed above two problems as part of this change.