### PR TITLE
pxTextCanvas implements fillText(), measureText(), fillStyle and clear()

### DIFF
--- a/examples/pxBenchmark/src/CMakeLists.txt
+++ b/examples/pxBenchmark/src/CMakeLists.txt
@@ -296,7 +296,7 @@ include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/)
 message(** ${CMAKE_CURRENT_SOURCE_DIR}/../external/Celero/include/} **)
 
 set(PXSCENE_COMMON_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxResource.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxConstants.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxRectangle.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxFont.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxText.cpp
-${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxTextBox.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImage.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImage9.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImageA.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImage9Border.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxArchive.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxAnimate.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxTextBox.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxTextCanvas.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImage.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImage9.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImageA.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImage9Border.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxArchive.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxAnimate.cpp)
 
 set(CELERO_DEFINITIONS "${CMAKE_CURRENT_SOURCE_DIR}/../external/Celero/include")
 

--- a/examples/pxScene2d/src/CMakeLists.txt
+++ b/examples/pxScene2d/src/CMakeLists.txt
@@ -366,7 +366,7 @@ include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR}/rasterizer)
 
 set(PXSCENE_COMMON_FILES pxResource.cpp pxConstants.cpp pxRectangle.cpp pxFont.cpp pxText.cpp
-        pxTextBox.cpp pxImage.cpp pxImage9.cpp pxImageA.cpp pxImage9Border.cpp pxArchive.cpp pxAnimate.cpp)
+    pxTextBox.cpp pxTextCanvas.cpp pxImage.cpp pxImage9.cpp pxImageA.cpp pxImage9Border.cpp pxArchive.cpp pxAnimate.cpp)
 
 set(PXSCENE_COMMON_FILES ${PXSCENE_COMMON_FILES} pxObject.cpp)
 set(PXSCENE_COMMON_FILES ${PXSCENE_COMMON_FILES} pxScene2d.cpp)

--- a/examples/pxScene2d/src/Makefile_MT
+++ b/examples/pxScene2d/src/Makefile_MT
@@ -97,6 +97,7 @@ PX_SRCS_FULL=\
     pxFont.cpp \
     pxText.cpp \
     pxTextBox.cpp \
+    pxTextCanvas.cpp \
     pxImage.cpp \
     pxImage9.cpp \
     pxArchive.cpp 
@@ -215,6 +216,7 @@ PXSCENE_LIB_SRCS=\
 	   pxRectangle.cpp \
            pxText.cpp \
            pxTextBox.cpp \
+           pxTextCanvas.cpp \
            pxImage.cpp \
            pxImage9.cpp \
            pxArchive.cpp \

--- a/examples/pxScene2d/src/pxFont.cpp
+++ b/examples/pxScene2d/src/pxFont.cpp
@@ -966,4 +966,12 @@ void pxTexturedQuads::draw(float x, float y)
 {
     draw(x, y, mColor);
 }
+
+void pxTexturedQuads::setColor(uint32_t c)
+{
+    mColor[0]/*R*/ = (float)((c>>24) & 0xff) / 255.0f;
+    mColor[1]/*G*/ = (float)((c>>16) & 0xff) / 255.0f;
+    mColor[2]/*B*/ = (float)((c>> 8) & 0xff) / 255.0f;
+    mColor[3]/*A*/ = (float)((c>> 0) & 0xff) / 255.0f;
+}
 #endif

--- a/examples/pxScene2d/src/pxFont.cpp
+++ b/examples/pxScene2d/src/pxFont.cpp
@@ -961,4 +961,9 @@ void pxTexturedQuads::draw(float x, float y, float* color)
     context.drawTexturedQuads(q.verts.size()/12, &verts[0], &q.uvs[0], q.t, color);
   }
 }
+
+void pxTexturedQuads::draw(float x, float y)
+{
+    draw(x, y, mColor);
+}
 #endif

--- a/examples/pxScene2d/src/pxFont.h
+++ b/examples/pxScene2d/src/pxFont.h
@@ -155,13 +155,7 @@ class pxTexturedQuads
 
   void draw(float x, float y, float* color);
   void draw(float x, float y);
-  void setColor(uint32_t c)
-  {
-      mColor[0]/*R*/ = (float)((c>>24) & 0xff) / 255.0f;
-      mColor[1]/*G*/ = (float)((c>>16) & 0xff) / 255.0f;
-      mColor[2]/*B*/ = (float)((c>> 8) & 0xff) / 255.0f;
-      mColor[3]/*A*/ = (float)((c>> 0) & 0xff) / 255.0f;
-  }
+  void setColor(uint32_t c);
 
   void clear()
   {

--- a/examples/pxScene2d/src/pxFont.h
+++ b/examples/pxScene2d/src/pxFont.h
@@ -154,6 +154,14 @@ class pxTexturedQuads
   }
 
   void draw(float x, float y, float* color);
+  void draw(float x, float y);
+  void setColor(uint32_t c)
+  {
+      mColor[0]/*R*/ = (float)((c>>24) & 0xff) / 255.0f;
+      mColor[1]/*G*/ = (float)((c>>16) & 0xff) / 255.0f;
+      mColor[2]/*B*/ = (float)((c>> 8) & 0xff) / 255.0f;
+      mColor[3]/*A*/ = (float)((c>> 0) & 0xff) / 255.0f;
+  }
 
   void clear()
   {
@@ -162,6 +170,7 @@ class pxTexturedQuads
 
 private:
   vector<quads> mQuads;
+  float mColor[4] = {0xff, 0xff, 0xff, 0xff};
 };
 
 #endif

--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -38,6 +38,7 @@
 #include "pxRectangle.h"
 #include "pxText.h"
 #include "pxTextBox.h"
+#include "pxTextCanvas.h"
 #include "pxImage.h"
 
 #ifdef ENABLE_SPARK_WEBGL
@@ -703,6 +704,8 @@ rtError pxScene2d::create(rtObjectRef p, rtObjectRef& o)
     e = createText(p,o);
   else if (!strcmp("textBox",t.cString()))
     e = createTextBox(p,o);
+  else if (!strcmp("textCanvas",t.cString()))
+    e = createTextCanvas(p,o);
   else if (!strcmp("image",t.cString()))
     e = createImage(p,o);
   else if (!strcmp("image9",t.cString()))
@@ -794,6 +797,14 @@ rtError pxScene2d::createText(rtObjectRef p, rtObjectRef& o)
 rtError pxScene2d::createTextBox(rtObjectRef p, rtObjectRef& o)
 {
   o = new pxTextBox(this);
+  o.set(p);
+  o.send("init");
+  return RT_OK;
+}
+
+rtError pxScene2d::createTextCanvas(rtObjectRef p, rtObjectRef& o)
+{
+  o = new pxTextCanvas(this);
   o.set(p);
   o.send("init");
   return RT_OK;

--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -917,6 +917,7 @@ public:
   rtError createRectangle(rtObjectRef p, rtObjectRef& o);
   rtError createText(rtObjectRef p, rtObjectRef& o);
   rtError createTextBox(rtObjectRef p, rtObjectRef& o);
+  rtError createTextCanvas(rtObjectRef p, rtObjectRef& o);
   rtError createImage(rtObjectRef p, rtObjectRef& o);
   rtError createPath(rtObjectRef p, rtObjectRef& o);
   rtError createImage9(rtObjectRef p, rtObjectRef& o);

--- a/examples/pxScene2d/src/pxTextCanvas.cpp
+++ b/examples/pxScene2d/src/pxTextCanvas.cpp
@@ -5,6 +5,37 @@
 
 extern pxContext context;
 
+//pxTextLine
+pxTextLine::pxTextLine(const char* text, uint32_t x, uint32_t y)
+        : pixelSize(10)
+        , color(0xFFFFFFFF)
+{
+    this->text = text;
+    this->x = x;
+    this->y = y;
+    this->styleSet = false;
+};
+
+void pxTextLine::setStyle(const rtObjectRef& f, uint32_t ps, uint32_t c) {
+    // TODO: validate pxFont object
+    this->font = f;
+    this->pixelSize = ps;
+    this->color = c;
+    this->styleSet = true;
+}
+
+//pxTextCanvasMeasurements
+pxTextCanvasMeasurements::pxTextCanvasMeasurements(rtObjectRef sm)
+{
+    fromSimpleMeasurements(sm);
+}
+
+void pxTextCanvasMeasurements::fromSimpleMeasurements(rtObjectRef sm) {
+    pxTextSimpleMeasurements* pSm = ((pxTextSimpleMeasurements*)sm.getPtr());
+    mw = pSm->w(); mh = pSm->h();
+}
+
+//pxTextCanvas
 pxTextCanvas::pxTextCanvas(pxScene2d* s): pxText(s)
         , mInitialized(false)
         , mNeedsRecalc(false)
@@ -53,16 +84,125 @@ void pxTextCanvas::resourceReady(rtString readyResolution)
     rtLogDebug("pxTextCanvas::resourceReady - end");
 }
 
+uint32_t pxTextCanvas::alignHorizontal() const
+{
+    return mAlignHorizontal;
+}
+
+rtError pxTextCanvas::alignHorizontal(uint32_t& v) const
+{
+    v = mAlignHorizontal;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setAlignHorizontal(uint32_t v)
+{
+    mAlignHorizontal = v;
+    setNeedsRecalc(true);
+    return RT_OK;
+}
+
+rtError pxTextCanvas::fillStyle(rtValue &c) const
+{
+    return textColor(c);
+}
+
+rtError pxTextCanvas::setFillStyle(rtValue c)
+{
+    rtLogInfo("pxTextCanvas::setFillStyle. Called with param: %#08x", c.toUInt32());
+    setTextColor(c);
+    return RT_OK;
+}
+rtError pxTextCanvas::textBaseline(rtString &b) const
+{
+    b = mTextBaseline;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setTextBaseline(const rtString& c)
+{
+    rtLogInfo("pxTextCanvas::setTextBaseline called with param: %s", c.cString());
+    rtLogError("pxTextCanvas::setTextBaseline. NOT IMPLEMENTED. Call ignored.");
+    mTextBaseline = c;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::globalAlpha(float& a) const
+{
+    a = mGlobalAlpha;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setGlobalAlpha(const float a)
+{
+    rtLogInfo("pxTextCanvas::setGlobalAlpha called with param: %f", a);
+    rtLogError("pxTextCanvas::setGlobalAlpha. NOT IMPLEMENTED. Call ignored.");
+    mGlobalAlpha = a;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::shadowColor(uint32_t& c) const
+{
+    c = mShadowColor;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setShadowColor(const uint32_t c)
+{
+    rtLogInfo("pxTextCanvas::setShadowColor. Called with param: %#08x", c);
+    rtLogError("pxTextCanvas::setShadowColor. NOT IMPLEMENTED. Call ignored.");
+    mShadowColor = c;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::shadowBlur(uint8_t& b) const
+{
+    b = mShadowColor;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setShadowBlur(const uint8_t b)
+{
+    rtLogInfo("pxTextCanvas::setShadowBlur. Called with param: %d", b);
+    rtLogError("pxTextCanvas::setShadowBlur. NOT IMPLEMENTED. Call ignored.");
+    mShadowBlur = b;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::shadowOffsetX(float& o) const
+{
+    o = mShadowOffsetX;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setShadowOffsetX(const float o)
+{
+    rtLogInfo("pxTextCanvas::setShadowOffsetX called with param: %f", o);
+    rtLogError("pxTextCanvas::setShadowOffsetX. NOT IMPLEMENTED. Call ignored.");
+    mShadowOffsetX = o;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::shadowOffsetY(float& o) const
+{
+    o = mShadowOffsetY;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setShadowOffsetY(const float o)
+{
+    rtLogInfo("pxTextCanvas::setShadowOffsetY called with param: %f", o);
+    rtLogError("pxTextCanvas::setShadowOffsetY. NOT IMPLEMENTED. Call ignored.");
+    mShadowOffsetY = o;
+    return RT_OK;
+}
+
 float pxTextCanvas::getFBOWidth()
 {
-    rtLogDebug("pxTextCanvas::getFBOWidth - begin.");
-    rtLogDebug("pxTextCanvas::getFBOWidth - end.");
     return pxText::getFBOWidth();
 }
 float pxTextCanvas::getFBOHeight()
 {
-    rtLogDebug("pxTextCanvas::getFBOHeight - begin.");
-    rtLogDebug("pxTextCanvas::getFBOHeight - end.");
     return pxText::getFBOHeight();
 }
 

--- a/examples/pxScene2d/src/pxTextCanvas.cpp
+++ b/examples/pxScene2d/src/pxTextCanvas.cpp
@@ -1,0 +1,328 @@
+#include "pxConstants.h"
+#include "pxText.h"
+#include "pxTextCanvas.h"
+#include "pxContext.h"
+
+extern pxContext context;
+
+pxTextCanvas::pxTextCanvas(pxScene2d* s): pxText(s)
+        , mInitialized(false)
+        , mNeedsRecalc(false)
+        , mAlignHorizontal(pxConstantsAlignHorizontal::LEFT)
+        , mGlobalAlpha(0.0)
+        , mShadowColor(0X00000000) /*fully transparent black*/
+        , mShadowBlur(0)
+        , mShadowOffsetX(0.0)
+        , mShadowOffsetY(0.0)
+
+{
+    rtLogDebug("pxTextCanvas::ctor - begin");
+    measurements = new pxTextCanvasMeasurements;
+    mFontLoaded = false;
+    mFontFailed = false;
+    mTextBaseline = "alphabetic"; //TODO: make a const class from it?
+    rtLogDebug("pxTextCanvas::ctor - end");
+}
+/** This signals that the font file loaded successfully; now we need to
+ * send the ready promise once we have the text, too
+ */
+void pxTextCanvas::resourceReady(rtString readyResolution)
+{
+    rtLogDebug("pxTextCanvas::resourceReady - begin");
+    if( !readyResolution.compare("resolve"))
+    {
+        mFontLoaded = true;
+        if( mInitialized) {
+            setNeedsRecalc(true);
+            pxObject::onTextureReady();
+            if( !mParent)
+            {
+                // Send the promise here because the canvas will not get an
+                // update call until it has parent
+                recalc();
+                sendPromise();
+            }
+        }
+    }
+    else
+    {
+        mFontFailed = true;
+        pxObject::onTextureReady();
+        mReady.send("reject",this);
+    }
+    rtLogDebug("pxTextCanvas::resourceReady - end");
+}
+
+float pxTextCanvas::getFBOWidth()
+{
+    rtLogDebug("pxTextCanvas::getFBOWidth - begin.");
+    rtLogDebug("pxTextCanvas::getFBOWidth - end.");
+    return pxText::getFBOWidth();
+}
+float pxTextCanvas::getFBOHeight()
+{
+    rtLogDebug("pxTextCanvas::getFBOHeight - begin.");
+    rtLogDebug("pxTextCanvas::getFBOHeight - end.");
+    return pxText::getFBOHeight();
+}
+
+void pxTextCanvas::onInit()
+{
+    rtLogDebug("pxTextCanvas::onInit - begin.");
+    pxText::onInit();
+    rtLogInfo("pxTextCanvas::onInit. mFontLoaded=%d\n",mFontLoaded);
+    mInitialized = true;
+
+    // If this is using the default font, we would not get a callback
+    if(mFontLoaded || (getFontResource() != nullptr && getFontResource()->isFontLoaded()))
+    {
+        mFontLoaded = true;
+        setNeedsRecalc(true);
+        if (!mParent)
+        {
+            resourceReady("resolve");
+        }
+    }
+    rtLogDebug("pxTextCanvas::onInit - end.");
+}
+
+void pxTextCanvas::recalc()
+{
+    rtLogDebug("pxTextCanvas::recalc - begin.");
+
+    if( mNeedsRecalc && mInitialized && mFontLoaded) {
+        clearMeasurements();
+#ifdef PXSCENE_FONT_ATLAS
+        mQuadsVector.clear();
+#endif
+        renderText(false);
+        setNeedsRecalc(false);
+        if(clip()) {
+            pxObject::onTextureReady();
+        }
+#ifdef PXSCENE_FONT_ATLAS
+        mQuadsVector.clear();
+#endif
+        renderText(true);
+        mDirty = false;
+    }
+    rtLogDebug("pxTextCanvas::recalc - end.");
+}
+
+void pxTextCanvas::clearMeasurements()
+{
+    getMeasurements()->clear();
+}
+
+void pxTextCanvas::setNeedsRecalc(bool recalc)
+{
+    rtLogDebug("Setting mNeedsRecalc=%d\n",recalc);
+    mNeedsRecalc = recalc;
+
+    if(recalc)
+    {
+        rtLogDebug("TextCanvas CREATE NEW PROMISE\n");
+        createNewPromise();
+//        mDirty = true;
+    }
+}
+
+void pxTextCanvas::sendPromise()
+{
+    rtLogDebug("TextCanvas sendPromise - begin");
+    rtLogDebug("pxTextCanvas::sendPromise mInitialized=%d mFontLoaded=%d mNeedsRecalc=%d\n",mInitialized,mFontLoaded,mNeedsRecalc);
+    // TODO: hanlde mNeedsRecalc properly!
+    if(mInitialized && mFontLoaded /*&& !mNeedsRecalc*/ && !mDirty && !((rtPromise*)mReady.getPtr())->status())
+    {
+        rtLogDebug("pxTextCanvas SENDPROMISE\n");
+        mReady.send("resolve",this);
+
+    } else {
+        rtLogDebug("pxTextCanvas NOT sending promise");
+    }
+    rtLogDebug("TextCanvas sendPromise - end");
+}
+
+void pxTextCanvas::renderText(bool render)
+{
+    rtLogDebug("pxTextCanvas::renderText - begin.");
+    if (render && !mTextLines.empty()) {
+        for (std::vector<pxTextLine>::iterator it = mTextLines.begin() ; it != mTextLines.end(); ++it)
+            renderTextLine(*it);
+    }
+    rtLogDebug("pxTextCanvas::renderText - end.");
+}
+
+void pxTextCanvas::renderTextLine(const pxTextLine& textLine)
+{
+    rtLogDebug("pxTextCanvas::renderTextLine - begin");
+
+    const char* cStr = textLine.text.cString();
+    float xPos = textLine.x;
+    float yPos = textLine.y;
+
+    // TODO ignoring sx and sy now.
+    float sx = 1.0;
+    float sy = 1.0;
+
+    float charW = 0, charH = 0;
+    uint32_t size = textLine.pixelSize;
+    setFont(textLine.font);
+
+    // TODO: calc alignment
+    if (getFontResource() != nullptr)
+    {
+        getFontResource()->measureTextInternal(cStr, size, sx, sy, charW, charH);
+        //TODO: add clipping support here
+        mw = charW > mw ? charW : mw;
+        mh = charH > mh ? charH : mh;
+    }
+
+    // Now, render the text
+    if( getFontResource() != nullptr)
+    {
+#ifdef PXSCENE_FONT_ATLAS
+        pxTexturedQuads quads;
+        getFontResource()->renderTextToQuads(cStr, size, sx, sy, quads, roundf(xPos), roundf(yPos));
+        quads.setColor(textLine.color);
+        mQuadsVector.push_back(quads);
+#else
+        //getFontResource()->renderText(cStr, size, xPos, tempY, sx, sy, mTextColor,lineWidth);
+        rtLogError("pxTextCanvas::drawing without FONT ATLAS is not supported yet.");
+#endif
+    }
+    rtLogDebug("pxTextCanvas::renderTextLine - end");
+}
+
+void pxTextCanvas::draw()
+{
+    rtLogDebug("pxTextCanvas::draw - begin.");
+#ifdef PXSCENE_FONT_ATLAS
+    if (mDirty)
+    {
+        mQuadsVector.clear();
+        renderText(true);
+        mDirty = false;
+    }
+    float x = 0, y = 0;
+    for (std::vector<pxTexturedQuads>::iterator it = mQuadsVector.begin() ; it != mQuadsVector.end(); ++it)
+        (*it).draw(x, y);
+#else
+    rtLogError("pxTextCanvas::drawing without FONT ATLAS is not supported yet.");
+#endif
+    rtLogDebug("pxTextCanvas::draw - end.");
+}
+
+float pxTextCanvas::getOnscreenWidth()
+{
+    // TODO review max texture handling
+    return this->w();
+}
+
+float pxTextCanvas::getOnscreenHeight()
+{
+    // TODO review max texture handling
+    return this->h();
+}
+
+void pxTextCanvas::update(double t, bool updateChildren)
+{
+    rtLogDebug("pxTextCanvas::update - begin.");
+    if( mNeedsRecalc ) {
+        recalc();
+        markDirty();
+    }
+    pxText::update(t, updateChildren);
+    rtLogDebug("pxTextCanvas::update - end.");
+}
+
+rtError pxTextCanvas::measureText(rtString text, rtObjectRef& o)
+{
+    rtLogDebug("pxTextCanvas::measureText - begin.");
+    rtLogInfo("pxTextCanvas::measureText() mNeedsRecalc is %d text: %s", mNeedsRecalc, text.cString());
+    rtObjectRef tcm = new pxTextCanvasMeasurements(); // TODO: aren't we leaking here with 'new'? Is it efficient?
+    o = tcm;
+    if(getFontResource() != nullptr) {
+        rtObjectRef sm; // pxTextSimpleMeasurements
+        getFontResource()->measureText(mPixelSize, text, sm);
+        ((pxTextCanvasMeasurements*)tcm.getPtr())->fromSimpleMeasurements(sm);
+
+        rtLogInfo("pxTextCanvas::measureText(). Got measurements; width: %d, height: %d "
+                , ((pxTextCanvasMeasurements*)tcm.getPtr())->width()
+                , ((pxTextCanvasMeasurements*)tcm.getPtr())->h()
+                );
+
+    } else {
+        rtLogWarn("measureText called TOO EARLY -- not initialized or font not loaded!\n");
+        //return RT_OK; // !CLF: TO DO - COULD RETURN RT_ERROR HERE TO CATCH NOT WAITING ON PROMISE
+    }
+    rtLogDebug("pxTextCanvas::measureText - end.");
+    return RT_OK;
+}
+
+rtError pxTextCanvas::fillText(rtString text, uint32_t x, uint32_t y)
+{
+    rtLogDebug("pxTextCanvas::fillText - begin.");
+    rtLogInfo("pxTextCanvas::fillText called with params: text: %s, x %d, y %d", text.cString(), x, y);
+    pxTextLine textLine(text, x, y);
+    uint32_t color;
+    textColorInternal(color);
+    textLine.setStyle(mFont, mPixelSize, color);
+    mTextLines.push_back(textLine);
+    setNeedsRecalc(true);
+    rtLogDebug("pxTextCanvas::fillText - end.");
+    return RT_OK;
+}
+
+rtError pxTextCanvas::clear()
+{
+    rtLogDebug("pxTextCanvas::clear - begin.");
+    mTextLines.clear();
+    mw = 0;
+    mh = 0;
+    setNeedsRecalc(true);
+    rtLogDebug("pxTextCanvas::clear - end.");
+
+    return RT_OK;
+}
+
+rtError pxTextCanvas::fillRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height)
+{
+    UNUSED_PARAM(x);
+    UNUSED_PARAM(y);
+    UNUSED_PARAM(width);
+    UNUSED_PARAM(height);
+    rtLogInfo("pxTextCanvas::fillRect called with params: x %d, y %d, width %d, height %d", x, y, width, height);
+    rtLogError("pxTextCanvas::fillRect. NOT IMPLEMENTED. Call ignored.");
+    return RT_OK;
+}
+
+rtError pxTextCanvas::translate(uint32_t x, uint32_t y)
+{
+    UNUSED_PARAM(x);
+    UNUSED_PARAM(y);
+    rtLogInfo("pxTextCanvas::translate called with params: x %d, y %d", x, y);
+    rtLogError("pxTextCanvas::translate. NOT IMPLEMENTED. Call ignored.");
+    return RT_OK;
+}
+
+// pxTextCanvasMeasurements
+rtDefineObject(pxTextCanvasMeasurements, rtObject);
+rtDefineProperty(pxTextCanvasMeasurements, width);
+
+// pxTextCanvas
+rtDefineObject(pxTextCanvas, pxText);
+rtDefineProperty(pxTextCanvas, alignHorizontal);
+rtDefineProperty(pxTextCanvas, fillStyle);
+rtDefineProperty(pxTextCanvas, textBaseline);
+rtDefineProperty(pxTextCanvas, globalAlpha);
+rtDefineProperty(pxTextCanvas, shadowColor);
+rtDefineProperty(pxTextCanvas, shadowBlur);
+rtDefineProperty(pxTextCanvas, shadowOffsetX);
+rtDefineProperty(pxTextCanvas, shadowOffsetY);
+
+rtDefineMethod(pxTextCanvas, measureText);
+rtDefineMethod(pxTextCanvas, fillText);
+rtDefineMethod(pxTextCanvas, clear);
+rtDefineMethod(pxTextCanvas, fillRect);
+rtDefineMethod(pxTextCanvas, translate);

--- a/examples/pxScene2d/src/pxTextCanvas.cpp
+++ b/examples/pxScene2d/src/pxTextCanvas.cpp
@@ -110,7 +110,9 @@ rtError pxTextCanvas::fillStyle(rtValue &c) const
 rtError pxTextCanvas::setFillStyle(rtValue c)
 {
     rtLogInfo("pxTextCanvas::setFillStyle. Called with param: %#08x", c.toUInt32());
-    setTextColor(c);
+    rtValue clr(argb2rgba(c.toUInt32()));
+    rtLogInfo("pxTextCanvas::setFillStyle. Converted to: %#08x", clr.toUInt32());
+    setTextColor(clr);
     return RT_OK;
 }
 rtError pxTextCanvas::textBaseline(rtString &b) const
@@ -155,13 +157,13 @@ rtError pxTextCanvas::setShadowColor(const uint32_t c)
     return RT_OK;
 }
 
-rtError pxTextCanvas::shadowBlur(uint8_t& b) const
+rtError pxTextCanvas::shadowBlur(uint32_t& b) const
 {
-    b = mShadowColor;
+    b = mShadowBlur;
     return RT_OK;
 }
 
-rtError pxTextCanvas::setShadowBlur(const uint8_t b)
+rtError pxTextCanvas::setShadowBlur(const uint32_t b)
 {
     rtLogInfo("pxTextCanvas::setShadowBlur. Called with param: %d", b);
     rtLogError("pxTextCanvas::setShadowBlur. NOT IMPLEMENTED. Call ignored.");
@@ -445,6 +447,12 @@ rtError pxTextCanvas::translate(uint32_t x, uint32_t y)
     rtLogError("pxTextCanvas::translate. NOT IMPLEMENTED. Call ignored.");
     return RT_OK;
 }
+
+uint32_t pxTextCanvas::argb2rgba(uint32_t val)
+{
+    return val << 8 | val >> 24;
+}
+
 
 // pxTextCanvasMeasurements
 rtDefineObject(pxTextCanvasMeasurements, rtObject);

--- a/examples/pxScene2d/src/pxTextCanvas.h
+++ b/examples/pxScene2d/src/pxTextCanvas.h
@@ -87,7 +87,7 @@ public:
     rtProperty(textBaseline, textBaseline, setTextBaseline, rtString);
     rtProperty(globalAlpha, globalAlpha, setGlobalAlpha, float);
     rtProperty(shadowColor, shadowColor, setShadowColor, uint32_t);
-    rtProperty(shadowBlur, shadowBlur, setShadowBlur, uint8_t);
+    rtProperty(shadowBlur, shadowBlur, setShadowBlur, uint32_t);
     rtProperty(shadowOffsetX, shadowOffsetX, setShadowOffsetX, float);
     rtProperty(shadowOffsetY, shadowOffsetY, setShadowOffsetY, float);
 
@@ -102,8 +102,8 @@ public:
     rtError setGlobalAlpha(const float a);
     rtError shadowColor(uint32_t& c) const;
     rtError setShadowColor(const uint32_t c);
-    rtError shadowBlur(uint8_t& b) const;
-    rtError setShadowBlur(const uint8_t b);
+    rtError shadowBlur(uint32_t& b) const;
+    rtError setShadowBlur(const uint32_t b);
     rtError shadowOffsetX(float& o) const;
     rtError setShadowOffsetX(const float o);
     rtError shadowOffsetY(float& o) const;
@@ -149,6 +149,7 @@ protected:
     pxTextCanvasMeasurements* getMeasurements() { return (pxTextCanvasMeasurements*)measurements.getPtr();}
     void recalc();
     void clearMeasurements();
+    static uint32_t argb2rgba(uint32_t val);
 
     bool mInitialized;
     bool mNeedsRecalc;
@@ -156,7 +157,7 @@ protected:
     rtString mTextBaseline;
     float mGlobalAlpha;
     uint32_t mShadowColor;
-    uint8_t  mShadowBlur;
+    uint32_t  mShadowBlur;
     float mShadowOffsetX;
     float mShadowOffsetY;
 

--- a/examples/pxScene2d/src/pxTextCanvas.h
+++ b/examples/pxScene2d/src/pxTextCanvas.h
@@ -28,24 +28,8 @@ struct pxTextLine
             , pixelSize(10)
             , color(0xFFFFFFFF)
     {};
-
-    pxTextLine(const char* text, uint32_t x, uint32_t y)
-            : pixelSize(10)
-            , color(0xFFFFFFFF)
-    {
-        this->text = text;
-        this->x = x;
-        this->y = y;
-        this->styleSet = false;
-    };
-
-    void setStyle(const rtObjectRef& f, uint32_t ps, uint32_t c) {
-        // TODO: validate pxFont object
-        this->font = f;
-        this->pixelSize = ps;
-        this->color = c;
-        this->styleSet = true;
-    }
+    pxTextLine(const char* text, uint32_t x, uint32_t y);
+    void setStyle(const rtObjectRef& f, uint32_t ps, uint32_t c);
 
     bool styleSet;
     rtString text;
@@ -66,10 +50,7 @@ class pxTextCanvasMeasurements: public rtObject
 {
 public:
     pxTextCanvasMeasurements():mw(0), mh(0) {}
-    pxTextCanvasMeasurements(rtObjectRef sm)
-    {
-        fromSimpleMeasurements(sm);
-    }
+    pxTextCanvasMeasurements(rtObjectRef sm);
     virtual ~pxTextCanvasMeasurements() {}
 
     rtDeclareObject(pxTextCanvasMeasurements, rtObject);
@@ -77,19 +58,12 @@ public:
 
     int32_t width() const { return mw;  }
     rtError width(int32_t& v) const { v = mw;  return RT_OK; }
-
     int32_t w() const { return mw;  }
     int32_t h() const { return mh; }
-
     void setW(int32_t v) { mw = v;}
     void setH(int32_t v) { mh = v; }
-
     void clear() { mw = 0; mh = 0;}
-
-    void fromSimpleMeasurements(rtObjectRef sm) {
-        pxTextSimpleMeasurements* pSm = ((pxTextSimpleMeasurements*)sm.getPtr());
-        mw = pSm->w(); mh = pSm->h();
-    }
+    void fromSimpleMeasurements(rtObjectRef sm);
 
 protected:
     int32_t mw;
@@ -117,108 +91,27 @@ public:
     rtProperty(shadowOffsetX, shadowOffsetX, setShadowOffsetX, float);
     rtProperty(shadowOffsetY, shadowOffsetY, setShadowOffsetY, float);
 
-    uint32_t alignHorizontal()              const { return mAlignHorizontal;}
-    rtError alignHorizontal(uint32_t& v)    const { v = mAlignHorizontal; return RT_OK;}
-    rtError setAlignHorizontal(uint32_t v)        { mAlignHorizontal = v;  setNeedsRecalc(true); return RT_OK;}
-
-    rtError fillStyle(rtValue &c) const
-    {
-        return textColor(c);
-    }
-
-    rtError setFillStyle(rtValue c)
-    {
-        rtLogInfo("pxTextCanvas::setFillStyle. Called with param: %#08x", c.toUInt32());
-        setTextColor(c);
-        return RT_OK;
-    }
-    rtError textBaseline(rtString &b) const
-    {
-        b = mTextBaseline;
-        return RT_OK;
-    }
-
-    rtError setTextBaseline(const rtString& c)
-    {
-        rtLogInfo("pxTextCanvas::setTextBaseline called with param: %s", c.cString());
-        rtLogError("pxTextCanvas::setTextBaseline. NOT IMPLEMENTED. Call ignored.");
-        mTextBaseline = c;
-        return RT_OK;
-    }
-
-    rtError globalAlpha(float& a) const
-    {
-        a = mGlobalAlpha;
-        return RT_OK;
-    }
-
-    rtError setGlobalAlpha(const float a)
-    {
-        rtLogInfo("pxTextCanvas::setGlobalAlpha called with param: %f", a);
-        rtLogError("pxTextCanvas::setGlobalAlpha. NOT IMPLEMENTED. Call ignored.");
-        mGlobalAlpha = a;
-        return RT_OK;
-    }
-
-    rtError shadowColor(uint32_t& c) const
-    {
-        c = mShadowColor;
-        return RT_OK;
-    }
-
-    rtError setShadowColor(const uint32_t c)
-    {
-        rtLogInfo("pxTextCanvas::setShadowColor. Called with param: %#08x", c);
-        rtLogError("pxTextCanvas::setShadowColor. NOT IMPLEMENTED. Call ignored.");
-        mShadowColor = c;
-        return RT_OK;
-    }
-
-    rtError shadowBlur(uint8_t& b) const
-    {
-        b = mShadowColor;
-        return RT_OK;
-    }
-
-    rtError setShadowBlur(const uint8_t b)
-    {
-        rtLogInfo("pxTextCanvas::setShadowBlur. Called with param: %d", b);
-        rtLogError("pxTextCanvas::setShadowBlur. NOT IMPLEMENTED. Call ignored.");
-        mShadowBlur = b;
-        return RT_OK;
-    }
-
-    rtError shadowOffsetX(float& o) const
-    {
-        o = mShadowOffsetX;
-        return RT_OK;
-    }
-
-    rtError setShadowOffsetX(const float o)
-    {
-        rtLogInfo("pxTextCanvas::setShadowOffsetX called with param: %f", o);
-        rtLogError("pxTextCanvas::setShadowOffsetX. NOT IMPLEMENTED. Call ignored.");
-        mShadowOffsetX = o;
-        return RT_OK;
-    }
-
-    rtError shadowOffsetY(float& o) const
-    {
-        o = mShadowOffsetY;
-        return RT_OK;
-    }
-
-    rtError setShadowOffsetY(const float o)
-    {
-        rtLogInfo("pxTextCanvas::setShadowOffsetY called with param: %f", o);
-        rtLogError("pxTextCanvas::setShadowOffsetY. NOT IMPLEMENTED. Call ignored.");
-        mShadowOffsetY = o;
-        return RT_OK;
-    }
+    uint32_t alignHorizontal() const;
+    rtError alignHorizontal(uint32_t& v) const;
+    rtError setAlignHorizontal(uint32_t v);
+    rtError fillStyle(rtValue &c) const;
+    rtError setFillStyle(rtValue c);
+    rtError textBaseline(rtString &b) const;
+    rtError setTextBaseline(const rtString& c);
+    rtError globalAlpha(float& a) const;
+    rtError setGlobalAlpha(const float a);
+    rtError shadowColor(uint32_t& c) const;
+    rtError setShadowColor(const uint32_t c);
+    rtError shadowBlur(uint8_t& b) const;
+    rtError setShadowBlur(const uint8_t b);
+    rtError shadowOffsetX(float& o) const;
+    rtError setShadowOffsetX(const float o);
+    rtError shadowOffsetY(float& o) const;
+    rtError setShadowOffsetY(const float o);
 
     /* override virtuals from pxObject that must affect the readiness of pxTextCanvas due to text measurements */
-    rtError setW(float v) override      { rtLogInfo("pxTextCanvas::setW: %f", v); setNeedsRecalc(true); return pxObject::setW(v);}
-    rtError setH(float v) override      { rtLogInfo("pxTextCanvas::setH: %f", v); setNeedsRecalc(true); return pxObject::setH(v);}
+    rtError setW(float v) override      { setNeedsRecalc(true); return pxObject::setW(v);}
+    rtError setH(float v) override      { setNeedsRecalc(true); return pxObject::setH(v);}
     rtError setClip(bool v) override    { setNeedsRecalc(true); return pxObject::setClip(v);}
     rtError setSX(float v) override     { setNeedsRecalc(true); return pxObject::setSX(v);}
     rtError setSY(float v) override     { setNeedsRecalc(true); return pxObject::setSY(v);}

--- a/examples/pxScene2d/src/pxTextCanvas.h
+++ b/examples/pxScene2d/src/pxTextCanvas.h
@@ -1,0 +1,280 @@
+/*
+
+ pxCore Copyright 2005-2019 John Robinson
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+#ifndef PX_TEXTCANVAS_H
+#define PX_TEXTCANVAS_H
+
+#include "pxScene2d.h"
+#include "pxText.h"
+struct pxTextLine
+{
+    pxTextLine(): styleSet(false)
+            , x(0), y(0)
+            , pixelSize(10)
+            , color(0xFFFFFFFF)
+    {};
+
+    pxTextLine(const char* text, uint32_t x, uint32_t y)
+            : pixelSize(10)
+            , color(0xFFFFFFFF)
+    {
+        this->text = text;
+        this->x = x;
+        this->y = y;
+        this->styleSet = false;
+    };
+
+    void setStyle(const rtObjectRef& f, uint32_t ps, uint32_t c) {
+        // TODO: validate pxFont object
+        this->font = f;
+        this->pixelSize = ps;
+        this->color = c;
+        this->styleSet = true;
+    }
+
+    bool styleSet;
+    rtString text;
+    uint32_t x;
+    uint32_t y;
+    // current style settings
+    rtObjectRef font;
+    uint32_t pixelSize;
+    uint32_t color;
+};
+
+/**********************************************************************
+ *
+ * pxTextCanvasMeasurements (used in javascript measureText() call)
+ *
+ **********************************************************************/
+class pxTextCanvasMeasurements: public rtObject
+{
+public:
+    pxTextCanvasMeasurements():mw(0), mh(0) {}
+    pxTextCanvasMeasurements(rtObjectRef sm)
+    {
+        fromSimpleMeasurements(sm);
+    }
+    virtual ~pxTextCanvasMeasurements() {}
+
+    rtDeclareObject(pxTextCanvasMeasurements, rtObject);
+    rtReadOnlyProperty(width, width, int32_t);
+
+    int32_t width() const { return mw;  }
+    rtError width(int32_t& v) const { v = mw;  return RT_OK; }
+
+    int32_t w() const { return mw;  }
+    int32_t h() const { return mh; }
+
+    void setW(int32_t v) { mw = v;}
+    void setH(int32_t v) { mh = v; }
+
+    void clear() { mw = 0; mh = 0;}
+
+    void fromSimpleMeasurements(rtObjectRef sm) {
+        pxTextSimpleMeasurements* pSm = ((pxTextSimpleMeasurements*)sm.getPtr());
+        mw = pSm->w(); mh = pSm->h();
+    }
+
+protected:
+    int32_t mw;
+    int32_t mh;
+};
+
+/**********************************************************************
+ *
+ * pxTextCanvas
+ *
+ **********************************************************************/
+class pxTextCanvas : public pxText {
+public:
+    rtDeclareObject(pxTextCanvas, pxText);
+
+    pxTextCanvas(pxScene2d *s);
+    virtual ~pxTextCanvas() {}
+
+    rtProperty(alignHorizontal, alignHorizontal, setAlignHorizontal, uint32_t);
+    rtProperty(fillStyle, fillStyle, setFillStyle, rtValue);
+    rtProperty(textBaseline, textBaseline, setTextBaseline, rtString);
+    rtProperty(globalAlpha, globalAlpha, setGlobalAlpha, float);
+    rtProperty(shadowColor, shadowColor, setShadowColor, uint32_t);
+    rtProperty(shadowBlur, shadowBlur, setShadowBlur, uint8_t);
+    rtProperty(shadowOffsetX, shadowOffsetX, setShadowOffsetX, float);
+    rtProperty(shadowOffsetY, shadowOffsetY, setShadowOffsetY, float);
+
+    uint32_t alignHorizontal()              const { return mAlignHorizontal;}
+    rtError alignHorizontal(uint32_t& v)    const { v = mAlignHorizontal; return RT_OK;}
+    rtError setAlignHorizontal(uint32_t v)        { mAlignHorizontal = v;  setNeedsRecalc(true); return RT_OK;}
+
+    rtError fillStyle(rtValue &c) const
+    {
+        return textColor(c);
+    }
+
+    rtError setFillStyle(rtValue c)
+    {
+        rtLogInfo("pxTextCanvas::setFillStyle. Called with param: %#08x", c.toUInt32());
+        setTextColor(c);
+        return RT_OK;
+    }
+    rtError textBaseline(rtString &b) const
+    {
+        b = mTextBaseline;
+        return RT_OK;
+    }
+
+    rtError setTextBaseline(const rtString& c)
+    {
+        rtLogInfo("pxTextCanvas::setTextBaseline called with param: %s", c.cString());
+        rtLogError("pxTextCanvas::setTextBaseline. NOT IMPLEMENTED. Call ignored.");
+        mTextBaseline = c;
+        return RT_OK;
+    }
+
+    rtError globalAlpha(float& a) const
+    {
+        a = mGlobalAlpha;
+        return RT_OK;
+    }
+
+    rtError setGlobalAlpha(const float a)
+    {
+        rtLogInfo("pxTextCanvas::setGlobalAlpha called with param: %f", a);
+        rtLogError("pxTextCanvas::setGlobalAlpha. NOT IMPLEMENTED. Call ignored.");
+        mGlobalAlpha = a;
+        return RT_OK;
+    }
+
+    rtError shadowColor(uint32_t& c) const
+    {
+        c = mShadowColor;
+        return RT_OK;
+    }
+
+    rtError setShadowColor(const uint32_t c)
+    {
+        rtLogInfo("pxTextCanvas::setShadowColor. Called with param: %#08x", c);
+        rtLogError("pxTextCanvas::setShadowColor. NOT IMPLEMENTED. Call ignored.");
+        mShadowColor = c;
+        return RT_OK;
+    }
+
+    rtError shadowBlur(uint8_t& b) const
+    {
+        b = mShadowColor;
+        return RT_OK;
+    }
+
+    rtError setShadowBlur(const uint8_t b)
+    {
+        rtLogInfo("pxTextCanvas::setShadowBlur. Called with param: %d", b);
+        rtLogError("pxTextCanvas::setShadowBlur. NOT IMPLEMENTED. Call ignored.");
+        mShadowBlur = b;
+        return RT_OK;
+    }
+
+    rtError shadowOffsetX(float& o) const
+    {
+        o = mShadowOffsetX;
+        return RT_OK;
+    }
+
+    rtError setShadowOffsetX(const float o)
+    {
+        rtLogInfo("pxTextCanvas::setShadowOffsetX called with param: %f", o);
+        rtLogError("pxTextCanvas::setShadowOffsetX. NOT IMPLEMENTED. Call ignored.");
+        mShadowOffsetX = o;
+        return RT_OK;
+    }
+
+    rtError shadowOffsetY(float& o) const
+    {
+        o = mShadowOffsetY;
+        return RT_OK;
+    }
+
+    rtError setShadowOffsetY(const float o)
+    {
+        rtLogInfo("pxTextCanvas::setShadowOffsetY called with param: %f", o);
+        rtLogError("pxTextCanvas::setShadowOffsetY. NOT IMPLEMENTED. Call ignored.");
+        mShadowOffsetY = o;
+        return RT_OK;
+    }
+
+    /* override virtuals from pxObject that must affect the readiness of pxTextCanvas due to text measurements */
+    rtError setW(float v) override      { rtLogInfo("pxTextCanvas::setW: %f", v); setNeedsRecalc(true); return pxObject::setW(v);}
+    rtError setH(float v) override      { rtLogInfo("pxTextCanvas::setH: %f", v); setNeedsRecalc(true); return pxObject::setH(v);}
+    rtError setClip(bool v) override    { setNeedsRecalc(true); return pxObject::setClip(v);}
+    rtError setSX(float v) override     { setNeedsRecalc(true); return pxObject::setSX(v);}
+    rtError setSY(float v) override     { setNeedsRecalc(true); return pxObject::setSY(v);}
+
+    void renderText(bool render);
+    void setNeedsRecalc(bool recalc);
+    virtual float getFBOWidth();
+    virtual float getFBOHeight();
+
+    virtual void resourceReady(rtString readyResolution);
+    virtual void sendPromise();
+    virtual void draw();
+    virtual void onInit();
+    virtual void update(double t, bool updateChildren = true);
+
+    virtual float getOnscreenWidth();
+    virtual float getOnscreenHeight();
+
+    rtMethod1ArgAndReturn("measureText", measureText, rtString, rtObjectRef);
+    rtError measureText(rtString text, rtObjectRef &o);
+
+    rtMethod3ArgAndNoReturn("fillText", fillText, rtString, uint32_t, uint32_t);
+    rtError fillText(rtString text, uint32_t x, uint32_t y);
+
+    rtMethodNoArgAndNoReturn("clear", clear);
+    rtError clear();
+
+    rtMethod4ArgAndNoReturn("fillRect", fillRect, uint32_t, uint32_t, uint32_t, uint32_t);
+    rtError fillRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+
+    rtMethod2ArgAndNoReturn("translate", translate, uint32_t, uint32_t);
+    rtError translate(uint32_t x, uint32_t y);
+
+protected:
+    pxTextCanvasMeasurements* getMeasurements() { return (pxTextCanvasMeasurements*)measurements.getPtr();}
+    void recalc();
+    void clearMeasurements();
+
+    bool mInitialized;
+    bool mNeedsRecalc;
+    uint32_t mAlignHorizontal;
+    rtString mTextBaseline;
+    float mGlobalAlpha;
+    uint32_t mShadowColor;
+    uint8_t  mShadowBlur;
+    float mShadowOffsetX;
+    float mShadowOffsetY;
+
+    std::vector<pxTextLine> mTextLines;
+
+#ifdef PXSCENE_FONT_ATLAS
+    std::vector<pxTexturedQuads> mQuadsVector;
+#endif
+    rtObjectRef measurements;
+
+    void renderTextLine(const pxTextLine& textLine);
+};
+
+#endif

--- a/tests/pxScene2d/test_pxTextCanvas.js
+++ b/tests/pxScene2d/test_pxTextCanvas.js
@@ -1,0 +1,364 @@
+/**
+ * Spark application
+ * author: sgladk001c
+ *
+ * This test will ensure that pxTextCanvas is behaving as expected
+ */
+
+"use strict";
+px.configImport({"px.local:": px.getPackageBaseFilePath()+"/"});
+
+px.import({
+    scene:  "px:scene.1.js"
+    , assert: "./test-run/assert.js"
+    , manual: "./test-run/tools_manualTests.js"
+}).then( function ready(imports) {
+
+    let sparkscene = imports.scene;
+    let assert = imports.assert.assert;
+    let manual = imports.manual;
+
+    let manualTest = manual.getManualTestValue();
+    let parent = sparkscene.root;
+    let promises = [];
+
+    // Can be replaced with the standard logger, consider including 'px:tools.../Logger.js'
+    let Logger = function(enabled = false) {
+        this.enabled = enabled;
+        this.enable = () => { this.enabled = true; };
+        this.diable = () => { this.enabled = false; };
+        this.message = function () {if (this.enabled) { console.log.apply(this, arguments); }};
+    };
+    let logger = new Logger(true);
+
+    //let fontUrlBase = "http://sparkui.org/examples/fonts/";
+    // local:
+    let fontUrlBase = "/Users/silver/developer/spark/simple-lightning-spark-apps/v0.simpleImage/static/fonts/";
+    let IndieFlower = "IndieFlower.ttf";
+    let DejaVu = "DejaVuSans.ttf";
+
+    let fontUrl = fontUrlBase + IndieFlower;
+    let fontUrl2 = fontUrlBase + DejaVu;
+    let fontResource = sparkscene.create({t:"fontResource", url: fontUrl});
+    let fontResource2 = sparkscene.create({t:"fontResource", url: fontUrl2});
+
+    let w = 300;
+    let h = 300;
+    // let x = 100;
+    // let y = 0;
+    let canvas;
+
+    promises.push(fontResource.ready);
+    promises.push(fontResource2.ready);
+
+    // beforeStart will verify that we have correct resolutions for the fontResources that were preloaded
+    // as well as for the canvas scene we're going to test
+    let beforeStart = function () {
+        return new Promise(function (resolve, reject) {
+            let results = [];
+            let message;
+            Promise.all(promises).then(function () {
+                message = 'promise resolved for the fonts';
+                results.push(assert(true, message));
+            }, function () {
+                message = 'Not expected rejection received for the fonts';
+                results.push(assert(false, message));
+                reject(results);
+            }).then(function () {
+                canvas = sparkscene.create({
+                    t: "textCanvas"
+                    , w: w
+                    , h: h
+                    , parent: parent
+                    , text: "Bitter sweet"
+                    , font: fontResource
+                });
+                return canvas.ready.then(
+                    () => {
+                        message = 'promise resolved for the textCanvas scene';
+                        results.push(assert(true, message));
+                    },
+                    () => {
+                        message = 'Not expected rejection received the textCanvas scene';
+                        results.push(assert(false, message));
+                        reject(results);
+                    });
+            }).then(function () {
+                resolve(results);
+            });
+        });
+    };
+
+    ///////////////////////
+    // Test functions begin
+
+    let fillStyle = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.fillStyle = 0xFF6600FF;
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let fillText = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.fillText('Hello, world', 0, 0);
+            //canvas.clear();
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let textBaseline = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.textBaseline = 'hanging';
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let globalAlpha = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.globalAlpha = 1.0;
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let shadowColor = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.shadowColor = 0xFF6600FF;
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let shadowBlur = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.shadowBlur = 5;
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let shadowOffsetX = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.shadowOffsetX = 1.5;
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let shadowOffsetY = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.shadowOffsetY = 1.6;
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let measureText = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            let text = 'I need to measure this';
+            let measure = canvas.measureText(text);
+            logger.message('Width of "' + text + '" is ' + measure.width);
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let clear = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            logger.message("Canvas", canvas);
+            canvas.fillStyle = 0xFFFFFFFF;
+            canvas.clear();
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let fillRect = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.fillRect(0, 0, 10, 10);
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let translate = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.translate(10, 10);
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    // Test functions end
+    //////////////////////////
+
+    // Function executor with timeout
+    let timeout = 1000; //msecs
+    let exec = function (params) {
+        return new Promise(function (resolve, reject) {
+            let results = [];
+            let message;
+
+            let timer = setTimeout(function () {
+                message = params.name + ' never got promise!';
+                logger.message('debug', message);
+                results.push(assert(false, message));
+                reject(results);
+            }, timeout);
+
+            params.func(params).then(function (res) {
+                results.push(res);
+                clearTimeout(timer);
+                resolve(results);
+            }, function () {
+                clearTimeout(timer);
+                reject(results);
+            });
+        }, function () {
+            logger.message('debug', 'exec() got a rejection promise');
+        });
+    };
+
+    // We execute the functions through exec() by supplying them as a params object
+    // params object: {name: 'function name', func: functionName, description: 'some optional text'};
+
+    let beforeStartEx = function() {
+        return exec({name: 'beforeStart', func: beforeStart});
+    };
+
+    let tests = {
+        0: () => {return exec({name: 'fillStyle', func: fillStyle, description: 'promise test'})}
+        , 1: () => {return exec({name: 'fillText', func: fillText, description: 'promise test'})}
+        , 2: () => {return exec({name: 'textBaseline', func: textBaseline, description: 'promise test'})}
+        , 3: () => {return exec({name: 'shadowColor', func: shadowColor, description: 'promise test'})}
+        , 4: () => {return exec({name: 'shadowBlur', func: shadowBlur, description: 'promise test'})}
+        , 5: () => {return exec({name: 'shadowOffsetX', func: shadowOffsetX, description: 'promise test'})}
+        , 6: () => {return exec({name: 'shadowOffsetY', func: shadowOffsetY, description: 'promise test'})}
+        , 7: () => {return exec({name: 'measureText', func: measureText, description: 'promise test'})}
+        , 8: () => {return exec({name: 'globalAlpha', func: globalAlpha, description: 'promise test'})}
+        , 9: () => {return exec({name: 'fillRect', func: fillRect, description: 'promise test'})}
+        , 10: () => {return exec({name: 'clear', func: clear, description: 'promise test'})}
+        , 11: () => {return exec({name: 'translate', func: translate, description: 'promise test'})}
+    };
+
+    if(manualTest === true) {
+        logger.message('Manual mode.');
+        manual.runTestsManually(tests, beforeStartEx);
+    }
+
+    logger.message('done.');
+}).catch(function importFailed(err) {
+    console.error("Import failed for test-textcanvas.js: " + err);
+});


### PR DESCRIPTION
Stubs for:

textBaseline
globalAlpha
shadowColor
shadowBlur
shadowOffsetX
shadowOffsetY
fillRect
translate

Demo app: https://github.com/sergiygladkyy/sparkTextCanvas
```
git clone
npm i
npm run release-spark
cd dist/spark
npm i
```
Then run dist/spark/lightning-demo-spark.js

See also the following files in the src dir:
```
test-textcanvas.js - CI test
textcanvas-spark-min.js - minimal textCanvas invocation
textcanvas-spark.js - non-lightning textCanvas demo

```

Related repos with the updates for node modules:
`wpe-lightning-sdk`: https://github.com/sergiygladkyy/Lightning-SDK
`wpe-lightning`: https://github.com/sergiygladkyy/Lightning
`wpe-lightning-spark`: https://github.com/sergiygladkyy/Lightning-Spark
