### PR TITLE
build fix:

### DIFF
--- a/examples/pxScene2d/src/glut/pxContextUtils.cpp
+++ b/examples/pxScene2d/src/glut/pxContextUtils.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 
 #include "pxContextUtils.h"
 
-pxError deleteInternalGLContext(int id)
+pxError deleteInternalGLContext(int)
 {
   //TODO
   return PX_OK;

--- a/examples/pxScene2d/src/pxTextBox.cpp
+++ b/examples/pxScene2d/src/pxTextBox.cpp
@@ -274,14 +274,14 @@ float pxTextBox::getOnscreenWidth()
 {
     // TODO review max texture handling
     rtRefT<pxTextBounds> bounds = getMeasurements()->getBounds();
-    return pxMax(mw, abs(bounds->x2()-bounds->x1()));
+    return pxMax(mw, fabsf(bounds->x2()-bounds->x1()));
 }
 
 float pxTextBox::getOnscreenHeight()
 {
     // TODO review max texture handling
     rtRefT<pxTextBounds> bounds = getMeasurements()->getBounds();
-    return pxMax(mh, abs(bounds->y2()-bounds->y1()));
+    return pxMax(mh, fabsf(bounds->y2()-bounds->y1()));
 }
 
 void pxTextBox::update(double t)


### PR DESCRIPTION
/home/npoltorapavlo/pxCore/examples/pxScene2d/src/pxTextBox.cpp:277:52: error: no matching function for call to ‘pxMax(float&, int)’
     return pxMax(mw, abs(bounds->x2()-bounds->x1()));
                                                    ^
/home/npoltorapavlo/pxCore/examples/pxScene2d/src/glut/pxContextUtils.cpp:21:37: warning: unused parameter ‘id’ [-Wunused-parameter]
 pxError deleteInternalGLContext(int id)
                                     ^