### PR TITLE
fix compilation error: 'error: comparison of integer expressions'

### DIFF
--- a/tests/pxScene2d/test_screenshot.cpp
+++ b/tests/pxScene2d/test_screenshot.cpp
@@ -65,7 +65,7 @@ printf("\n >>>>>>>>>>>>>>>>>>>>> [%d]  len = %d   res = %d",i, out.length(), res
       rtError res1 = base64_encode(pngData2.data(), pngData2.length(), s1);
 
       EXPECT_TRUE (res1 == (i == 0) ? RT_FAIL : RT_OK);
-      EXPECT_EQ (s1.length(), 4*((i+2)/3));
+      EXPECT_EQ ((size_t)s1.length(), 4*((i+2)/3));
       EXPECT_TRUE (s1.length() == 0 || NULL != s1.cString());
 
       if (NULL != s1.cString() )


### PR DESCRIPTION
Fixes the following issue:
In file included from /home/dw/projects/pxscene/pxCore/tests/pxScene2d/test_includes.h:32,
                 from /home/dw/projects/pxscene/pxCore/tests/pxScene2d/test_screenshot.cpp:25:
/home/dw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = long unsigned int]’:
/home/dw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/include/gtest/gtest.h:1421:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = long unsigned int; bool lhs_is_null_literal = false]’
/home/dw/projects/pxscene/pxCore/tests/pxScene2d/test_screenshot.cpp:68:7:   required from here
/home/dw/projects/pxscene/pxCore/tests/pxScene2d/../../examples/pxScene2d/external/gtest/googletest/include/gtest/gtest.h:1392:11: error: comparison of integer expressions of different signedness: ‘const int’ and ‘const long unsigned int’ [-Werror=sign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
cc1plus: all warnings being treated as errors