### PR TITLE
RDK-24363 : Added support for byte range rtFileDownload.

### DIFF
--- a/src/rtFileCache.cpp
+++ b/src/rtFileCache.cpp
@@ -267,7 +267,7 @@ rtError rtFileCache::addToCache(const rtHttpCacheData& data)
   mCurrentSize += mFileSizeMap[filename];
   int64_t size = cleanup();
   mCacheMutex.unlock();
-  rtLogDebug("addToCache url(%s) filename(%s) size(%ld) Cache expiration(%s) total cache size (%ld)", url.cString(), filename.cString(), (long) mFileSizeMap[filename], data.expirationDate().cString(), (long) size);
+  rtLogInfo("addToCache url(%s) filename(%s) size(%ld) Cache expiration(%s) total cache size (%ld)", url.cString(), filename.cString(), (long) mFileSizeMap[filename], data.expirationDate().cString(), (long) size);
   return RT_OK;
 }
 

--- a/src/rtFileDownloader.cpp
+++ b/src/rtFileDownloader.cpp
@@ -584,9 +584,9 @@ void rtFileDownloadRequest::setByteRangeIntervals(const char* byteRangeIntervals
   mByteRangeIntervals = rtString(byteRangeIntervals);
 }
 
-char* rtFileDownloadRequest::byteRangeIntervals(void)
+rtString rtFileDownloadRequest::byteRangeIntervals(void)
 {
-  return mByteRangeIntervals.cString();
+  return mByteRangeIntervals;
 }
 
 void rtFileDownloadRequest::setDownloadOnly(bool downloadOnly)
@@ -982,7 +982,8 @@ bool rtFileDownloader::downloadFromNetwork(rtFileDownloadRequest* downloadReques
 
     if(downloadRequest->isByteRangeEnabled())
     {
-      curl_easy_setopt(curl_handle, CURLOPT_RANGE, (char*)downloadRequest->byteRangeIntervals());
+      rtString byteRangeIntervals = downloadRequest->byteRangeIntervals();
+      curl_easy_setopt(curl_handle, CURLOPT_RANGE, byteRangeIntervals.cString());
     }
 
     /* get it! */

--- a/src/rtFileDownloader.h
+++ b/src/rtFileDownloader.h
@@ -118,7 +118,7 @@ public:
   void setByteRangeEnable(bool bByteRangeFlag);
   bool isByteRangeEnabled(void);
   void setByteRangeIntervals(const char* byteRangeIntervals);
-  char* byteRangeIntervals(void);
+  rtString byteRangeIntervals(void);
 
 private:
   rtString mFileUrl;

--- a/src/rtFileDownloader.h
+++ b/src/rtFileDownloader.h
@@ -111,6 +111,14 @@ public:
   size_t readDataSize() const;
   rtObjectRef downloadMetrics() const;
   void setDownloadMetrics(int32_t connectTimeMs, int32_t sslConnectTimeMs, int32_t totalTimeMs, int32_t downloadSpeedBytesPerSecond);
+  void setDownloadOnly(bool downloadOnly);
+  bool isDownloadOnly(void);
+  void setActualFileSize(size_t actualFileSize);
+  size_t actualFileSize(void);
+  void setByteRangeEnable(bool bByteRangeFlag);
+  bool isByteRangeEnabled(void);
+  void setByteRangeIntervals(const char* byteRangeIntervals);
+  char* byteRangeIntervals(void);
 
 private:
   rtString mFileUrl;
@@ -148,6 +156,10 @@ private:
   const uint8_t* mReadData;
   size_t mReadDataSize;
   rtObjectRef mDownloadMetrics;
+  bool mDownloadOnly;
+  size_t mActualFileSize;
+  bool mIsByteRangeEnabled;
+  rtString mByteRangeIntervals;
 };
 
 struct rtFileDownloadHandle

--- a/src/rtHttpCache.cpp
+++ b/src/rtHttpCache.cpp
@@ -489,7 +489,7 @@ bool rtHttpCacheData::handleDownloadRequest(vector<rtString>& headers,bool downl
   }
 
   if (downloadRequest->downloadStatusCode() == 0 &&
-       downloadRequest->httpStatusCode() == 200)
+       ((downloadRequest->httpStatusCode() == 200) || (downloadRequest->isByteRangeEnabled() && downloadRequest->httpStatusCode() == 206)))
   {
     if (downloadRequest->headerData() != NULL)
       mHeaderMetaData.init((uint8_t*)downloadRequest->headerData(), downloadRequest->headerDataSize());

--- a/tests/pxScene2d/test_imagecache.cpp
+++ b/tests/pxScene2d/test_imagecache.cpp
@@ -1287,6 +1287,26 @@ class rtFileDownloaderTest : public testing::Test, public commonTestFns
       return 0;
     }
 
+    void byteRangeTest()
+    {
+      rtString byteRange("NULL");
+      size_t m_fileSize = 19991; // Actual file size of https://www.sparkui.org/tests-ci/tests/images/008.jpg
+
+      rtFileCache::instance()->clearCache();
+      rtFileDownloadRequest* request = new rtFileDownloadRequest("https://www.sparkui.org/tests-ci/tests/images/008.jpg",this);
+
+      request->setByteRangeEnable(true);
+      request->setActualFileSize(m_fileSize);
+      // Set the intervals as 1K range.
+      request->setByteRangeIntervals("0-1024, 1025-2048, 2049-3072, 3073-4096, 4097-5120, 5121-6144, 6145-7168, 7169-8192, 8193-9216, 9217-10240, 10241-11264, 11265-12288, 12289-13312, 13313-14336, 14337-15360, 15361-16384, 16385-17408, 17409-18432, 18433-19456, 19457-19991");
+
+      bool ret = rtFileDownloader::instance()->downloadFromNetwork(request);
+      EXPECT_TRUE (ret == true);
+      EXPECT_TRUE (request->httpStatusCode() == 206);
+      EXPECT_TRUE (request->downloadedDataSize() == m_fileSize);
+      EXPECT_TRUE (request->downloadStatusCode() == 0);
+    }
+
   private:
     int expectedStatusCode;
     int expectedHttpCode;


### PR DESCRIPTION
RDK-24363 requires curl download to be byte range. User enable the byte range if required and pass the range string.