### PR TITLE
Update to the latest semaphoreci 'Docker v1807' image

### DIFF
--- a/ci/builds/ci-semaphoreci.sh
+++ b/ci/builds/ci-semaphoreci.sh
@@ -25,7 +25,7 @@
 #    (a) Leave "Setup" - leave empty
 #    (b) Add new command line: ./ci/builds/ci-semaphoreci.sh
 # (2) "Platform"
-#    (a) Select from "DOCKER (NATIVE)" "Ubuntu 14.04 LTS v1805.1"
+#    (a) Select from "DOCKER (NATIVE)" "Docker v1807"
 # (3) "Environment Variables"
 # (4) "Configuration files"
 # (5) "Repository"
@@ -65,6 +65,8 @@ if [ -n "${SEMAPHORE}" ]; then
     done
 
     free || true
+
+    unset DISPLAY
 fi
 
 

--- a/ci/builds/ci-travis.sh
+++ b/ci/builds/ci-travis.sh
@@ -22,10 +22,6 @@ SCRIPT_DIR=$(cd `dirname $0` && pwd)
 
 pushd "${SCRIPT_DIR}"
 
-if [ -e /etc/init.d/xvfb ]; then
-    export DISPLAY=:99.0
-    /bin/bash -xe /etc/init.d/xvfb start
-    sleep 5 # give xvfb some time to start
-fi
+unset DISPLAY
 
 time ./dw.sh ./script-runall.sh "$@" $CI_EXTRA_ARG

--- a/ci/builds/test-testrunner.sh
+++ b/ci/builds/test-testrunner.sh
@@ -34,7 +34,7 @@ cleanup() {
 
     do_cleanup=""
     if [ -n "${weston_pid}" ]; then
-        kill -9 $weston_pid 2>/dev/null
+        kill -9 $weston_pid 2>/dev/null || true
         weston_pid=""
     fi
 


### PR DESCRIPTION
- recommend by default to use 'Docker v1807' image,
- make it also works with Docker v1809 (release candidate) image,
  - unset DISPLAY (as it's fake on semaphoreci),
  - don't rely on external xvfb (use our own).