### PR TITLE
tests and fixes for rtHttp* listeners:

### DIFF
--- a/src/rtHttpRequest.cpp
+++ b/src/rtHttpRequest.cpp
@@ -91,27 +91,22 @@ rtHttpRequest::~rtHttpRequest()
 
 rtError rtHttpRequest::addListener(const rtString& eventName, const rtFunctionRef& f)
 {
-  mEmit->addListener(eventName, f);
-  return RT_OK;
+  return mEmit->addListener(eventName, f);
 }
 
 rtError rtHttpRequest::once(const rtString& eventName, const rtFunctionRef& f)
 {
-  mEmit->addListener(eventName, f);
-  // TODO
-  return RT_OK;
+  return mEmit->addListener(eventName, f, true);
 }
 
 rtError rtHttpRequest::removeAllListeners()
 {
-  mEmit->clearListeners();
-  return RT_OK;
+  return mEmit->clearListeners();
 }
 
 rtError rtHttpRequest::removeAllListenersByName(const rtString& eventName)
 {
-  mEmit->setListener(eventName.cString(), NULL);
-  return RT_OK;
+  return mEmit->clearListeners(eventName.cString());
 }
 
 rtError rtHttpRequest::abort() const
@@ -187,11 +182,14 @@ void rtHttpRequest::onDownloadComplete(rtFileDownloadRequest* downloadRequest)
   resp->setDownloadedData(downloadRequest->downloadedData(), downloadRequest->downloadedDataSize());
 
   rtObjectRef ref = resp; 
-  req->mEmit.send("response", ref);
 
-  resp->onData();
-
-  resp->onEnd();
+  if (downloadRequest->errorString().isEmpty()) {
+    req->mEmit.send("response", ref);
+    resp->onData();
+    resp->onEnd();
+  } else {
+    req->mEmit.send("error", downloadRequest->errorString());
+  }
 }
 
 rtString rtHttpRequest::url() const

--- a/src/rtHttpResponse.cpp
+++ b/src/rtHttpResponse.cpp
@@ -67,27 +67,22 @@ rtError rtHttpResponse::headers(rtObjectRef& v) const
 
 rtError rtHttpResponse::addListener(const rtString& eventName, const rtFunctionRef& f)
 {
-  mEmit->addListener(eventName, f);
-  return RT_OK;
+  return mEmit->addListener(eventName, f);
 }
 
 rtError rtHttpResponse::once(const rtString& eventName, const rtFunctionRef& f)
 {
-  mEmit->addListener(eventName, f);
-  // TODO
-  return RT_OK;
+  return mEmit->addListener(eventName, f, true);
 }
 
 rtError rtHttpResponse::removeAllListeners()
 {
-  mEmit->clearListeners();
-  return RT_OK;
+  return mEmit->clearListeners();
 }
 
 rtError rtHttpResponse::removeAllListenersByName(const rtString& eventName)
 {
-  mEmit->setListener(eventName.cString(), NULL);
-  return RT_OK;
+  return mEmit->clearListeners(eventName.cString());
 }
 
 void rtHttpResponse::setStatusCode(int32_t v)

--- a/src/rtObject.h
+++ b/src/rtObject.h
@@ -666,10 +666,11 @@ public:
   virtual unsigned long Release();
 
   rtError setListener(const char* eventName, rtIFunction* f);
-  rtError addListener(const char* eventName, rtIFunction* f);
+  rtError addListener(const char* eventName, rtIFunction* f, bool emitOnce = false);
   rtError delListener(const char* eventName, rtIFunction* f);
 
   rtError clearListeners() {mEntries.clear(); return RT_OK;}
+  rtError clearListeners(const char* eventName);
 
   virtual rtError Send(int numArgs,const rtValue* args,rtValue* result);
   virtual rtError SendAsync(int numArgs, const rtValue* args);
@@ -689,13 +690,14 @@ private:
   void processPendingEvents();
 
 protected:
-  struct _rtEmitEntry 
+  struct _rtEmitEntry
   {
     rtString n;
     rtFunctionRef f;
     bool isProp;
     bool markForDelete;
     size_t fnHash;
+    bool emitOnce;
   };
   
   std::vector<_rtEmitEntry> mEntries;

--- a/tests/pxScene2d/test_rtHttpRequest.cpp
+++ b/tests/pxScene2d/test_rtHttpRequest.cpp
@@ -48,7 +48,7 @@ public:
 
     req = new rtHttpRequest("https://example.com");
     ref = req;
-    EXPECT_EQ ((int)0, (int)req->url().compare("https://example.com"));
+    EXPECT_EQ (std::string(req->url().cString()), "https://example.com");
     EXPECT_EQ ((int)0, (int)req->headers().size());
     EXPECT_TRUE (req->method().isEmpty());
     EXPECT_TRUE (req->writeData().isEmpty());
@@ -73,12 +73,12 @@ public:
     req = new rtHttpRequest(options);
     req->write("{\"postKey1\":\"postValue1\"}");
     ref = req;
-    EXPECT_EQ ((int)0, (int)req->url().compare("http://httpbin.org/post"));
+    EXPECT_EQ (std::string(req->url().cString()), "http://httpbin.org/post");
     EXPECT_EQ ((int)2, (int)req->headers().size());
-    EXPECT_EQ ((int)0, (int)req->headers()[0].compare("Content-Type: application/json"));
-    EXPECT_EQ ((int)0, (int)req->headers()[1].compare("Authorization: token"));
-    EXPECT_EQ ((int)0, (int)req->method().compare("POST"));
-    EXPECT_EQ ((int)0, (int)req->writeData().compare("{\"postKey1\":\"postValue1\"}"));
+    EXPECT_EQ (std::string(req->headers()[0].cString()), "Content-Type: application/json");
+    EXPECT_EQ (std::string(req->headers()[1].cString()), "Authorization: token");
+    EXPECT_EQ (std::string(req->method().cString()), "POST");
+    EXPECT_EQ (std::string(req->writeData().cString()), "{\"postKey1\":\"postValue1\"}");
     EXPECT_FALSE (req->inQueue());
   }
 
@@ -90,15 +90,15 @@ public:
     req = new rtHttpRequest("https://example.com");
     req->setHeader("Authorization", "token");
     ref = req;
-    EXPECT_EQ ((int)0, (int)req->url().compare("https://example.com"));
+    EXPECT_EQ (std::string(req->url().cString()), "https://example.com");
     EXPECT_EQ ((int)1, (int)req->headers().size());
-    EXPECT_EQ ((int)0, (int)req->headers()[0].compare("Authorization: token"));
+    EXPECT_EQ (std::string(req->headers()[0].cString()), "Authorization: token");
     EXPECT_TRUE (req->method().isEmpty());
     EXPECT_TRUE (req->writeData().isEmpty());
     EXPECT_FALSE (req->inQueue());
   }
 
-  static rtError end_test_callback(int numArgs, const rtValue* args, rtValue* result, void* context)
+  static rtError end_test_callback1(int numArgs, const rtValue* args, rtValue* result, void* context)
   {
     EXPECT_EQ ((int)1, (int)numArgs);
 
@@ -111,6 +111,18 @@ public:
     EXPECT_TRUE (errorMessage.isEmpty());
 
     UNUSED_PARAM(result);
+
+    sem_post((sem_t*)context);
+    return RT_OK;
+  }
+
+  static rtError end_test_callback2(int numArgs, const rtValue* args, rtValue* result, void* context)
+  {
+    UNUSED_PARAM(numArgs);
+    UNUSED_PARAM(args);
+    UNUSED_PARAM(result);
+
+    EXPECT_FALSE (true);
 
     sem_post((sem_t*)context);
     return RT_OK;
@@ -131,19 +143,21 @@ public:
     headers.set("Authorization", "token");
     options.set("headers", headers);
 
-    rtFunctionRef fn;
+    rtFunctionRef fn1 = new rtFunctionCallback(end_test_callback1, testSem);
+    rtFunctionRef fn2 = new rtFunctionCallback(end_test_callback2, testSem);
 
     req = new rtHttpRequest(options);
-    req->addListener("response", new rtFunctionCallback(end_test_callback, testSem));
-    req->write("{\"postKey1\":\"postValue1\"}");
-    req->end();
+    EXPECT_EQ ((int)RT_OK, req->addListener("response", fn1));
+    EXPECT_EQ ((int)RT_OK, req->addListener("error", fn2));
+    EXPECT_EQ ((int)RT_OK, req->write("{\"postKey1\":\"postValue1\"}"));
+    EXPECT_EQ ((int)RT_OK, req->end());
     ref = req;
-    EXPECT_EQ ((int)0, (int)req->url().compare("http://httpbin.org/post"));
+    EXPECT_EQ (std::string(req->url().cString()), "http://httpbin.org/post");
     EXPECT_EQ ((int)2, (int)req->headers().size());
-    EXPECT_EQ ((int)0, (int)req->headers()[0].compare("Content-Type: application/json"));
-    EXPECT_EQ ((int)0, (int)req->headers()[1].compare("Authorization: token"));
-    EXPECT_EQ ((int)0, (int)req->method().compare("POST"));
-    EXPECT_EQ ((int)0, (int)req->writeData().compare("{\"postKey1\":\"postValue1\"}"));
+    EXPECT_EQ (std::string(req->headers()[0].cString()), "Content-Type: application/json");
+    EXPECT_EQ (std::string(req->headers()[1].cString()), "Authorization: token");
+    EXPECT_EQ (std::string(req->method().cString()), "POST");
+    EXPECT_EQ (std::string(req->writeData().cString()), "{\"postKey1\":\"postValue1\"}");
     EXPECT_TRUE (req->inQueue());
 
     // already in queue
@@ -152,6 +166,79 @@ public:
     EXPECT_EQ ((int)RT_FAIL, (int)req->setHeader("Key", "Value"));
 
     sem_wait(testSem);
+  }
+
+  static rtError addListener_test_callback(int numArgs, const rtValue* args, rtValue* result, void* context)
+  {
+    UNUSED_PARAM(numArgs);
+    UNUSED_PARAM(args);
+    UNUSED_PARAM(result);
+
+    int* times_fn_called = (int*)context;
+    (*times_fn_called)++;
+
+    return RT_OK;
+  }
+
+  void addListener_test()
+  {
+    rtObjectRef ref;
+    rtHttpRequest* req;
+
+    int times_fn1_called = 0;
+    int times_fn2_called = 0;
+    int times_fn3_called = 0;
+    rtFunctionRef fn1 = new rtFunctionCallback(addListener_test_callback, &times_fn1_called);
+    rtFunctionRef fn2 = new rtFunctionCallback(addListener_test_callback, &times_fn2_called);
+    rtFunctionRef fn3 = new rtFunctionCallback(addListener_test_callback, &times_fn3_called);
+
+    req = new rtHttpRequest("https://example.com");
+    EXPECT_EQ ((int)RT_OK, req->addListener("response", fn1));
+    EXPECT_EQ ((int)RT_OK, req->once("response", fn2));
+    EXPECT_EQ ((int)RT_OK, req->addListener("error", fn3));
+    ref = req;
+
+    rtFileDownloadRequest* dwnl_OK = new rtFileDownloadRequest("https://example.com", req, rtHttpRequest::onDownloadComplete);
+
+    rtHttpRequest::onDownloadComplete(dwnl_OK);
+    EXPECT_EQ (1, times_fn1_called);
+    EXPECT_EQ (1, times_fn2_called);
+    EXPECT_EQ (0, times_fn3_called);
+
+    rtHttpRequest::onDownloadComplete(dwnl_OK);
+    EXPECT_EQ (2, times_fn1_called);
+    EXPECT_EQ (1, times_fn2_called);
+    EXPECT_EQ (0, times_fn3_called);
+
+    EXPECT_EQ ((int)RT_OK, req->removeAllListenersByName("response"));
+
+    rtHttpRequest::onDownloadComplete(dwnl_OK);
+    EXPECT_EQ (2, times_fn1_called);
+    EXPECT_EQ (1, times_fn2_called);
+    EXPECT_EQ (0, times_fn3_called);
+
+    rtFileDownloadRequest* dwnl_ERR = new rtFileDownloadRequest("https://example.com", req, rtHttpRequest::onDownloadComplete);
+    dwnl_ERR->setErrorString("ERR test");
+
+    rtHttpRequest::onDownloadComplete(dwnl_ERR);
+    EXPECT_EQ (2, times_fn1_called);
+    EXPECT_EQ (1, times_fn2_called);
+    EXPECT_EQ (1, times_fn3_called);
+
+    rtHttpRequest::onDownloadComplete(dwnl_ERR);
+    EXPECT_EQ (2, times_fn1_called);
+    EXPECT_EQ (1, times_fn2_called);
+    EXPECT_EQ (2, times_fn3_called);
+
+    EXPECT_EQ ((int)RT_OK, req->removeAllListeners());
+
+    rtHttpRequest::onDownloadComplete(dwnl_ERR);
+    EXPECT_EQ (2, times_fn1_called);
+    EXPECT_EQ (1, times_fn2_called);
+    EXPECT_EQ (2, times_fn3_called);
+
+    delete dwnl_OK;
+    delete dwnl_ERR;
   }
 
   sem_t* testSem;
@@ -163,4 +250,5 @@ TEST_F(rtHttpRequestTest, rtHttpRequestTests)
   ctor_options_test();
   setHeader_test();
   end_test();
+  addListener_test();
 }

--- a/tests/pxScene2d/test_rtHttpResponse.cpp
+++ b/tests/pxScene2d/test_rtHttpResponse.cpp
@@ -37,9 +37,9 @@ public:
   {
     rtString s;
     s = rtHttpResponse::toLowercaseStr("Access-Control-Allow-Origin");
-    EXPECT_EQ ((int)0, (int)s.compare("access-control-allow-origin"));
+    EXPECT_EQ (std::string(s.cString()), "access-control-allow-origin");
     s = rtHttpResponse::toLowercaseStr("Access-Control-Allow-Credentials");
-    EXPECT_EQ ((int)0, (int)s.compare("access-control-allow-credentials"));
+    EXPECT_EQ (std::string(s.cString()), "access-control-allow-credentials");
   }
 
   void parseHeaders_test()
@@ -61,15 +61,15 @@ public:
     rtError e = rtHttpResponse::parseHeaders(rawHeaderData, headerMap);
     EXPECT_EQ ((int)RT_OK, (int)e);
     EXPECT_EQ ((int)9, (int)headerMap.size());
-    EXPECT_EQ ((int)0, (int)headerMap["content-type"].compare("application/json"));
-    EXPECT_EQ ((int)0, (int)headerMap["set-cookie"].compare("cookie-from-server=noop"));
-    EXPECT_EQ ((int)0, (int)headerMap["access-control-allow-origin"].compare(""));
-    EXPECT_EQ ((int)0, (int)headerMap["x-cloud-trace-context"].compare("209bc1a00c7409bf54f1642316d9fe6f;o=1"));
-    EXPECT_EQ ((int)0, (int)headerMap["date"].compare("Tue, 10 Jul 2018 14:33:54 GMT"));
-    EXPECT_EQ ((int)0, (int)headerMap["server"].compare("Google Frontend"));
-    EXPECT_EQ ((int)0, (int)headerMap["content-length"].compare("845"));
-    EXPECT_EQ ((int)0, (int)headerMap["expires"].compare("Tue, 10 Jul 2018 14:33:54 GMT"));
-    EXPECT_EQ ((int)0, (int)headerMap["connection"].compare("close"));
+    EXPECT_EQ (std::string(headerMap["content-type"].cString()), "application/json");
+    EXPECT_EQ (std::string(headerMap["set-cookie"].cString()), "cookie-from-server=noop");
+    EXPECT_EQ (std::string(headerMap["access-control-allow-origin"].cString()), "");
+    EXPECT_EQ (std::string(headerMap["x-cloud-trace-context"].cString()), "209bc1a00c7409bf54f1642316d9fe6f;o=1");
+    EXPECT_EQ (std::string(headerMap["date"].cString()), "Tue, 10 Jul 2018 14:33:54 GMT");
+    EXPECT_EQ (std::string(headerMap["server"].cString()), "Google Frontend");
+    EXPECT_EQ (std::string(headerMap["content-length"].cString()), "845");
+    EXPECT_EQ (std::string(headerMap["expires"].cString()), "Tue, 10 Jul 2018 14:33:54 GMT");
+    EXPECT_EQ (std::string(headerMap["connection"].cString()), "close");
 
     rawHeaderData =
      "HTTP/1.1 200 OK\r\n"
@@ -90,18 +90,18 @@ public:
     e = rtHttpResponse::parseHeaders(rawHeaderData, headerMap);
     EXPECT_EQ ((int)RT_OK, (int)e);
     EXPECT_EQ ((int)12, (int)headerMap.size());
-    EXPECT_EQ ((int)0, (int)headerMap["date"].compare("Tue, 02 Oct 2018 13:24:44 GMT"));
-    EXPECT_EQ ((int)0, (int)headerMap["content-type"].compare("text/html"));
-    EXPECT_EQ ((int)0, (int)headerMap["transfer-encoding"].compare("chunked"));
-    EXPECT_EQ ((int)0, (int)headerMap["connection"].compare("keep-alive"));
-    EXPECT_EQ ((int)0, (int)headerMap["set-cookie"].compare("__cfduid=d17b30f71dcb858abe7f0067525cbb0721538486684; expires=Wed, 02-Oct-19 13:24:44 GMT; path=/; domain=.nodejs.org; HttpOnly"));
-    EXPECT_EQ ((int)0, (int)headerMap["last-modified"].compare("Sat, 29 Sep 2018 11:08:33 GMT"));
-    EXPECT_EQ ((int)0, (int)headerMap["cf-cache-status"].compare("HIT"));
-    EXPECT_EQ ((int)0, (int)headerMap["expires"].compare("Tue, 02 Oct 2018 17:24:44 GMT"));
-    EXPECT_EQ ((int)0, (int)headerMap["cache-control"].compare("public, max-age=14400"));
-    EXPECT_EQ ((int)0, (int)headerMap["expect-ct"].compare("max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\""));
-    EXPECT_EQ ((int)0, (int)headerMap["server"].compare("cloudflare"));
-    EXPECT_EQ ((int)0, (int)headerMap["cf-ray"].compare("46377db4dc4d8267-KBP"));
+    EXPECT_EQ (std::string(headerMap["date"].cString()), "Tue, 02 Oct 2018 13:24:44 GMT");
+    EXPECT_EQ (std::string(headerMap["content-type"].cString()), "text/html");
+    EXPECT_EQ (std::string(headerMap["transfer-encoding"].cString()), "chunked");
+    EXPECT_EQ (std::string(headerMap["connection"].cString()), "keep-alive");
+    EXPECT_EQ (std::string(headerMap["set-cookie"].cString()), "__cfduid=d17b30f71dcb858abe7f0067525cbb0721538486684; expires=Wed, 02-Oct-19 13:24:44 GMT; path=/; domain=.nodejs.org; HttpOnly");
+    EXPECT_EQ (std::string(headerMap["last-modified"].cString()), "Sat, 29 Sep 2018 11:08:33 GMT");
+    EXPECT_EQ (std::string(headerMap["cf-cache-status"].cString()), "HIT");
+    EXPECT_EQ (std::string(headerMap["expires"].cString()), "Tue, 02 Oct 2018 17:24:44 GMT");
+    EXPECT_EQ (std::string(headerMap["cache-control"].cString()), "public, max-age=14400");
+    EXPECT_EQ (std::string(headerMap["expect-ct"].cString()), "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"");
+    EXPECT_EQ (std::string(headerMap["server"].cString()), "cloudflare");
+    EXPECT_EQ (std::string(headerMap["cf-ray"].cString()), "46377db4dc4d8267-KBP");
 
     rawHeaderData =
       "Server:\t\t\tApache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips\n"
@@ -114,11 +114,11 @@ public:
     e = rtHttpResponse::parseHeaders(rawHeaderData, headerMap);
     EXPECT_EQ ((int)RT_OK, (int)e);
     EXPECT_EQ ((int)5, (int)headerMap.size());
-    EXPECT_EQ ((int)0, (int)headerMap["server"].compare("Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips"));
-    EXPECT_EQ ((int)0, (int)headerMap["location"].compare("https://example.com "));
-    EXPECT_EQ ((int)0, (int)headerMap["content-length"].compare("284"));
-    EXPECT_EQ ((int)0, (int)headerMap["connection"].compare(""));
-    EXPECT_EQ ((int)0, (int)headerMap["content-type"].compare("text/html; charset=iso-8859-1"));
+    EXPECT_EQ (std::string(headerMap["server"].cString()), "Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips");
+    EXPECT_EQ (std::string(headerMap["location"].cString()), "https://example.com ");
+    EXPECT_EQ (std::string(headerMap["content-length"].cString()), "284");
+    EXPECT_EQ (std::string(headerMap["connection"].cString()), "");
+    EXPECT_EQ (std::string(headerMap["content-type"].cString()), "text/html; charset=iso-8859-1");
 
     rawHeaderData =
       "Server:Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips\r\n"
@@ -131,10 +131,10 @@ public:
     e = rtHttpResponse::parseHeaders(rawHeaderData, headerMap);
     EXPECT_EQ ((int)RT_OK, (int)e);
     EXPECT_EQ ((int)4, (int)headerMap.size());
-    EXPECT_EQ ((int)0, (int)headerMap["server"].compare("Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips"));
-    EXPECT_EQ ((int)0, (int)headerMap["x-cloud-trace-context"].compare("敷リオワニ内前ヲルホ"));
-    EXPECT_EQ ((int)0, (int)headerMap["access-control-allow-origin"].compare("http://localhost:8888"));
-    EXPECT_EQ ((int)0, (int)headerMap["connection"].compare("CLOSE"));
+    EXPECT_EQ (std::string(headerMap["server"].cString()), "Apache/2.4.6 (CentOS) OpenSSL/1.0.1e-fips");
+    EXPECT_EQ (std::string(headerMap["x-cloud-trace-context"].cString()), "敷リオワニ内前ヲルホ");
+    EXPECT_EQ (std::string(headerMap["access-control-allow-origin"].cString()), "http://localhost:8888");
+    EXPECT_EQ (std::string(headerMap["connection"].cString()), "CLOSE");
 
     rawHeaderData =
       "content-type: application/json"
@@ -143,7 +143,7 @@ public:
     e = rtHttpResponse::parseHeaders(rawHeaderData, headerMap);
     EXPECT_EQ ((int)RT_OK, (int)e);
     EXPECT_EQ ((int)1, (int)headerMap.size());
-    EXPECT_EQ ((int)0, (int)headerMap["content-type"].compare("application/json"));
+    EXPECT_EQ (std::string(headerMap["content-type"].cString()), "application/json");
 
     rawHeaderData =
       "x"
@@ -161,10 +161,76 @@ public:
     EXPECT_EQ ((int)RT_OK, (int)e);
     EXPECT_EQ ((int)0, (int)headerMap.size());
   }
+
+  static rtError addListener_test_callback(int numArgs, const rtValue* args, rtValue* result, void* context)
+  {
+    UNUSED_PARAM(numArgs);
+    UNUSED_PARAM(args);
+    UNUSED_PARAM(result);
+
+    int* times_fn_called = (int*)context;
+    (*times_fn_called)++;
+
+    return RT_OK;
+  }
+
+  void addListener_test()
+  {
+    rtObjectRef ref;
+    rtHttpResponse* resp;
+
+    int times_fn1_called = 0;
+    int times_fn2_called = 0;
+    int times_fn3_called = 0;
+    rtFunctionRef fn1 = new rtFunctionCallback(addListener_test_callback, &times_fn1_called);
+    rtFunctionRef fn2 = new rtFunctionCallback(addListener_test_callback, &times_fn2_called);
+    rtFunctionRef fn3 = new rtFunctionCallback(addListener_test_callback, &times_fn3_called);
+
+    resp = new rtHttpResponse();
+    EXPECT_EQ ((int)RT_OK, resp->addListener("data", fn1));
+    EXPECT_EQ ((int)RT_OK, resp->once("data", fn2));
+    EXPECT_EQ ((int)RT_OK, resp->addListener("end", fn3));
+    ref = resp;
+
+    resp->onData();
+    EXPECT_EQ (1, times_fn1_called);
+    EXPECT_EQ (1, times_fn2_called);
+    EXPECT_EQ (0, times_fn3_called);
+
+    resp->onData();
+    EXPECT_EQ (2, times_fn1_called);
+    EXPECT_EQ (1, times_fn2_called);
+    EXPECT_EQ (0, times_fn3_called);
+
+    EXPECT_EQ ((int)RT_OK, resp->removeAllListenersByName("data"));
+
+    resp->onData();
+    EXPECT_EQ (2, times_fn1_called);
+    EXPECT_EQ (1, times_fn2_called);
+    EXPECT_EQ (0, times_fn3_called);
+
+    resp->onEnd();
+    EXPECT_EQ (2, times_fn1_called);
+    EXPECT_EQ (1, times_fn2_called);
+    EXPECT_EQ (1, times_fn3_called);
+
+    resp->onEnd();
+    EXPECT_EQ (2, times_fn1_called);
+    EXPECT_EQ (1, times_fn2_called);
+    EXPECT_EQ (2, times_fn3_called);
+
+    EXPECT_EQ ((int)RT_OK, resp->removeAllListeners());
+
+    resp->onEnd();
+    EXPECT_EQ (2, times_fn1_called);
+    EXPECT_EQ (1, times_fn2_called);
+    EXPECT_EQ (2, times_fn3_called);
+  }
 };
 
 TEST_F(rtHttpResponseTest, rtHttpResponseTests)
 {
   toLowercaseStr_test();
   parseHeaders_test();
+  addListener_test();
 }


### PR DESCRIPTION
* tests for rtHttpRequest
* tests for rtHttpResponse
* new methods for rtEmit: clearListeners by event name, 'once' listeners
* fix for rtHttpRequest: emit 'error' instead of 'response' in case error set