### PR TITLE
Wayland container should be able to support processes spawning sub processes

### DIFF
--- a/examples/pxScene2d/src/pxWayland.cpp
+++ b/examples/pxScene2d/src/pxWayland.cpp
@@ -465,7 +465,8 @@ void pxWayland::handleHidePointer( bool hide )
 
 void pxWayland::handleClientStatus( int status, int pid, int detail )
 {
-   mClientPID = status == WstClient_stoppedAbnormal || status == WstClient_stoppedNormal ? -1 : pid;
+   if ( mClientPID <= 0 )
+      mClientPID = status == WstClient_stoppedAbnormal || status == WstClient_stoppedNormal ? -1 : pid;
    if ( mEvents )
    {
       switch ( status )

--- a/examples/pxScene2d/src/pxWayland.cpp
+++ b/examples/pxScene2d/src/pxWayland.cpp
@@ -466,7 +466,7 @@ void pxWayland::handleHidePointer( bool hide )
 void pxWayland::handleClientStatus( int status, int pid, int detail )
 {
    if ( mClientPID <= 0 )
-      mClientPID = status == WstClient_stoppedAbnormal || status == WstClient_stoppedNormal ? -1 : pid;
+      mClientPID = ( ( status == WstClient_stoppedAbnormal ) || ( status == WstClient_stoppedNormal ) ) ? -1 : pid;
    if ( mEvents )
    {
       switch ( status )


### PR DESCRIPTION
Good example of this is WPELauncher. In the initial code the PID of the
last received status update is stored as the ClientPID. So only this process
gets killed on a destroy call.