### PR TITLE
fix reorder error (mUseCallbackDataSize, mDownloadProgressUserPtr)

### DIFF
--- a/src/rtFileDownloader.cpp
+++ b/src/rtFileDownloader.cpp
@@ -158,14 +158,14 @@ void onDownloadHandleCheck()
 
 rtFileDownloadRequest::rtFileDownloadRequest(const char* imageUrl, void* callbackData, void (*callbackFunction)(rtFileDownloadRequest*))
       : mFileUrl(imageUrl), mProxyServer(),
-    mErrorString(), mHttpStatusCode(0), mCallbackFunction(callbackFunction), mDownloadProgressCallbackFunction(NULL), mUseCallbackDataSize(false), mDownloadProgressUserPtr(NULL),
+    mErrorString(), mHttpStatusCode(0), mCallbackFunction(callbackFunction), mDownloadProgressCallbackFunction(NULL), mDownloadProgressUserPtr(NULL),
     mDownloadedData(0), mDownloadedDataSize(), mDownloadStatusCode(0) ,mCallbackData(callbackData),
     mCallbackFunctionMutex(), mHeaderData(0), mHeaderDataSize(0), mHeaderOnly(false), mDownloadHandleExpiresTime(-2)
 #ifdef ENABLE_HTTP_CACHE
     , mCacheEnabled(true), mIsDataInCache(false), mDeferCacheRead(false), mCachedFileReadSize(0)
 #endif
     , mIsProgressMeterSwitchOff(false), mHTTPFailOnError(false), mDefaultTimeout(false)
-    , mCORS(), mCanceled(false), mCanceledMutex()
+    , mCORS(), mCanceled(false), mUseCallbackDataSize(false), mCanceledMutex()
 {
   mAdditionalHttpHeaders.clear();
 #ifdef ENABLE_HTTP_CACHE


### PR DESCRIPTION
Fixes the followin compilation error:

In file included from pxCore/src/rtFileDownloader.cpp:24:
pxCore/src/rtFileDownloader.h: In constructor ‘rtFileDownloadRequest::rtFileDownloadRequest(const char*, void*, void (*)(rtFileDownloadRequest*))’:
pxCore/src/rtFileDownloader.h:138:8: error: ‘rtFileDownloadRequest::mUseCallbackDataSize’ will be initialized after [-Werror=reorder]
   bool mUseCallbackDataSize;
        ^~~~~~~~~~~~~~~~~~~~
pxCore/src/rtFileDownloader.h:115:9: error:   ‘void* rtFileDownloadRequest::mDownloadProgressUserPtr’ [-Werror=reorder]
   void *mDownloadProgressUserPtr;
         ^~~~~~~~~~~~~~~~~~~~~~~~
pxCore/src/rtFileDownloader.cpp:159:1: error:   when initialized here [-Werror=reorder]
 rtFileDownloadRequest::rtFileDownloadRequest(const char* imageUrl, void* callbackData, void (*callbackFunction)(rtFileDownloadRequest*))
 ^~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [src/CMakeFiles/pxCore.dir/build.make:375: src/CMakeFiles/pxCore.dir/rtFileDownloader.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....