### PR TITLE
Mutex lock/unlock is not required during reaching from cache. DELIA-3…

### DIFF
--- a/src/rtFileDownloader.cpp
+++ b/src/rtFileDownloader.cpp
@@ -426,6 +426,7 @@ FILE* rtFileDownloadRequest::cacheFilePointer(void)
   {
     if ((NULL != rtFileCache::instance()) && (RT_OK == rtFileCache::instance()->httpCacheData(this->fileUrl(), cachedData)))
     {
+      rtLogInfo("fileUrl[%s] fileName[%s] \n", this->fileUrl().cString(), cachedData.fileName().cString());
       return cachedData.filePointer();
     }
   }
@@ -717,7 +718,7 @@ void rtFileDownloader::downloadFile(rtFileDownloadRequest* downloadRequest)
     {
         if(downloadRequest->deferCacheRead())
         {
-            mFileCacheMutex.lock();
+            rtLogInfo("Reading from cache Start for %s\n", downloadRequest->fileUrl().cString());
             FILE *fp = downloadRequest->cacheFilePointer();
 
             if(fp != NULL)
@@ -746,13 +747,15 @@ void rtFileDownloader::downloadFile(rtFileDownloadRequest* downloadRequest)
                 delete [] buffer;
                 fclose(fp);
             }
-            mFileCacheMutex.unlock();
+            rtLogInfo("Reading from cache End for %s\n", downloadRequest->fileUrl().cString());
         }
     }
     else
 #endif
     {
+      rtLogInfo("downloadFromNetwork Start for %s\n", downloadRequest->fileUrl().cString());
       nwDownloadSuccess = downloadFromNetwork(downloadRequest);
+      rtLogInfo("downloadFromNetwork End for %s\n", downloadRequest->fileUrl().cString());
     }    
     
     if (!downloadRequest->executeCallback(downloadRequest->downloadStatusCode()))

--- a/src/rtFileDownloader.cpp
+++ b/src/rtFileDownloader.cpp
@@ -753,9 +753,7 @@ void rtFileDownloader::downloadFile(rtFileDownloadRequest* downloadRequest)
     else
 #endif
     {
-      rtLogInfo("downloadFromNetwork Start for %s\n", downloadRequest->fileUrl().cString());
       nwDownloadSuccess = downloadFromNetwork(downloadRequest);
-      rtLogInfo("downloadFromNetwork End for %s\n", downloadRequest->fileUrl().cString());
     }    
     
     if (!downloadRequest->executeCallback(downloadRequest->downloadStatusCode()))

--- a/src/rtHttpCache.cpp
+++ b/src/rtHttpCache.cpp
@@ -368,6 +368,11 @@ void rtHttpCacheData::setFileName(rtString& fileName)
   mFileName = fileName;
 }
 
+rtString rtHttpCacheData::fileName(void)
+{
+  return mFileName;
+}
+
 void rtHttpCacheData::setExpirationDate()
 {
   bool foundMaxAge = false;

--- a/src/rtHttpCache.h
+++ b/src/rtHttpCache.h
@@ -86,6 +86,8 @@ class rtHttpCacheData
 
     void setFileName(rtString& fileName);
 
+    rtString fileName(void);
+
   private:
     /* populates the map with header attribute and value */
     void populateHeaderMap();


### PR DESCRIPTION
Mutex lock/unlock is not required during reaching from cache. The issue reported in DELIA-33016 got fixed with this fix.