### PR TITLE
Add PREFER_SYSTEM_LIBRARIES support for 'v8' engine

### DIFF
--- a/ci/builds/0499-clean.sh
+++ b/ci/builds/0499-clean.sh
@@ -1,0 +1,1 @@
+script-clean.sh

--- a/ci/builds/0500-wayland-v8-gcc-tsan.sh
+++ b/ci/builds/0500-wayland-v8-gcc-tsan.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright 2018 Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Common part
+SCRIPT_DIR=$(cd `dirname $0` && pwd)
+source "${SCRIPT_DIR}/common.sh"
+
+SPARK_BASEDIR=${SCRIPT_DIR}/../../
+pushd $SPARK_BASEDIR
+
+# Specific part
+
+mkdir -p build
+pushd build
+
+compile_rt_remote
+
+cmake \
+  ${RTREMOTE_GENERATOR_EXPORT} \
+  ${spark_common_opts[*]} \
+  ${spark_force_v8[*]} \
+  ${spark_wayland_opts[*]} \
+  -DCMAKE_CXX_FLAGS="${cxx_common_opts[*]} ${gcc_specific_opts[*]} ${gcc_tsan_opts[*]}" \
+  ..
+
+make_build "$@"

--- a/ci/builds/common.sh
+++ b/ci/builds/common.sh
@@ -86,6 +86,15 @@ spark_force_node8=(
 )
 
 
+spark_force_v8=(
+  '-DSUPPORT_V8=ON'
+  '-DSUPPORT_NODE=OFF'
+  '-DSUPPORT_DUKTAPE=OFF'
+  '-DPKG_CONFIG_DISABLE_NODE=ON'
+  '-DPKG_CONFIG_DISABLE_NODE8=ON'
+)
+
+
 # Preferably don't use any options starting with:
 # -Wno-<option-name>
 cxx_common_opts=(

--- a/cmake/CommDeps.cmake
+++ b/cmake/CommDeps.cmake
@@ -98,18 +98,23 @@ if (NOT WIN32)
       pkg_search_module(X11 x11)
     endif (NOT DFB)
     pkg_search_module(CRYPTO libcrypto)
-    
+
     if (PREFER_SYSTEM_LIBRARIES)
         pkg_search_module(OPENSSL openssl)
     endif (PREFER_SYSTEM_LIBRARIES)
     if (NOT OPENSSL_FOUND)
         set(OPENSSL_INCLUDE_DIRS "${EXTDIR}/libnode-v6.9.0/deps/openssl/openssl/include")
     endif (NOT OPENSSL_FOUND)
-    
+
     pkg_search_module(UV libuv)
 
     pkg_search_module(WAYLAND_EGL wayland-egl)
     pkg_search_module(WAYLAND_CLIENT wayland-client)
+
+    if (PREFER_SYSTEM_LIBRARIES AND SUPPORT_V8)
+        pkg_search_module(ICU_I18N icu-i18n)
+        pkg_search_module(ICU_UC icu-uc)
+    endif (PREFER_SYSTEM_LIBRARIES AND SUPPORT_V8)
 
 else (NOT WIN32)
 
@@ -134,7 +139,6 @@ else (NOT WIN32)
     set(FREETYPE_INCLUDE_DIRS "${EXTDIR}/freetype-2.8.1/include")
     set(FREETYPE_LIBRARY_DIRS "${VCLIBS}")
     set(FREETYPE_LIBRARIES "freetype281MT_D.lib")
-    
 
     set(GLEW_INCLUDE_DIRS "${EXTDIR}/glew-2.0.0/include")
     set(GLEW_LIBRARY_DIRS "${VCLIBS}")
@@ -161,6 +165,8 @@ set(COMM_DEPS_INCLUDE_DIRS ${COMM_DEPS_INCLUDE_DIRS}
      ${OPENSSL_INCLUDE_DIRS}
          ${X11_INCLUDE_DIRS}
           ${UV_INCLUDE_DIRS}
+    ${ICU_I18N_INCLUDE_DIRS}
+      ${ICU_UC_INCLUDE_DIRS}
    )
 
 set(COMM_DEPS_LIBRARY_DIRS ${COMM_DEPS_LIBRARY_DIRS}
@@ -178,6 +184,8 @@ set(COMM_DEPS_LIBRARY_DIRS ${COMM_DEPS_LIBRARY_DIRS}
      ${OPENSSL_LIBRARY_DIRS}
          ${X11_LIBRARY_DIRS}
           ${UV_LIBRARY_DIRS}
+    ${ICU_I18N_LIBRARY_DIRS}
+      ${ICU_UC_LIBRARY_DIRS}
    )
 
 set(COMM_DEPS_LIBRARIES ${COMM_DEPS_LIBRARIES}
@@ -195,4 +203,6 @@ set(COMM_DEPS_LIBRARIES ${COMM_DEPS_LIBRARIES}
         ${OPENSSL_LIBRARIES}
             ${X11_LIBRARIES}
              ${UV_LIBRARIES}
+       ${ICU_I18N_LIBRARIES}
+         ${ICU_UC_LIBRARIES}
    )


### PR DESCRIPTION
It also fixes compilation errors when SUPPORT_V8 is defined.

Recommended options for compiling with 'v8' JS engine:
  -DPREFER_SYSTEM_LIBRARIES=ON
  -DSUPPORT_V8=ON
  -DSUPPORT_NODE=OFF
  -DSUPPORT_DUKTAPE=OFF
  -DPKG_CONFIG_DISABLE_NODE=ON
  -DPKG_CONFIG_DISABLE_NODE8=ON

For more comprehensive example please have a look at:
    ci/builds/*-wayland-v8-gcc-tsan.sh script.