### PR TITLE
Adding time units [ms or s] support to animateTo

### DIFF
--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -197,7 +197,7 @@ public:
   rtMethodNoArgAndNoReturn("moveForward", moveForward);
   rtMethodNoArgAndNoReturn("moveBackward", moveBackward);
 
-  rtMethod5ArgAndReturn("animateTo", animateToP2, rtObjectRef, double,
+  rtMethod5ArgAndReturn("animateTo", animateToP2, rtObjectRef, rtValue,
                         uint32_t, uint32_t, int32_t, rtObjectRef);
 
   rtMethod5ArgAndReturn("animate", animateToObj, rtObjectRef, double,
@@ -403,7 +403,7 @@ public:
                      uint32_t interp, uint32_t options,
                      int32_t count, rtObjectRef promise);
 
-  rtError animateToP2(rtObjectRef props, double duration, 
+  rtError animateToP2(rtObjectRef props, rtValue duration,
                       uint32_t interp, uint32_t options,
                       int32_t count, rtObjectRef& promise);
 


### PR DESCRIPTION
Adding flexible units support to **animateTo()** ...

```
  o.animateTo({sx:0.2,sy:0.2},    1.2        , scene.animation.TWEEN_LINEAR, scene.animation.OPTION_LOOP, 1)            <<<<<<<< CURRENT SUPPORT (seconds only)
  o.animateTo({sx:0.2,sy:0.2},    "1200ms"   , scene.animation.TWEEN_LINEAR, scene.animation.OPTION_LOOP, 1)
  o.animateTo({sx:0.2,sy:0.2},    "1200 ms"  , scene.animation.TWEEN_LINEAR, scene.animation.OPTION_LOOP, 1)
  o.animateTo({sx:0.2,sy:0.2},    "1.2s"     , scene.animation.TWEEN_LINEAR, scene.animation.OPTION_LOOP, 1)
  o.animateTo({sx:0.2,sy:0.2},    "1.200S"   , scene.animation.TWEEN_LINEAR, scene.animation.OPTION_LOOP, 1)
```

... in a FULLY backward compatible manner.

This change provides support for the use of **milliseconds** in a manner more consistent with **setTimeout()** and *setInterval()*