### PR TITLE
fix: Add handling of symlink to spark.sh

### DIFF
--- a/examples/pxScene2d/pxScene2d_xcode/spark.sh
+++ b/examples/pxScene2d/pxScene2d_xcode/spark.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 #Get absolute path to this script
-THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  THIS_DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$THIS_DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+THIS_DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 cd "$THIS_DIR"
 

--- a/examples/pxScene2d/src/macstuff/spark.sh
+++ b/examples/pxScene2d/src/macstuff/spark.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #Get absolute path to this script
-THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+THIS_DIR="$( cd "$( dirname "$( realpath -e "${BASH_SOURCE[0]}" )" )" && pwd )"
 
 cd "$THIS_DIR"
 

--- a/examples/pxScene2d/src/macstuff/spark.sh
+++ b/examples/pxScene2d/src/macstuff/spark.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 #Get absolute path to this script
-THIS_DIR="$( cd "$( dirname "$( realpath -e "${BASH_SOURCE[0]}" )" )" && pwd )"
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  THIS_DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$THIS_DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+THIS_DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 cd "$THIS_DIR"
 

--- a/examples/pxScene2d/src/spark.sh
+++ b/examples/pxScene2d/src/spark.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 #Get absolute path to this script
-THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  THIS_DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$THIS_DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+THIS_DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
 
 cd $THIS_DIR
 


### PR DESCRIPTION
Use `realpath` to resolve any symlinks to get the actual directory of
this shell script.  This allows for symlinks to spark.sh to work
correctly instead of using the directory of the symlink.