### PR TITLE
DELIA-28961 : Fixing the issue reported in DELIA-28961, for LSA AD cache with back to back ad insertion.

### DIFF
--- a/src/rtFileDownloader.cpp
+++ b/src/rtFileDownloader.cpp
@@ -120,7 +120,7 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
   mem->contentsSize += downloadSize;
   mem->contentsBuffer[mem->contentsSize] = 0;
 
-  if (mem->downloadRequest->useCallbackDataSize() == true)
+  if (mem->downloadRequest->useDownloadProgressCallbackDataSize() == true)
   {
      return downloadCallbackSize;
   }
@@ -158,7 +158,7 @@ void onDownloadHandleCheck()
 
 rtFileDownloadRequest::rtFileDownloadRequest(const char* imageUrl, void* callbackData, void (*callbackFunction)(rtFileDownloadRequest*))
       : mFileUrl(imageUrl), mProxyServer(),
-    mErrorString(), mHttpStatusCode(0), mCallbackFunction(callbackFunction), mDownloadProgressCallbackFunction(NULL), mUseCallbackDataSize(false), mDownloadProgressUserPtr(NULL),
+    mErrorString(), mHttpStatusCode(0), mCallbackFunction(callbackFunction), mDownloadProgressCallbackFunction(NULL), mUseDownloadProgressCallbackDataSize(false), mDownloadProgressUserPtr(NULL),
     mDownloadedData(0), mDownloadedDataSize(), mDownloadStatusCode(0) ,mCallbackData(callbackData),
     mCallbackFunctionMutex(), mHeaderData(0), mHeaderDataSize(0), mHeaderOnly(false), mDownloadHandleExpiresTime(-2)
 #ifdef ENABLE_HTTP_CACHE
@@ -415,14 +415,14 @@ void rtFileDownloadRequest::setProgressMeter(bool val)
   mIsProgressMeterSwitchOff = val;
 }
 
-void rtFileDownloadRequest::setUseCallbackDataSize(bool val)
+void rtFileDownloadRequest::setUseDownloadProgressCallbackDataSize(bool val)
 {
-  mUseCallbackDataSize = val;
+  mUseDownloadProgressCallbackDataSize = val;
 }
 
-bool rtFileDownloadRequest::useCallbackDataSize()
+bool rtFileDownloadRequest::useDownloadProgressCallbackDataSize()
 {
-  return mUseCallbackDataSize;
+  return mUseDownloadProgressCallbackDataSize;
 }
 
 bool rtFileDownloadRequest::isProgressMeterSwitchOff()

--- a/src/rtFileDownloader.cpp
+++ b/src/rtFileDownloader.cpp
@@ -648,7 +648,8 @@ void rtFileDownloader::downloadFile(rtFileDownloadRequest* downloadRequest)
             {
                 char* buffer = new char[downloadRequest->getCachedFileReadSize()];
                 int bytesCount = 0;
-                size_t dataSize = 0;
+                size_t dataSize = 0;                
+				char invalidData[8] = "Invalid";
 
                 // The cahced file has expiration value ends with | delimeter.
                 while ( !feof(fp) )
@@ -665,7 +666,7 @@ void rtFileDownloader::downloadFile(rtFileDownloadRequest* downloadRequest)
                     downloadRequest->executeDownloadProgressCallback((unsigned char*)buffer, bytesCount, 1 );
                 }
                 // For deferCacheRead, the user requires the downloadedDataSize but not the data.
-                downloadRequest->setDownloadedData( "Invalid", dataSize);
+                downloadRequest->setDownloadedData( invalidData, dataSize);
                 delete [] buffer;
                 fclose(fp);
             }

--- a/src/rtFileDownloader.cpp
+++ b/src/rtFileDownloader.cpp
@@ -120,7 +120,7 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
   mem->contentsSize += downloadSize;
   mem->contentsBuffer[mem->contentsSize] = 0;
 
-  if (mem->downloadRequest->useDownloadProgressCallbackDataSize() == true)
+  if (mem->downloadRequest->useCallbackDataSize() == true)
   {
      return downloadCallbackSize;
   }
@@ -158,7 +158,7 @@ void onDownloadHandleCheck()
 
 rtFileDownloadRequest::rtFileDownloadRequest(const char* imageUrl, void* callbackData, void (*callbackFunction)(rtFileDownloadRequest*))
       : mFileUrl(imageUrl), mProxyServer(),
-    mErrorString(), mHttpStatusCode(0), mCallbackFunction(callbackFunction), mDownloadProgressCallbackFunction(NULL), mUseDownloadProgressCallbackDataSize(false), mDownloadProgressUserPtr(NULL),
+    mErrorString(), mHttpStatusCode(0), mCallbackFunction(callbackFunction), mDownloadProgressCallbackFunction(NULL), mUseCallbackDataSize(false), mDownloadProgressUserPtr(NULL),
     mDownloadedData(0), mDownloadedDataSize(), mDownloadStatusCode(0) ,mCallbackData(callbackData),
     mCallbackFunctionMutex(), mHeaderData(0), mHeaderDataSize(0), mHeaderOnly(false), mDownloadHandleExpiresTime(-2)
 #ifdef ENABLE_HTTP_CACHE
@@ -415,14 +415,14 @@ void rtFileDownloadRequest::setProgressMeter(bool val)
   mIsProgressMeterSwitchOff = val;
 }
 
-void rtFileDownloadRequest::setUseDownloadProgressCallbackDataSize(bool val)
+void rtFileDownloadRequest::setUseCallbackDataSize(bool val)
 {
-  mUseDownloadProgressCallbackDataSize = val;
+  mUseCallbackDataSize = val;
 }
 
-bool rtFileDownloadRequest::useDownloadProgressCallbackDataSize()
+bool rtFileDownloadRequest::useCallbackDataSize()
 {
-  return mUseDownloadProgressCallbackDataSize;
+  return mUseCallbackDataSize;
 }
 
 bool rtFileDownloadRequest::isProgressMeterSwitchOff()

--- a/src/rtFileDownloader.cpp
+++ b/src/rtFileDownloader.cpp
@@ -104,9 +104,10 @@ static size_t HeaderCallback(void *contents, size_t size, size_t nmemb, void *us
 static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
 {
   size_t downloadSize = size * nmemb;
+  size_t downloadCallbackSize = 0;
   struct MemoryStruct *mem = (struct MemoryStruct *)userp;
 
-  mem->downloadRequest->executeDownloadProgressCallback(contents, size, nmemb );
+  downloadCallbackSize = mem->downloadRequest->executeDownloadProgressCallback(contents, size, nmemb );
 
   mem->contentsBuffer = (char*)realloc(mem->contentsBuffer, mem->contentsSize + downloadSize + 1);
   if(mem->contentsBuffer == NULL) {
@@ -119,7 +120,14 @@ static size_t WriteMemoryCallback(void *contents, size_t size, size_t nmemb, voi
   mem->contentsSize += downloadSize;
   mem->contentsBuffer[mem->contentsSize] = 0;
 
-  return downloadSize;
+  if (mem->downloadRequest->useCallbackDataSize() == true)
+  {
+     return downloadCallbackSize;
+  }
+  else
+  {
+     return downloadSize;
+  }
 }
 
 
@@ -150,11 +158,11 @@ void onDownloadHandleCheck()
 
 rtFileDownloadRequest::rtFileDownloadRequest(const char* imageUrl, void* callbackData, void (*callbackFunction)(rtFileDownloadRequest*))
       : mFileUrl(imageUrl), mProxyServer(),
-    mErrorString(), mHttpStatusCode(0), mCallbackFunction(callbackFunction), mDownloadProgressCallbackFunction(NULL), mDownloadProgressUserPtr(NULL),
+    mErrorString(), mHttpStatusCode(0), mCallbackFunction(callbackFunction), mDownloadProgressCallbackFunction(NULL), mUseCallbackDataSize(false), mDownloadProgressUserPtr(NULL),
     mDownloadedData(0), mDownloadedDataSize(), mDownloadStatusCode(0) ,mCallbackData(callbackData),
     mCallbackFunctionMutex(), mHeaderData(0), mHeaderDataSize(0), mHeaderOnly(false), mDownloadHandleExpiresTime(-2)
 #ifdef ENABLE_HTTP_CACHE
-    , mCacheEnabled(true), mIsDataInCache(false), mDeferCacheRead(false)
+    , mCacheEnabled(true), mIsDataInCache(false), mDeferCacheRead(false), mCachedFileReadSize(0)
 #endif
     , mIsProgressMeterSwitchOff(false), mHTTPFailOnError(false), mDefaultTimeout(false)
     , mCORS(), mCanceled(false), mCanceledMutex()
@@ -246,14 +254,13 @@ bool rtFileDownloadRequest::executeCallback(int statusCode)
   return false;
 }
 
-bool rtFileDownloadRequest::executeDownloadProgressCallback(void * ptr, size_t size, size_t nmemb)
+size_t rtFileDownloadRequest::executeDownloadProgressCallback(void * ptr, size_t size, size_t nmemb)
 {
   if(mDownloadProgressCallbackFunction)
   {
-    mDownloadProgressCallbackFunction(ptr, size, nmemb, mDownloadProgressUserPtr);
-    return true;
+    return mDownloadProgressCallbackFunction(ptr, size, nmemb, mDownloadProgressUserPtr);
   }
-  return false;
+  return 0;
 }
 
 void rtFileDownloadRequest::setDownloadedData(char* data, size_t size)
@@ -368,6 +375,16 @@ bool rtFileDownloadRequest::isDataCached()
   return mIsDataInCache;
 }
 
+size_t rtFileDownloadRequest::getCachedFileReadSize(void )
+{
+  return mCachedFileReadSize;
+}
+
+void rtFileDownloadRequest::setCachedFileReadSize(size_t cachedFileReadSize)
+{
+  mCachedFileReadSize = cachedFileReadSize;
+}
+
 void rtFileDownloadRequest::setDeferCacheRead(bool val)
 {
   mDeferCacheRead = val;
@@ -396,6 +413,16 @@ FILE* rtFileDownloadRequest::cacheFilePointer(void)
 void rtFileDownloadRequest::setProgressMeter(bool val)
 {
   mIsProgressMeterSwitchOff = val;
+}
+
+void rtFileDownloadRequest::setUseCallbackDataSize(bool val)
+{
+  mUseCallbackDataSize = val;
+}
+
+bool rtFileDownloadRequest::useCallbackDataSize()
+{
+  return mUseCallbackDataSize;
 }
 
 bool rtFileDownloadRequest::isProgressMeterSwitchOff()
@@ -610,7 +637,42 @@ void rtFileDownloader::downloadFile(rtFileDownloadRequest* downloadRequest)
     {
       nwDownloadSuccess = downloadFromNetwork(downloadRequest);
     }
+    else
+    {
+        if(downloadRequest->deferCacheRead())
+        {
+            mFileCacheMutex.lock();
+            FILE *fp = downloadRequest->cacheFilePointer();
 
+            if(fp != NULL)
+            {
+                char* buffer = new char[downloadRequest->getCachedFileReadSize()];
+                int bytesCount = 0;
+                size_t dataSize = 0;
+
+                // The cahced file has expiration value ends with | delimeter.
+                while ( !feof(fp) )
+                {
+                    dataSize++;
+                    if (fgetc(fp) == '|')
+                        break;
+                }
+                while (!feof(fp))
+                {
+                    memset(buffer, 0, downloadRequest->getCachedFileReadSize());
+                    bytesCount = fread(buffer, 1, downloadRequest->getCachedFileReadSize(), fp);
+                    dataSize += bytesCount;
+                    downloadRequest->executeDownloadProgressCallback((unsigned char*)buffer, bytesCount, 1 );
+                }
+                // For deferCacheRead, the user requires the downloadedDataSize but not the data.
+                downloadRequest->setDownloadedData( "Invalid", dataSize);
+                delete [] buffer;
+                fclose(fp);
+            }
+            mFileCacheMutex.unlock();
+        }
+    }
+    
     if (!downloadRequest->executeCallback(downloadRequest->downloadStatusCode()))
     {
       if (mDefaultCallbackFunction != NULL)

--- a/src/rtFileDownloader.cpp
+++ b/src/rtFileDownloader.cpp
@@ -632,12 +632,7 @@ void rtFileDownloader::downloadFile(rtFileDownloadRequest* downloadRequest)
       }
     }
 
-    if (false == isDataInCache)
-#endif
-    {
-      nwDownloadSuccess = downloadFromNetwork(downloadRequest);
-    }
-    else
+    if (isDataInCache)
     {
         if(downloadRequest->deferCacheRead())
         {
@@ -673,6 +668,11 @@ void rtFileDownloader::downloadFile(rtFileDownloadRequest* downloadRequest)
             mFileCacheMutex.unlock();
         }
     }
+    else
+#endif
+    {
+      nwDownloadSuccess = downloadFromNetwork(downloadRequest);
+    }    
     
     if (!downloadRequest->executeCallback(downloadRequest->downloadStatusCode()))
     {

--- a/src/rtFileDownloader.h
+++ b/src/rtFileDownloader.h
@@ -92,8 +92,8 @@ public:
 #endif //ENABLE_HTTP_CACHE
   void setProgressMeter(bool val);
   bool isProgressMeterSwitchOff();
-  void setUseDownloadProgressCallbackDataSize(bool val);
-  bool useDownloadProgressCallbackDataSize();
+  void setUseCallbackDataSize(bool val);
+  bool useCallbackDataSize();
   void setHTTPFailOnError(bool val);
   bool isHTTPFailOnError();
   void setHTTPError(const char* httpError);
@@ -135,7 +135,7 @@ private:
   bool mDefaultTimeout;
   rtCORSRef mCORS;
   bool mCanceled;
-  bool mUseDownloadProgressCallbackDataSize;
+  bool mUseCallbackDataSize;
   rtMutex mCanceledMutex;
 };
 

--- a/src/rtFileDownloader.h
+++ b/src/rtFileDownloader.h
@@ -61,7 +61,7 @@ public:
   long httpStatusCode();
   void setHttpStatusCode(long statusCode);
   bool executeCallback(int statusCode);
-  bool executeDownloadProgressCallback(void *ptr, size_t size, size_t nmemb);
+  size_t executeDownloadProgressCallback(void *ptr, size_t size, size_t nmemb);
   void setDownloadedData(char* data, size_t size);
   void downloadedData(char*& data, size_t& size);
   char* downloadedData();
@@ -84,12 +84,16 @@ public:
   bool cacheEnabled();
   void setDataIsCached(bool val);
   bool isDataCached();
+  size_t getCachedFileReadSize(void);
+  void setCachedFileReadSize(size_t cachedFileReadSize);
   void setDeferCacheRead(bool val);
   bool deferCacheRead();
   FILE* cacheFilePointer(void);
 #endif //ENABLE_HTTP_CACHE
   void setProgressMeter(bool val);
   bool isProgressMeterSwitchOff();
+  void setUseCallbackDataSize(bool val);
+  bool useCallbackDataSize();
   void setHTTPFailOnError(bool val);
   bool isHTTPFailOnError();
   void setHTTPError(const char* httpError);
@@ -123,6 +127,7 @@ private:
   bool mCacheEnabled;
   bool mIsDataInCache;
   bool mDeferCacheRead;
+  size_t mCachedFileReadSize;
 #endif //ENABLE_HTTP_CACHE
   bool mIsProgressMeterSwitchOff;
   bool mHTTPFailOnError;
@@ -130,6 +135,7 @@ private:
   bool mDefaultTimeout;
   rtCORSRef mCORS;
   bool mCanceled;
+  bool mUseCallbackDataSize;
   rtMutex mCanceledMutex;
 };
 

--- a/src/rtFileDownloader.h
+++ b/src/rtFileDownloader.h
@@ -92,8 +92,8 @@ public:
 #endif //ENABLE_HTTP_CACHE
   void setProgressMeter(bool val);
   bool isProgressMeterSwitchOff();
-  void setUseCallbackDataSize(bool val);
-  bool useCallbackDataSize();
+  void setUseDownloadProgressCallbackDataSize(bool val);
+  bool useDownloadProgressCallbackDataSize();
   void setHTTPFailOnError(bool val);
   bool isHTTPFailOnError();
   void setHTTPError(const char* httpError);
@@ -135,7 +135,7 @@ private:
   bool mDefaultTimeout;
   rtCORSRef mCORS;
   bool mCanceled;
-  bool mUseCallbackDataSize;
+  bool mUseDownloadProgressCallbackDataSize;
   rtMutex mCanceledMutex;
 };
 

--- a/tests/pxScene2d/test_imagecache.cpp
+++ b/tests/pxScene2d/test_imagecache.cpp
@@ -938,8 +938,7 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
       request->setCallbackFunction(rtFileDownloaderTest::downloadCallbackForUseCallbackDataSize);
       request->setDownloadProgressCallbackFunction(rtFileDownloaderTest::downloadProgressCallbackForUseCallbackDataSize, this);
       request->setUseDownloadProgressCallbackDataSize(true);
-      expectedStatusCode = 0;
-      expectedHttpCode = 200;
+      expectedStatusCode = CURLE_WRITE_ERROR;
       rtFileDownloader::instance()->downloadFile(request);
       sem_wait(testSem);
     }
@@ -1240,7 +1239,6 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
       {
         rtFileDownloaderTest* callbackData = (rtFileDownloaderTest*) fileDownloadRequest->callbackData();
         EXPECT_TRUE (callbackData->expectedHttpCode == fileDownloadRequest->httpStatusCode());
-        EXPECT_TRUE (callbackData->expectedStatusCode ==  fileDownloadRequest->downloadStatusCode());
         EXPECT_FALSE (fileDownloadRequest->isDataCached());
         sem_post(callbackData->testSem);
       }

--- a/tests/pxScene2d/test_imagecache.cpp
+++ b/tests/pxScene2d/test_imagecache.cpp
@@ -914,6 +914,7 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
       //EXPECT_TRUE (RT_OK ==rtFileCache::instance()->httpCacheData("https://px-apps.sys.comcast.net/pxscene-samples/images/tiles/008.jpg",data));
     }
 
+    #define DEFER_CACHE_BUFFER_SIZE 	 (16*1024) // 16 K Added similar to CURL_MAX_WRITE_SIZE (the usual default is 16K)
     void setDeferCacheReadTest()
     {
       // TODO TESTS images files downloaded from pxscene-samples need expiry date
@@ -921,9 +922,24 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
       rtFileDownloadRequest* request = new rtFileDownloadRequest("https://px-apps.sys.comcast.net/pxscene-samples/images/tiles/008.jpg",this);
       request->setCallbackFunction(rtFileDownloaderTest::downloadCallbackForDeferCache);
       request->setDeferCacheRead(true);
+      request->setCachedFileReadSize(DEFER_CACHE_BUFFER_SIZE);
       expectedStatusCode = 0;
       expectedHttpCode = 200;
       expectedCachePresence = false;
+      rtFileDownloader::instance()->downloadFile(request);
+      sem_wait(testSem);
+    }
+
+    void setUseCallbackDataSizeTest()
+    {
+      // TODO TESTS images files downloaded from pxscene-samples need expiry date
+      rtFileCache::instance()->clearCache();
+      rtFileDownloadRequest* request = new rtFileDownloadRequest("https://px-apps.sys.comcast.net/pxscene-samples/images/tiles/008.jpg",this);
+      request->setCallbackFunction(rtFileDownloaderTest::downloadCallbackForUseCallbackDataSize);
+      request->setDownloadProgressCallbackFunction(rtFileDownloaderTest::downloadProgressCallbackForUseCallbackDataSize, this);
+      request->setUseDownloadProgressCallbackDataSize(true);
+      expectedStatusCode = 0;
+      expectedHttpCode = 200;
       rtFileDownloader::instance()->downloadFile(request);
       sem_wait(testSem);
     }
@@ -1186,7 +1202,6 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
     }
     // download progress test ends
 
-	#define DEFER_CACHE_BUFFER_SIZE 	 (16*1024) // 16 K Added similar to CURL_MAX_WRITE_SIZE (the usual default is 16K)
     static void downloadCallbackForDeferCache(rtFileDownloadRequest* fileDownloadRequest)
     {
       rtHttpCacheData cachedData;
@@ -1198,28 +1213,10 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
         EXPECT_TRUE (callbackData->expectedCachePresence == rtFileDownloader::instance()->checkAndDownloadFromCache(fileDownloadRequest,cachedData));
         if(fileDownloadRequest->isDataCached())
         {
-          FILE *fp = fileDownloadRequest->cacheFilePointer();
+		  char* invalidData;
           size_t dataSizeFromDeferCache = 0;
 
-          if((fp != NULL) && (fileDownloadRequest->deferCacheRead() == true))
-          {
-            char buffer[DEFER_CACHE_BUFFER_SIZE]="";
-            int bytesCount = 0;
-
-            // The cahced file has expiration value ends with | delimeter.
-            while ( !feof(fp) )
-            {
-              if (fgetc(fp) == '|')
-                break;
-            }
-            while (!feof(fp))
-            {
-              memset(buffer, 0, DEFER_CACHE_BUFFER_SIZE);
-              bytesCount = fread(buffer,1,DEFER_CACHE_BUFFER_SIZE,fp);
-              dataSizeFromDeferCache += bytesCount;
-            }
-            fclose(fp);
-          }
+          fileDownloadRequest->downloadedData(invalidData, dataSizeFromDeferCache);
 
           fileDownloadRequest->setDeferCacheRead(false);
           rtHttpCacheData cachedData(fileDownloadRequest->fileUrl().cString());
@@ -1232,6 +1229,19 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
             EXPECT_TRUE (dataSize == dataSizeFromDeferCache);
           }
         }
+        sem_post(callbackData->testSem);
+      }
+    }
+
+    static void downloadCallbackForUseCallbackDataSize(rtFileDownloadRequest* fileDownloadRequest)
+    {
+      rtHttpCacheData cachedData;
+      if (fileDownloadRequest != NULL && fileDownloadRequest->callbackData() != NULL)
+      {
+        rtFileDownloaderTest* callbackData = (rtFileDownloaderTest*) fileDownloadRequest->callbackData();
+        EXPECT_TRUE (callbackData->expectedHttpCode == fileDownloadRequest->httpStatusCode());
+        EXPECT_TRUE (callbackData->expectedStatusCode ==  fileDownloadRequest->downloadStatusCode());
+        EXPECT_FALSE (fileDownloadRequest->isDataCached());
         sem_post(callbackData->testSem);
       }
     }
@@ -1260,6 +1270,16 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
       }
     }
 
+    static size_t downloadProgressCallbackForUseCallbackDataSize(void *ptr, size_t size, size_t nmemb, void *userData)
+    {
+      // Lets consider an example of due to user/caller interuption this callback consumed only half of the data.
+      int consumed= (size*nmemb)/2;
+      UNUSED_PARAM (ptr);
+      UNUSED_PARAM(userData);
+
+      return consumed;
+    }
+
     static size_t downloadProgressCallback(void *ptr, size_t size, size_t nmemb, void *userData)
     {
       UNUSED_PARAM (ptr);
@@ -1286,6 +1306,8 @@ TEST_F(rtFileDownloaderTest, checkCacheTests)
   downloadFileCacheDataProperAvailableTest();
   disableCacheTest();
   downloadFileAddToCacheTest();
+  setDeferCacheReadTest();
+  setUseCallbackDataSizeTest();
   checkAndDownloadFromNetworkSuccess();
   checkAndDownloadFromNetworkFailure();
   startFileDownloadInBackgroundTest();

--- a/tests/pxScene2d/test_imagecache.cpp
+++ b/tests/pxScene2d/test_imagecache.cpp
@@ -1161,10 +1161,11 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
 
     void executeDownloadProgressCallbackPresentTest()
     {
+      size_t size = 0, nmemb = 0;
       rtFileCache::instance()->clearCache();
       rtFileDownloadRequest request("https://px-apps.sys.comcast.net/pxscene-samples/images/tiles/008.jpg",this);
       request.setDownloadProgressCallbackFunction(rtFileDownloaderTest::downloadProgressCallback, this);
-      EXPECT_TRUE (true == request.executeDownloadProgressCallback(NULL, 0, 0));
+      EXPECT_TRUE ((size * nmemb) == request.executeDownloadProgressCallback(NULL, size, nmemb));
     }
 
     void executeDownloadProgressCallbackAbsentTest()

--- a/tests/pxScene2d/test_imagecache.cpp
+++ b/tests/pxScene2d/test_imagecache.cpp
@@ -937,8 +937,7 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
       rtFileDownloadRequest* request = new rtFileDownloadRequest("https://px-apps.sys.comcast.net/pxscene-samples/images/tiles/008.jpg",this);
       request->setCallbackFunction(rtFileDownloaderTest::downloadCallbackForUseCallbackDataSize);
       request->setDownloadProgressCallbackFunction(rtFileDownloaderTest::downloadProgressCallbackForUseCallbackDataSize, this);
-      request->setUseDownloadProgressCallbackDataSize(true);
-      expectedStatusCode = CURLE_WRITE_ERROR;
+      request->setUseCallbackDataSize(true);
       rtFileDownloader::instance()->downloadFile(request);
       sem_wait(testSem);
     }
@@ -1238,8 +1237,7 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
       if (fileDownloadRequest != NULL && fileDownloadRequest->callbackData() != NULL)
       {
         rtFileDownloaderTest* callbackData = (rtFileDownloaderTest*) fileDownloadRequest->callbackData();
-        EXPECT_TRUE (callbackData->expectedHttpCode == fileDownloadRequest->httpStatusCode());
-        EXPECT_FALSE (fileDownloadRequest->isDataCached());
+        EXPECT_TRUE ( false == fileDownloadRequest->isDataCached());
         sem_post(callbackData->testSem);
       }
     }


### PR DESCRIPTION
1. Added return size of executeDownloadProgressCallback in WriteMemoryCallback
2. Handled defer cache read() functionality in downloadFile