### PR TITLE
fix initialization order error (mLastFrameDirtyRect, mArchive)

### DIFF
--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -1816,7 +1816,7 @@ pxScene2d::pxScene2d(bool top, pxScriptView* scriptView)
   : mRoot(), mInfo(), mCapabilityVersions(), start(0), sigma_draw(0), sigma_update(0), end2(0), frameCount(0), mWidth(0), mHeight(0), mStopPropagation(false), mContainer(NULL), mShowDirtyRectangle(false),
     mInnerpxObjects(), mSuspended(false),
 #ifdef PX_DIRTY_RECTANGLES
-    mDirtyRect(), mLastFrameDirtyRect(),mArchive(),
+    mArchive(),mDirtyRect(), mLastFrameDirtyRect(),
 #endif //PX_DIRTY_RECTANGLES
     mDirty(true), mTestView(NULL), mDisposed(false)
 {


### PR DESCRIPTION
Fixes the following error:

In file included from /home/runner/pxCore/examples/pxScene2d/src/pxScene2d.cpp:21:
pxCore/exmples/pxScene2d/src/pxScene2d.h: In constructor ‘pxScene2d::pxScene2d(bool, pxScriptView*)’:
pxCore/examples/pxScene2d/src/pxScene2d.h:1710:10: error: ‘pxScene2d::mLastFrameDirtyRect’ will be initialized after [-Werror=reorder]
   pxRect mLastFrameDirtyRect;
          ^~~~~~~~~~~~~~~~~~~
pxCore/examples/pxScene2d/src/pxScene2d.h:1702:15: error:   ‘rtObjectRef pxScene2d::mArchive’ [-Werror=reorder]
   rtObjectRef mArchive;
               ^~~~~~~~
pxCore/examples/pxScene2d/src/pxScene2d.cpp:1815:1: error:   when initialized here [-Werror=reorder]
 pxScene2d::pxScene2d(bool top, pxScriptView* scriptView)
 ^~~~~~~~~