### PR TITLE
Fix for SVG caching bug.

### DIFF
--- a/src/pxUtil.cpp
+++ b/src/pxUtil.cpp
@@ -1023,12 +1023,21 @@ rtError pxLoadSVGImage(const char* buf, size_t buflen, pxOffscreen& o, int  w /*
     return RT_FAIL;
   }
 
-  NSVGimage *image = nsvgParse( (char *) buf, "px", 96.0f); // 96 dpi (suggested default)
+  // NOTE:  'nanosvg' is *destructive* to the SVG source buffer
+  //
+  //        Pass it a copy !
+  //
+  void *buf_copy = malloc(buflen);
+  memcpy(buf_copy, buf, buflen);
+  
+  NSVGimage *image = nsvgParse( (char *) buf_copy, "px", 96.0f); // 96 dpi (suggested default)
   if (image == NULL)
   {
     rtLogError("SVG:  Could not init decode SVG.\n");
     return RT_FAIL;
   }
+
+  free(buf_copy); // clean-up
 
   int image_w = (int)image->width;  // parsed SVG image dimensions
   int image_h = (int)image->height; // parsed SVG image dimensions

--- a/src/rtHttpCache.cpp
+++ b/src/rtHttpCache.cpp
@@ -124,6 +124,12 @@ void rtHttpCacheData::populateHeaderMap()
       {
         key = attribute.substr(0,name_end_pos);
       }
+
+      // Accomadate lowercase from NPM "http-server" - https://www.npmjs.com/package/http-server
+      //
+      if(key == "cache-control")
+          key = "Cache-Control";
+
       size_t cReturn_nwLnPos  = key.find_first_of("\r");
       if (string::npos != cReturn_nwLnPos)
         key.erase(cReturn_nwLnPos,1);


### PR DESCRIPTION
'nanosvg' performs a destructive parse to the SVG source buffer.  

Passing it a working copy prevents the destruction propagating elsewhere (e.g. into the cache)