### PR TITLE
Adding memory usage for rtValue and pxObject

### DIFF
--- a/examples/pxScene2d/src/Spark.cpp
+++ b/examples/pxScene2d/src/Spark.cpp
@@ -103,7 +103,7 @@ char** g_origArgv = NULL;
 #endif
 bool gDumpMemUsage = false;
 extern bool gApplicationIsClosing;
-extern int pxObjectCount;
+extern uint32_t pxObjectCount_;
 
 #include "pxFont.h"
 
@@ -313,7 +313,7 @@ protected:
       #endif
       script.collectGarbage();
       rtThreadPool::globalInstance()->destroy();
-      rtLogInfo("pxobjectcount is [%d]",pxObjectCount);
+      rtLogInfo("pxObjectCount is [%d]",pxObjectCount_);
 #ifndef PX_PLATFORM_DFB_NON_X11
       rtLogInfo("texture memory usage is [%" PRId64 "]",context.currentTextureMemoryUsageInBytes());
 #endif

--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -109,6 +109,8 @@ static int fpsWarningThreshold = 25;
 
 rtEmitRef pxScriptView::mEmit = new rtEmit();
 
+uint32_t pxObjectSize  = sizeof(pxObject);
+
 // Debug Statistics
 #ifdef USE_RENDER_STATS
 
@@ -151,7 +153,8 @@ void stopProfiling()
   CALLGRIND_STOP_INSTRUMENTATION;
 }
 #endif //ENABLE_VALGRIND
-int pxObjectCount = 0;
+
+uint32_t pxObjectCount_ = 0;
 bool gApplicationIsClosing = false;
 
 #include <rapidjson/document.h>
@@ -463,7 +466,7 @@ pxObject::pxObject(pxScene2d* scene): rtObject(), mParent(NULL), mpx(0), mpy(0),
     , mIsDirty(true), mRenderMatrix(), mScreenCoordinates(), mDirtyRect()
     ,mDrawableSnapshotForMask(), mMaskSnapshot(), mIsDisposed(false), mSceneSuspended(false)
   {
-    pxObjectCount++;
+    pxObjectCount_++;
     mScene = scene;
     mReady = new rtPromise;
     mEmit = new rtEmit;
@@ -483,7 +486,7 @@ pxObject::~pxObject()
       (*it)->mParent = NULL;  // setParent mutates the mChildren collection
     }
     mChildren.clear();
-    pxObjectCount--;
+    pxObjectCount_--;
     clearSnapshot(mSnapshotRef);
     clearSnapshot(mClipSnapshotRef);
     clearSnapshot(mDrawableSnapshotForMask);
@@ -2332,7 +2335,7 @@ rtError pxScene2d::logDebugMetrics()
 {
 #ifdef ENABLE_DEBUG_METRICS
     script.collectGarbage();
-    rtLogInfo("pxobjectcount is [%d]",pxObjectCount);
+    rtLogInfo("pxObjectCount_ is [%d]",pxObjectCount_);
 #ifdef PX_PLATFORM_MAC
       rtLogInfo("texture memory usage is [%lld]",context.currentTextureMemoryUsageInBytes());
 #else
@@ -2636,9 +2639,9 @@ void pxScene2d::onUpdate(double t)
       // double update_ms = ( (double) sigma_update   / (double) frameCount ) * 1000.0f; // Average update time
 
       // rtLogDebug("%g fps   pxObjects: %d   Draw: %g   Tex: %g   Fbo: %g     draw_ms: %0.04g   update_ms: %0.04g\n",
-      //     fps, pxObjectCount, dpf, bpf, fpf, draw_ms, update_ms );
+      //     fps, pxObjectCount_, dpf, bpf, fpf, draw_ms, update_ms );
 
-      rtLogDebug("%g fps   pxObjects: %d   Draw: %g   Tex: %g   Fbo: %g \n", fps, pxObjectCount, dpf, bpf, fpf);
+      rtLogDebug("%g fps   pxObjects: %d   Draw: %g   Tex: %g   Fbo: %g \n", fps, pxObjectCount_, dpf, bpf, fpf);
 
       gDrawCalls    = 0;
       gTexBindCalls = 0;
@@ -2665,7 +2668,7 @@ void pxScene2d::onUpdate(double t)
       }
     }
     previousFps = fps;
-    rtLogDebug("%d fps   pxObjects: %d\n", fps, pxObjectCount);
+    rtLogDebug("%d fps   pxObjects: %d\n", fps, pxObjectCount_);
 #endif //USE_RENDER_STATS
 
     {

--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -93,6 +93,12 @@ class AsyncScriptInfo {
 // TODO Move this to pxEventLoop
 extern rtThreadQueue* gUIThreadQueue;
 
+extern uint32_t rtValueCount_;
+extern uint32_t rtValueSize;
+
+extern uint32_t pxObjectCount_;
+extern uint32_t pxObjectSize;
+
 // TODO Finish
 //#include "pxTransform.h"
 #include "pxConstants.h"
@@ -1344,6 +1350,35 @@ class pxScene2d: public rtObject, public pxIView, public rtIServiceProvider
 {
 public:
   rtDeclareObject(pxScene2d, rtObject);
+  
+  rtReadOnlyProperty(pxObjectBytes, pxObjectBytes, uint32_t);
+  rtError pxObjectBytes(uint32_t& v) const
+  {
+    v = pxObjectCount_ * pxObjectSize;
+    return RT_OK;
+  }
+  
+  rtReadOnlyProperty(pxObjectCount, pxObjectCount, uint32_t);
+  rtError pxObjectCount(uint32_t& v) const
+  {
+    v = pxObjectCount_;
+    return RT_OK;
+  }
+  
+  rtReadOnlyProperty(rtValueBytes, rtValueBytes, uint32_t);
+  rtError rtValueBytes(uint32_t& v) const
+  {
+    v = rtValueCount_ * rtValueSize;
+    return RT_OK;
+  }
+
+  rtReadOnlyProperty(rtValueCount, rtValueCount, uint32_t);
+  rtError rtValueCount(uint32_t& v) const
+  {
+    v = rtValueCount_;
+    return RT_OK;
+  }
+  
   rtReadOnlyProperty(root, root, rtObjectRef);
   rtReadOnlyProperty(w, w, int32_t);
   rtReadOnlyProperty(h, h, int32_t);

--- a/examples/pxScene2d/src/rcvrcore/scene.1.js
+++ b/examples/pxScene2d/src/rcvrcore/scene.1.js
@@ -35,10 +35,16 @@ function Scene() {
       this.animation = scene.animation;
       this.stretch   = scene.stretch;
       this.maskOp    = scene.maskOp;
-      this.alignVertical = scene.alignVertical;
+      this.alignVertical   = scene.alignVertical;
       this.alignHorizontal = scene.alignHorizontal;
       this.truncation = scene.truncation;
       this.root = scene.root;
+      
+      this.pxObjectCount = scene.pxObjectCount;
+      this.pxObjectBytes = scene.pxObjectBytes;
+      this.rtValueCount  = scene.rtValueCount;
+      this.rtValueBytes  = scene.rtValueBytes;
+
       this.info = scene.info;
       this.capabilities = scene.capabilities;
       this.filePath = filePath;

--- a/src/rtValue.cpp
+++ b/src/rtValue.cpp
@@ -24,27 +24,31 @@
 #include "rtObject.h"
 #include "rtValue.h"
 
-rtValue::rtValue()                      :mType(0) { setEmpty();   }
-rtValue::rtValue(bool v)                :mType(0) { setBool(v);   }
-rtValue::rtValue(int8_t v)              :mType(0) { setInt8(v);   }
-rtValue::rtValue(uint8_t v)             :mType(0) { setUInt8(v);  }
-rtValue::rtValue(int32_t v)             :mType(0) { setInt32(v);  }
-rtValue::rtValue(uint32_t v)            :mType(0) { setUInt32(v); }
-rtValue::rtValue(int64_t v)             :mType(0) { setInt64(v);  }
-rtValue::rtValue(uint64_t v)            :mType(0) { setUInt64(v); }
-rtValue::rtValue(float v)               :mType(0) { setFloat(v);  }
-rtValue::rtValue(double v)              :mType(0) { setDouble(v); }
-rtValue::rtValue(const char* v)         :mType(0) { setString(v); }
-rtValue::rtValue(const rtString& v)     :mType(0) { setString(v); }
-rtValue::rtValue(const rtIObject* v)    :mType(0) { setObject(v); }
-rtValue::rtValue(const rtObjectRef& v)  :mType(0) { setObject(v); }
-rtValue::rtValue(const rtIFunction* v)  :mType(0) { setFunction(v); }
-rtValue::rtValue(const rtFunctionRef& v):mType(0) { setFunction(v); }
-rtValue::rtValue(const rtValue& v)      :mType(0) { setValue(v);  }
-rtValue::rtValue(voidPtr v)             :mType(0) { setVoidPtr(v); }
+uint32_t rtValueCount_ = 0;
+uint32_t rtValueSize  = sizeof(rtValue);
+
+rtValue::rtValue()                      :mType(0) { rtValueCount_++;  setEmpty();     }
+rtValue::rtValue(bool v)                :mType(0) { rtValueCount_++;  setBool(v);     }
+rtValue::rtValue(int8_t v)              :mType(0) { rtValueCount_++;  setInt8(v);     }
+rtValue::rtValue(uint8_t v)             :mType(0) { rtValueCount_++;  setUInt8(v);    }
+rtValue::rtValue(int32_t v)             :mType(0) { rtValueCount_++;  setInt32(v);    }
+rtValue::rtValue(uint32_t v)            :mType(0) { rtValueCount_++;  setUInt32(v);   }
+rtValue::rtValue(int64_t v)             :mType(0) { rtValueCount_++;  setInt64(v);    }
+rtValue::rtValue(uint64_t v)            :mType(0) { rtValueCount_++;  setUInt64(v);   }
+rtValue::rtValue(float v)               :mType(0) { rtValueCount_++;  setFloat(v);    }
+rtValue::rtValue(double v)              :mType(0) { rtValueCount_++;  setDouble(v);   }
+rtValue::rtValue(const char* v)         :mType(0) { rtValueCount_++;  setString(v);   }
+rtValue::rtValue(const rtString& v)     :mType(0) { rtValueCount_++;  setString(v);   }
+rtValue::rtValue(const rtIObject* v)    :mType(0) { rtValueCount_++;  setObject(v);   }
+rtValue::rtValue(const rtObjectRef& v)  :mType(0) { rtValueCount_++;  setObject(v);   }
+rtValue::rtValue(const rtIFunction* v)  :mType(0) { rtValueCount_++;  setFunction(v); }
+rtValue::rtValue(const rtFunctionRef& v):mType(0) { rtValueCount_++;  setFunction(v); }
+rtValue::rtValue(const rtValue& v)      :mType(0) { rtValueCount_++;  setValue(v);    }
+rtValue::rtValue(voidPtr v)             :mType(0) { rtValueCount_++;  setVoidPtr(v);  }
 
 rtValue::~rtValue()
 {
+  rtValueCount_--;
   term();
 }
 

--- a/tests/pxScene2d/test_jsfiles.cpp
+++ b/tests/pxScene2d/test_jsfiles.cpp
@@ -44,7 +44,7 @@ using namespace std;
 extern rtScript script;
 extern int gargc;
 extern char** gargv;
-extern int pxObjectCount;
+extern int pxObjectCount_;
 
 void fgDeinitialize( void )
 {
@@ -133,7 +133,7 @@ class jsFilesTest : public testing::Test
     void test(const char* file, float timeout)
     {
       script.collectGarbage();
-      int oldpxCount = pxObjectCount;
+      int oldpxCount = pxObjectCount_;
       long oldtextMem = mContext.currentTextureMemoryUsageInBytes();
       startJsFile(file);
       process(timeout);
@@ -141,8 +141,8 @@ class jsFilesTest : public testing::Test
       script.collectGarbage();
       //currently we are getting the count +1 , due to which test is failing
       //suspecting this is due to scenecontainer without parent leak.
-      //EXPECT_TRUE (pxObjectCount == oldpxCount);
-      printf("old px count [%d] new px count [%d] \n",oldpxCount,pxObjectCount);
+      //EXPECT_TRUE (pxObjectCount_ == oldpxCount);
+      printf("old px count [%d] new px count [%d] \n",oldpxCount,pxObjectCount_);
       fflush(stdout);
       EXPECT_TRUE (mContext.currentTextureMemoryUsageInBytes() == oldtextMem);
     }


### PR DESCRIPTION
Exposed in JS as follows...

```
console.log("PX OBJECT COUNT: " +  scene.pxObjectCount );
console.log("PX OBJECT BYTES: " +  scene.pxObjectBytes );

console.log("RT VALUE COUNT: " +  scene.rtValueCount );
console.log("RT VALUE BYTES: " +  scene.rtValueBytes );
console.log("TEX MEMORY: " + scene.textureMemoryUsage() )
```