### PR TITLE
fix error: unused variable ‘v’ and parameter 'result'

### DIFF
--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -3934,12 +3934,11 @@ void pxScriptView::runScript()
 
 rtError pxScriptView::printFunc(int numArgs, const rtValue* args, rtValue* result, void* ctx)
 {
+  UNUSED_PARAM(result);
   rtLogInfo(__FUNCTION__);
 
   if (ctx)
   {
-    pxScriptView* v = (pxScriptView*)ctx;
-
     if (numArgs > 0 && !args[0].isEmpty())
     {
       rtString toPrint = args[0].toString();


### PR DESCRIPTION
    Fixes the following errors:
    
    pxCore/examples/pxScene2d/src/pxScene2d.cpp: In static member function ‘static rtError pxScriptView::printFunc(int, const rtValue*, rtValue*, void*)’:
    pxscene/pxCore/examples/pxScene2d/src/pxScene2d.cpp:3941:19: error: unused variable ‘v’ [-Werror=unused-variable]
         pxScriptView* v = (pxScriptView*)ctx;
                       ^
    cc1plus: all warnings being treated as errors
    
    and
    
    pxCore/examples/pxScene2d/src/pxScene2d.cpp:3935:76: error: unused parameter 'result' [-Werror,-Wunused-parameter]
    rtError pxScriptView::printFunc(int numArgs, const rtValue* args, rtValue* result, void* ctx)
                                                                               ^
    1 error generated.