### PR TITLE
pxTextCanvas initial support

### DIFF
--- a/examples/pxBenchmark/src/CMakeLists.txt
+++ b/examples/pxBenchmark/src/CMakeLists.txt
@@ -298,7 +298,7 @@ include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/)
 message(** ${CMAKE_CURRENT_SOURCE_DIR}/../external/Celero/include/} **)
 
 set(PXSCENE_COMMON_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxResource.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxConstants.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxRectangle.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxFont.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxText.cpp
-${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxTextBox.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImage.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImage9.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImageA.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImage9Border.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxArchive.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxAnimate.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxTextBox.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxTextCanvas.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImage.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImage9.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImageA.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxImage9Border.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxArchive.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../../pxScene2d/src/pxAnimate.cpp)
 
 set(CELERO_DEFINITIONS "${CMAKE_CURRENT_SOURCE_DIR}/../external/Celero/include")
 

--- a/examples/pxScene2d/src/CMakeLists.txt
+++ b/examples/pxScene2d/src/CMakeLists.txt
@@ -368,7 +368,7 @@ include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(AFTER ${CMAKE_CURRENT_SOURCE_DIR}/rasterizer)
 
 set(PXSCENE_COMMON_FILES pxResource.cpp pxConstants.cpp pxRectangle.cpp pxFont.cpp pxText.cpp
-        pxTextBox.cpp pxImage.cpp pxImage9.cpp pxImageA.cpp pxImage9Border.cpp pxArchive.cpp pxAnimate.cpp)
+    pxTextBox.cpp pxTextCanvas.cpp pxImage.cpp pxImage9.cpp pxImageA.cpp pxImage9Border.cpp pxArchive.cpp pxAnimate.cpp)
 
 set(PXSCENE_COMMON_FILES ${PXSCENE_COMMON_FILES} pxObject.cpp)
 set(PXSCENE_COMMON_FILES ${PXSCENE_COMMON_FILES} pxShaderUtils.cpp)

--- a/examples/pxScene2d/src/Makefile_MT
+++ b/examples/pxScene2d/src/Makefile_MT
@@ -97,6 +97,7 @@ PX_SRCS_FULL=\
     pxFont.cpp \
     pxText.cpp \
     pxTextBox.cpp \
+    pxTextCanvas.cpp \
     pxImage.cpp \
     pxImage9.cpp \
     pxArchive.cpp 
@@ -215,6 +216,7 @@ PXSCENE_LIB_SRCS=\
 	   pxRectangle.cpp \
            pxText.cpp \
            pxTextBox.cpp \
+           pxTextCanvas.cpp \
            pxImage.cpp \
            pxImage9.cpp \
            pxArchive.cpp \

--- a/examples/pxScene2d/src/pxContext.h
+++ b/examples/pxScene2d/src/pxContext.h
@@ -53,7 +53,47 @@ class shaderProgram; //fwd
   #define PXSCENE_DEFAULT_TEXTURE_MEMORY_LIMIT_THRESHOLD_PADDING_IN_BYTES (5 * 1024 * 1024)
 #endif
 
-//enum pxStretch { PX_NONE = 0, PX_STRETCH = 1, PX_REPEAT = 2 };
+
+typedef struct shadowFx_
+{
+  bool      shadow;
+
+  float     shadowColor[4];
+  float     shadowOffsetX;
+  float     shadowOffsetY;
+  float     shadowBlur;
+
+  float     x;         // used internally
+  float     y;         // used internally
+  float     radius;    // used internally
+  
+  float     width;           // used internally
+  float     height;          // used internally
+}
+shadowFx_t;
+
+typedef struct highlightFx_
+{
+  bool      highlight;
+
+  float     highlightColor[4];
+  float     highlightOffset;
+  float     highlightPaddingLeft;
+  float     highlightPaddingRight;
+  
+  
+  float     highlightHeight; // used internally
+  float     width;           // used internally
+  float     height;          // used internally
+}
+highlightFx_t;
+
+typedef struct textFx_
+{
+  highlightFx_t  highlight;
+  shadowFx_t     shadow;
+}
+textFx_t;
 
 class pxContext {
  public:
@@ -126,7 +166,16 @@ class pxContext {
                  bool downscaleSmooth = false,
                  pxConstantsMaskOperation::constants maskOp= pxConstantsMaskOperation::NORMAL);
 
-  void drawEffect(float x, float y, float w, float h, pxTextureRef t, shaderProgram *shader);
+  void drawEffect(float x, float y, float w, float h, pxTextureRef t, shaderProgram *shader, void *user = NULL);
+  void   drawBlur(float x, float y, float w, float h, pxTextureRef t, shaderProgram *shader, void *user /* = NULL*/);
+  
+  struct filterXYR
+  {
+    float x; float y; float r;
+  };
+  
+  pxContextFramebufferRef applyBlurSettings(pxContextFramebufferRef src, shadowFx_t *shdw,
+                                       filterXYR *filters, size_t count);
 
 #ifdef PXSCENE_FONT_ATLAS
   // This is intended to draw numQuads from the same texture.
@@ -134,8 +183,11 @@ class pxContext {
   // using GL_TRIANGLES in an optimal way.  quad oriented backends can skip vertices appropriately
   // 6 vertices (12 floats) and 6 uvs (12 floats) per quad
   void drawTexturedQuads(int numQuads, const void *verts, const void* uvs,
-                          pxTextureRef t, float* color);
+                         pxTextureRef t, float* color, void *user = NULL);
 #endif                          
+
+  void drawTextEffects(int numQuads, const void *verts, const void* uvs,
+                      pxTextureRef t, textFx_t *textFx);
 
   void drawImage9(float w, float h, float x1, float y1,
                   float x2, float y2, pxTextureRef texture);

--- a/examples/pxScene2d/src/pxContext.h
+++ b/examples/pxScene2d/src/pxContext.h
@@ -167,7 +167,6 @@ class pxContext {
                  pxConstantsMaskOperation::constants maskOp= pxConstantsMaskOperation::NORMAL);
 
   void drawEffect(float x, float y, float w, float h, pxTextureRef t, shaderProgram *shader, void *user = NULL);
-  void   drawBlur(float x, float y, float w, float h, pxTextureRef t, shaderProgram *shader, void *user /* = NULL*/);
   
   struct filterXYR
   {

--- a/examples/pxScene2d/src/pxContextGL.cpp
+++ b/examples/pxScene2d/src/pxContextGL.cpp
@@ -1420,7 +1420,7 @@ protected:
   }
 
 public:
-  pxError draw(int resW, int resH, float* matrix, float alpha,
+  virtual pxError draw(int resW, int resH, float* matrix, float alpha,
             GLenum mode,
             const void* pos,
             int count,
@@ -1481,7 +1481,7 @@ protected:
   }
 
 public:
-  pxError draw(int resW, int resH, float* matrix, float alpha,
+  virtual pxError draw(int resW, int resH, float* matrix, float alpha,
             GLenum mode,
             int count,
             const void* pos,
@@ -1577,7 +1577,7 @@ class aLinearBlurShaderProgram: public shaderProgram
 
 public:
 
-  pxError draw(int resW, int resH, float* matrix, float alpha,
+  virtual pxError draw(int resW, int resH, float* matrix, float alpha,
                pxTextureRef texture,
                GLenum mode,
                const void* pos,
@@ -1663,7 +1663,7 @@ protected:
   }
 
 public:
-  pxError draw(int resW, int resH, float* matrix, float alpha,
+  virtual pxError draw(int resW, int resH, float* matrix, float alpha,
             int count,
             const void* pos, const void* uv,
             pxTextureRef texture,
@@ -1735,7 +1735,7 @@ protected:
   }
 
 public:
-  pxError draw(int resW, int resH, float* matrix, float alpha,
+  virtual pxError draw(int resW, int resH, float* matrix, float alpha,
                int count,
                const void* pos, const void* uv,
                pxTextureRef texture,
@@ -1820,7 +1820,7 @@ protected:
   }
 
 public:
-  pxError draw(int resW, int resH, float* matrix, float alpha,
+  virtual pxError draw(int resW, int resH, float* matrix, float alpha,
             int count,
             const void* pos,
             const void* uv,
@@ -1899,53 +1899,6 @@ static void drawRect2(GLfloat x, GLfloat y, GLfloat w, GLfloat h, const float* c
 
   gSolidShader->draw(gResW,gResH,gMatrix.data(),gAlpha,GL_TRIANGLE_STRIP,verts,4,colorPM);
 }
-
-// YUCK - should use drawEffect() ... but virtual draw() mishmash
-// YUCK - should use drawEffect() ... but virtual draw() mishmash
-// YUCK - should use drawEffect() ... but virtual draw() mishmash
-// YUCK - should use drawEffect() ... but virtual draw() mishmash
-void pxContext::drawBlur(float x, float y, float w, float h, pxTextureRef t, shaderProgram *shader, void *user /* = NULL*/)
-{
-  if(shader == NULL)
-  {
-    rtLogError("drawBlur() ... Shader is NULL !");
-    return;
-  }
-  
-  // args are tested at call site...
-  
-  const float verts[4][2] =
-  {
-    { x  , y   },
-    { x+w, y   },
-    { x  , y+h },
-    { x+w, y+h }
-  };
-  
-  float iw = static_cast<float>( t ? t->width()  : 1);
-  float ih = static_cast<float>( t ? t->height() : 1);
-  
-  float tw = w/iw;
-  float th = h/ih;
-  
-  float firstTextureY  = 1.0;
-  float secondTextureY = static_cast<float>(1.0-th);
-  
-  const float uv[4][2] =
-  {
-    { 0,  firstTextureY  },
-    { tw, firstTextureY  },
-    { 0,  secondTextureY },
-    { tw, secondTextureY }
-  };
-  
-  aLinearBlurShaderProgram *blur = (aLinearBlurShaderProgram *) shader;
-  blur->draw(gResW, gResH, gMatrix.data(), gAlpha, t, GL_TRIANGLE_STRIP, verts, (t ? uv : NULL), 4, user);
-}
-// YUCK - should use drawEffect() ... but virtual draw() mishmash
-// YUCK - should use drawEffect() ... but virtual draw() mishmash
-// YUCK - should use drawEffect() ... but virtual draw() mishmash
-// YUCK - should use drawEffect() ... but virtual draw() mishmash
 
 
 static void drawEffect(GLfloat x, GLfloat y, GLfloat w, GLfloat h, pxTextureRef t, shaderProgram *shader, void *user /* = NULL*/)

--- a/examples/pxScene2d/src/pxFont.cpp
+++ b/examples/pxScene2d/src/pxFont.cpp
@@ -966,4 +966,12 @@ void pxTexturedQuads::draw(float x, float y)
 {
     draw(x, y, mColor);
 }
+
+void pxTexturedQuads::setColor(uint32_t c)
+{
+    mColor[0]/*R*/ = (float)((c>>24) & 0xff) / 255.0f;
+    mColor[1]/*G*/ = (float)((c>>16) & 0xff) / 255.0f;
+    mColor[2]/*B*/ = (float)((c>> 8) & 0xff) / 255.0f;
+    mColor[3]/*A*/ = (float)((c>> 0) & 0xff) / 255.0f;
+}
 #endif

--- a/examples/pxScene2d/src/pxFont.cpp
+++ b/examples/pxScene2d/src/pxFont.cpp
@@ -961,4 +961,9 @@ void pxTexturedQuads::draw(float x, float y, float* color, textFx_t *fx /* = NUL
     context.drawTexturedQuads( (int) q.verts.size()/12, &verts[0], &q.uvs[0], q.t, color, fx);
   }
 }
+
+void pxTexturedQuads::draw(float x, float y)
+{
+    draw(x, y, mColor);
+}
 #endif

--- a/examples/pxScene2d/src/pxFont.cpp
+++ b/examples/pxScene2d/src/pxFont.cpp
@@ -940,7 +940,7 @@ bool pxFontAtlas::addGlyph(uint32_t w, uint32_t h, void* buffer, GlyphTextureEnt
 }
 
 
-void pxTexturedQuads::draw(float x, float y, float* color)
+void pxTexturedQuads::draw(float x, float y, float* color, textFx_t *fx /* = NULL */)
 {
   for (uint32_t i = 0; i < mQuads.size(); i++)
   {
@@ -958,7 +958,7 @@ void pxTexturedQuads::draw(float x, float y, float* color)
       }
     }
 
-    context.drawTexturedQuads(q.verts.size()/12, &verts[0], &q.uvs[0], q.t, color);
+    context.drawTexturedQuads( (int) q.verts.size()/12, &verts[0], &q.uvs[0], q.t, color, fx);
   }
 }
 #endif

--- a/examples/pxScene2d/src/pxFont.h
+++ b/examples/pxScene2d/src/pxFont.h
@@ -154,6 +154,14 @@ class pxTexturedQuads
   }
 
   void draw(float x, float y, float* color, textFx_t *fx = NULL);
+  void draw(float x, float y);
+  void setColor(uint32_t c)
+  {
+      mColor[0]/*R*/ = (float)((c>>24) & 0xff) / 255.0f;
+      mColor[1]/*G*/ = (float)((c>>16) & 0xff) / 255.0f;
+      mColor[2]/*B*/ = (float)((c>> 8) & 0xff) / 255.0f;
+      mColor[3]/*A*/ = (float)((c>> 0) & 0xff) / 255.0f;
+  }
 
   void clear()
   {
@@ -162,6 +170,7 @@ class pxTexturedQuads
 
 private:
   vector<quads> mQuads;
+  float mColor[4] = {0xff, 0xff, 0xff, 0xff};
 };
 
 #endif

--- a/examples/pxScene2d/src/pxFont.h
+++ b/examples/pxScene2d/src/pxFont.h
@@ -155,13 +155,7 @@ class pxTexturedQuads
 
   void draw(float x, float y, float* color, textFx_t *fx = NULL);
   void draw(float x, float y);
-  void setColor(uint32_t c)
-  {
-      mColor[0]/*R*/ = (float)((c>>24) & 0xff) / 255.0f;
-      mColor[1]/*G*/ = (float)((c>>16) & 0xff) / 255.0f;
-      mColor[2]/*B*/ = (float)((c>> 8) & 0xff) / 255.0f;
-      mColor[3]/*A*/ = (float)((c>> 0) & 0xff) / 255.0f;
-  }
+  void setColor(uint32_t c);
 
   void clear()
   {

--- a/examples/pxScene2d/src/pxFont.h
+++ b/examples/pxScene2d/src/pxFont.h
@@ -153,7 +153,7 @@ class pxTexturedQuads
     u.push_back(v2);
   }
 
-  void draw(float x, float y, float* color);
+  void draw(float x, float y, float* color, textFx_t *fx = NULL);
 
   void clear()
   {

--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -38,6 +38,7 @@
 #include "pxRectangle.h"
 #include "pxText.h"
 #include "pxTextBox.h"
+#include "pxTextCanvas.h"
 #include "pxImage.h"
 
 #ifdef ENABLE_SPARK_WEBGL
@@ -711,6 +712,8 @@ rtError pxScene2d::create(rtObjectRef p, rtObjectRef& o)
     e = createText(p,o);
   else if (!strcmp("textBox",t.cString()))
     e = createTextBox(p,o);
+  else if (!strcmp("textCanvas",t.cString()))
+    e = createTextCanvas(p,o);
   else if (!strcmp("image",t.cString()))
     e = createImage(p,o);
   else if (!strcmp("image9",t.cString()))
@@ -807,6 +810,14 @@ rtError pxScene2d::createText(rtObjectRef p, rtObjectRef& o)
 rtError pxScene2d::createTextBox(rtObjectRef p, rtObjectRef& o)
 {
   o = new pxTextBox(this);
+  o.set(p);
+  o.send("init");
+  return RT_OK;
+}
+
+rtError pxScene2d::createTextCanvas(rtObjectRef p, rtObjectRef& o)
+{
+  o = new pxTextCanvas(this);
   o.set(p);
   o.send("init");
   return RT_OK;

--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -922,6 +922,7 @@ public:
   rtError createRectangle(rtObjectRef p, rtObjectRef& o);
   rtError createText(rtObjectRef p, rtObjectRef& o);
   rtError createTextBox(rtObjectRef p, rtObjectRef& o);
+  rtError createTextCanvas(rtObjectRef p, rtObjectRef& o);
   rtError createImage(rtObjectRef p, rtObjectRef& o);
   rtError createPath(rtObjectRef p, rtObjectRef& o);
   rtError createImage9(rtObjectRef p, rtObjectRef& o);

--- a/examples/pxScene2d/src/pxShaderUtils.cpp
+++ b/examples/pxScene2d/src/pxShaderUtils.cpp
@@ -171,8 +171,10 @@ pxError shaderProgram::draw(int resW, int resH, float* matrix, float alpha,
                             GLenum mode,
                             const void* pos,
                             const void* uv,
-                            int count)
+                            int count, void* user /* = NULL */)
 {
+  UNUSED_PARAM(user);
+
   if(!resW || !resH || !matrix || !pos)
   {
     return RT_FAIL;

--- a/examples/pxScene2d/src/pxShaderUtils.h
+++ b/examples/pxScene2d/src/pxShaderUtils.h
@@ -150,7 +150,8 @@ public:
                 GLenum mode,
                 const void* pos,
                 const void* uv,
-                int count);
+                int count,
+                void* user = NULL);
 
 protected:
 

--- a/examples/pxScene2d/src/pxText.h
+++ b/examples/pxScene2d/src/pxText.h
@@ -44,90 +44,82 @@ public:
   rtProperty(font, font, setFont, rtObjectRef);
   rtMethodNoArgAndReturn("texture", texture, uint32_t);
 
+  rtProperty(shadow,        shadow,        setShadow,        bool);
+  rtProperty(shadowColor,   shadowColor,   setShadowColor,   rtValue);
+  rtProperty(shadowOffsetX, shadowOffsetX, setShadowOffsetX, float);
+  rtProperty(shadowOffsetY, shadowOffsetY, setShadowOffsetY, float);
+  rtProperty(shadowBlur,    shadowBlur,    setShadowBlur,    float);
+
+  rtProperty(highlight,             highlight,             setHighlight,              bool);
+  rtProperty(highlightColor,        highlightColor,        setHighlightColor,         rtValue);
+  rtProperty(highlightOffset,       highlightOffset,       setHighlightOffset,        float);
+  rtProperty(highlightPaddingLeft,  highlightPaddingLeft,  setHighlightPadddingLeft,  float);
+  rtProperty(highlightPaddingRight, highlightPaddingRight, setHighlightPadddingRight, float);
+
+
   pxText(pxScene2d* scene);
   virtual ~pxText();
+
   rtError text(rtString& s) const;
   virtual rtError setText(const char* text);
-  rtError removeResourceListener();
 
-  rtError textColorInternal(uint32_t& c) const
-  {
-#ifdef PX_LITTLEENDIAN_PIXELS
+  rtError setColor(float *var, rtValue c);
+  rtError colorFloat4_to_UInt32( const float *clr, uint32_t& c) const;
+  rtError colorUInt32_to_Float4(float *clr, uint32_t c) const;
 
-    c = ((uint8_t) (mTextColor[0] * 255.0f) << 24) |  // R
-        ((uint8_t) (mTextColor[1] * 255.0f) << 16) |  // G
-        ((uint8_t) (mTextColor[2] * 255.0f) <<  8) |  // B
-        ((uint8_t) (mTextColor[3] * 255.0f) <<  0);   // A
-#else
-
-    c = ((uint8_t) (mTextColor[3] * 255.0f) << 24) |  // A
-        ((uint8_t) (mTextColor[2] * 255.0f) << 16) |  // B
-        ((uint8_t) (mTextColor[1] * 255.0f) <<  8) |  // G
-        ((uint8_t) (mTextColor[0] * 255.0f) <<  0);   // R
-#endif
-
-    
-    return RT_OK;
-  }
-
-  rtError setTextColorInternal(uint32_t c)
-  {
-    mTextColor[PX_RED  ] = (float)((c>>24) & 0xff) / 255.0f;
-    mTextColor[PX_GREEN] = (float)((c>>16) & 0xff) / 255.0f;
-    mTextColor[PX_BLUE ] = (float)((c>> 8) & 0xff) / 255.0f;
-    mTextColor[PX_ALPHA] = (float)((c>> 0) & 0xff) / 255.0f;
-    return RT_OK;
-  }
-  
-  rtError textColor(rtValue &c) const
-  {
-    uint32_t cc = 0;
-    rtError err = textColorInternal(cc);
-    
-    c = cc;
-    
-    return err;
-  }
-  
-  rtError setTextColor(rtValue c)
-  {
-    // Set via STRING...
-    if( c.getType() == 's')
-    {
-      rtString str = c.toString();
-      
-      uint8_t r,g,b, a;
-      if( web2rgb( str, r, g, b, a) == RT_OK)
-      {
-        mTextColor[PX_RED  ] = (float) r / 255.0f;  // R
-        mTextColor[PX_GREEN] = (float) g / 255.0f;  // G
-        mTextColor[PX_BLUE ] = (float) b / 255.0f;  // B
-        mTextColor[PX_ALPHA] = (float) a / 255.0f;  // A
-        
-        return RT_OK;
-      }
-      
-      return RT_FAIL;
-    }
-    
-    // Set via UINT32...
-    uint32_t clr = c.toUInt32();
-    
-    return setTextColorInternal(clr);
-  }
+  rtError textColor(rtValue &c) const;
+  rtError setTextColor(rtValue c);
 
   rtError fontUrl(rtString& v) const { getFontResource()->url(v); return RT_OK; }
   virtual rtError setFontUrl(const char* s);
 
   rtError pixelSize(uint32_t& v) const { v = mPixelSize; return RT_OK; }
   virtual rtError setPixelSize(uint32_t v);
-  
+
   rtError font(rtObjectRef& o) const { o = mFont; return RT_OK; }
   virtual rtError setFont(rtObjectRef o);
 
   virtual rtError texture(uint32_t & v);
+
+  // - - - - - - - - - - - - - - - - - - Shadow - - - - - - - - - - - - - - - - - -
+
+  rtError shadow(bool &v) const                      { v = mShadow;  return RT_OK; }
+  virtual rtError setShadow(bool v)                  { mShadow = v;  return RT_OK; }
+
+  rtError shadowColor(rtValue &c) const;
+  rtError setShadowColor(rtValue c);
+
+  rtError shadowOffsetX(float &v) const              { v = mShadowOffsetX; return RT_OK; }
+  virtual rtError setShadowOffsetX(float v)          { mShadowOffsetX = v; return RT_OK; }
+
+  rtError shadowOffsetY(float &v) const              { v = mShadowOffsetY; return RT_OK; }
+  virtual rtError setShadowOffsetY(float v)          { mShadowOffsetY = v; return RT_OK; }
+
+  rtError shadowBlur(float &v) const                 { v = mShadowBlur;    return RT_OK; }
+  virtual rtError setShadowBlur(float v)             { mShadowBlur = v;    return RT_OK; }
+
+  // - - - - - - - - - - - - - - - - - - Highlight - - - - - - - - - - - - - - - - - -
+
+  rtError highlight(bool &v) const                   { v = mHighlight;  return RT_OK; }
+  virtual rtError setHighlight(bool v)               { mHighlight = v;  return RT_OK; }
+
+  rtError highlightColor(rtValue &c) const;
+  rtError setHighlightColor(rtValue c);
+
+  rtError highlightOffset(float &v) const            { v = mHighlightOffset;       return RT_OK; }
+  virtual rtError setHighlightOffset(float v)        { mHighlightOffset = v;       return RT_OK; }
+
+  rtError highlightPaddingLeft(float &v) const       { v = mHighlightPaddingLeft;  return RT_OK; }
+  virtual rtError setHighlightPadddingLeft(float v)  { mHighlightPaddingLeft = v;  return RT_OK; }
+
+  rtError highlightPaddingRight(float &v) const      { v = mHighlightPaddingRight; return RT_OK; }
+  virtual rtError setHighlightPadddingRight(float v) { mHighlightPaddingRight = v; return RT_OK; }
+
+  // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   
   virtual void onInit();
+
+  rtError removeResourceListener();
   
   virtual rtError Set(uint32_t i, const rtValue* value) override
   {
@@ -147,7 +139,19 @@ public:
               !strcmp(name,"fontUrl") ||
               !strcmp(name,"font") ||
               !strcmp(name,"sx") || 
-              !strcmp(name,"sy");
+              !strcmp(name,"sy")                   ||
+
+              !strcmp(name,"shadow")               ||
+              !strcmp(name,"shadowColor")          ||
+              !strcmp(name,"shadowOffsetX")        ||
+              !strcmp(name,"shadowOffsetY")        ||
+              !strcmp(name,"shadowBlur")           ||
+
+              !strcmp(name,"highlight")            ||
+              !strcmp(name,"highlightColor")       ||
+              !strcmp(name,"highlightOffset")      ||
+              !strcmp(name,"highlightPaddingLeft") ||
+              !strcmp(name,"highlightPaddingRight");
 #else
     mDirty = true;
 #endif
@@ -182,6 +186,19 @@ public:
   
   float mTextColor[4];
   uint32_t mPixelSize;
+
+  bool     mShadow;
+  float    mShadowColor[4];
+  float    mShadowOffsetX;
+  float    mShadowOffsetY;
+  float    mShadowBlur;
+
+  bool     mHighlight;
+  float    mHighlightColor[4];
+  float    mHighlightOffset;
+  float    mHighlightPaddingLeft;
+  float    mHighlightPaddingRight;
+
   bool mDirty;
   pxContextFramebufferRef mCached;
   rtFileDownloadRequest* mFontDownloadRequest;

--- a/examples/pxScene2d/src/pxTextBox.cpp
+++ b/examples/pxScene2d/src/pxTextBox.cpp
@@ -753,7 +753,7 @@ void pxTextBox::renderOneLine(const char * tempStr, float tempX, float tempY, fl
       {
         rtLogWarn("Text width is larger than maximum texture allowed: %lf.  Maximum texture size of %d will be used.",charW, MAX_TEXTURE_WIDTH);
         float tempWidthRatio = charW/MAX_TEXTURE_WIDTH;
-        uint32_t strLen = strlen(tempStr);
+        uint32_t strLen = (uint32_t) strlen(tempStr);
         uint32_t tempNewLen = static_cast<uint32_t> (strLen/tempWidthRatio);
 
         char* trimmedTempStr = (char *)malloc(tempNewLen+1);

--- a/examples/pxScene2d/src/pxTextCanvas.cpp
+++ b/examples/pxScene2d/src/pxTextCanvas.cpp
@@ -5,6 +5,37 @@
 
 extern pxContext context;
 
+//pxTextLine
+pxTextLine::pxTextLine(const char* text, uint32_t x, uint32_t y)
+        : pixelSize(10)
+        , color(0xFFFFFFFF)
+{
+    this->text = text;
+    this->x = x;
+    this->y = y;
+    this->styleSet = false;
+};
+
+void pxTextLine::setStyle(const rtObjectRef& f, uint32_t ps, uint32_t c) {
+    // TODO: validate pxFont object
+    this->font = f;
+    this->pixelSize = ps;
+    this->color = c;
+    this->styleSet = true;
+}
+
+//pxTextCanvasMeasurements
+pxTextCanvasMeasurements::pxTextCanvasMeasurements(rtObjectRef sm)
+{
+    fromSimpleMeasurements(sm);
+}
+
+void pxTextCanvasMeasurements::fromSimpleMeasurements(rtObjectRef sm) {
+    pxTextSimpleMeasurements* pSm = ((pxTextSimpleMeasurements*)sm.getPtr());
+    mw = pSm->w(); mh = pSm->h();
+}
+
+//pxTextCanvas
 pxTextCanvas::pxTextCanvas(pxScene2d* s): pxText(s)
         , mInitialized(false)
         , mNeedsRecalc(false)
@@ -53,16 +84,125 @@ void pxTextCanvas::resourceReady(rtString readyResolution)
     rtLogDebug("pxTextCanvas::resourceReady - end");
 }
 
+uint32_t pxTextCanvas::alignHorizontal() const
+{
+    return mAlignHorizontal;
+}
+
+rtError pxTextCanvas::alignHorizontal(uint32_t& v) const
+{
+    v = mAlignHorizontal;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setAlignHorizontal(uint32_t v)
+{
+    mAlignHorizontal = v;
+    setNeedsRecalc(true);
+    return RT_OK;
+}
+
+rtError pxTextCanvas::fillStyle(rtValue &c) const
+{
+    return textColor(c);
+}
+
+rtError pxTextCanvas::setFillStyle(rtValue c)
+{
+    rtLogInfo("pxTextCanvas::setFillStyle. Called with param: %#08x", c.toUInt32());
+    setTextColor(c);
+    return RT_OK;
+}
+rtError pxTextCanvas::textBaseline(rtString &b) const
+{
+    b = mTextBaseline;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setTextBaseline(const rtString& c)
+{
+    rtLogInfo("pxTextCanvas::setTextBaseline called with param: %s", c.cString());
+    rtLogError("pxTextCanvas::setTextBaseline. NOT IMPLEMENTED. Call ignored.");
+    mTextBaseline = c;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::globalAlpha(float& a) const
+{
+    a = mGlobalAlpha;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setGlobalAlpha(const float a)
+{
+    rtLogInfo("pxTextCanvas::setGlobalAlpha called with param: %f", a);
+    rtLogError("pxTextCanvas::setGlobalAlpha. NOT IMPLEMENTED. Call ignored.");
+    mGlobalAlpha = a;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::shadowColor(uint32_t& c) const
+{
+    c = mShadowColor;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setShadowColor(const uint32_t c)
+{
+    rtLogInfo("pxTextCanvas::setShadowColor. Called with param: %#08x", c);
+    rtLogError("pxTextCanvas::setShadowColor. NOT IMPLEMENTED. Call ignored.");
+    mShadowColor = c;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::shadowBlur(uint8_t& b) const
+{
+    b = mShadowColor;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setShadowBlur(const uint8_t b)
+{
+    rtLogInfo("pxTextCanvas::setShadowBlur. Called with param: %d", b);
+    rtLogError("pxTextCanvas::setShadowBlur. NOT IMPLEMENTED. Call ignored.");
+    mShadowBlur = b;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::shadowOffsetX(float& o) const
+{
+    o = mShadowOffsetX;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setShadowOffsetX(const float o)
+{
+    rtLogInfo("pxTextCanvas::setShadowOffsetX called with param: %f", o);
+    rtLogError("pxTextCanvas::setShadowOffsetX. NOT IMPLEMENTED. Call ignored.");
+    mShadowOffsetX = o;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::shadowOffsetY(float& o) const
+{
+    o = mShadowOffsetY;
+    return RT_OK;
+}
+
+rtError pxTextCanvas::setShadowOffsetY(const float o)
+{
+    rtLogInfo("pxTextCanvas::setShadowOffsetY called with param: %f", o);
+    rtLogError("pxTextCanvas::setShadowOffsetY. NOT IMPLEMENTED. Call ignored.");
+    mShadowOffsetY = o;
+    return RT_OK;
+}
+
 float pxTextCanvas::getFBOWidth()
 {
-    rtLogDebug("pxTextCanvas::getFBOWidth - begin.");
-    rtLogDebug("pxTextCanvas::getFBOWidth - end.");
     return pxText::getFBOWidth();
 }
 float pxTextCanvas::getFBOHeight()
 {
-    rtLogDebug("pxTextCanvas::getFBOHeight - begin.");
-    rtLogDebug("pxTextCanvas::getFBOHeight - end.");
     return pxText::getFBOHeight();
 }
 

--- a/examples/pxScene2d/src/pxTextCanvas.cpp
+++ b/examples/pxScene2d/src/pxTextCanvas.cpp
@@ -41,26 +41,21 @@ pxTextCanvas::pxTextCanvas(pxScene2d* s): pxText(s)
         , mNeedsRecalc(false)
         , mAlignHorizontal(pxConstantsAlignHorizontal::LEFT)
         , mGlobalAlpha(0.0)
-        , mShadowColor(0X00000000) /*fully transparent black*/
-        , mShadowBlur(0)
-        , mShadowOffsetX(0.0)
-        , mShadowOffsetY(0.0)
-
+        , mTranslateX(0)
+        , mTranslateY(0)
 {
-    rtLogDebug("pxTextCanvas::ctor - begin");
     measurements = new pxTextCanvasMeasurements;
     mFontLoaded = false;
     mFontFailed = false;
     mTextBaseline = "alphabetic"; //TODO: make a const class from it?
+    mColorMode = "RGBA"; //TODO: make a const class from it?
 	mLabel = "";
-    rtLogDebug("pxTextCanvas::ctor - end");
 }
 /** This signals that the font file loaded successfully; now we need to
  * send the ready promise once we have the text, too
  */
 void pxTextCanvas::resourceReady(rtString readyResolution)
 {
-    rtLogDebug("pxTextCanvas::resourceReady - begin");
     if( !readyResolution.compare("resolve"))
     {
         mFontLoaded = true;
@@ -82,7 +77,6 @@ void pxTextCanvas::resourceReady(rtString readyResolution)
         pxObject::onTextureReady();
         mReady.send("reject",this);
     }
-    rtLogDebug("pxTextCanvas::resourceReady - end");
 }
 
 uint32_t pxTextCanvas::alignHorizontal() const
@@ -110,12 +104,18 @@ rtError pxTextCanvas::fillStyle(rtValue &c) const
 
 rtError pxTextCanvas::setFillStyle(rtValue c)
 {
-    rtLogInfo("pxTextCanvas::setFillStyle. Called with param: %#08x", c.toUInt32());
-    rtValue clr(argb2rgba(c.toUInt32()));
-    rtLogInfo("pxTextCanvas::setFillStyle. Converted to: %#08x", clr.toUInt32());
+    rtValue clr;
+    if (mColorMode == "ARGB")
+    {
+        clr = argb2rgba(c.toUInt32());
+        rtLogDebug("pxTextCanvas::setFillStyle. ARGB param %#08x converted to RGBA: %#08x", c.toUInt32(), clr.toUInt32());
+    } else {
+        clr = c;
+    }
     setTextColor(clr);
     return RT_OK;
 }
+
 rtError pxTextCanvas::textBaseline(rtString &b) const
 {
     b = mTextBaseline;
@@ -144,61 +144,6 @@ rtError pxTextCanvas::setGlobalAlpha(const float a)
     return RT_OK;
 }
 
-rtError pxTextCanvas::shadowColor(uint32_t& c) const
-{
-    c = mShadowColor;
-    return RT_OK;
-}
-
-rtError pxTextCanvas::setShadowColor(const uint32_t c)
-{
-    rtLogInfo("pxTextCanvas::setShadowColor. Called with param: %#08x", c);
-    rtLogError("pxTextCanvas::setShadowColor. NOT IMPLEMENTED. Call ignored.");
-    mShadowColor = c;
-    return RT_OK;
-}
-
-rtError pxTextCanvas::shadowBlur(uint32_t& b) const
-{
-    b = mShadowBlur;
-    return RT_OK;
-}
-
-rtError pxTextCanvas::setShadowBlur(const uint32_t b)
-{
-    rtLogInfo("pxTextCanvas::setShadowBlur. Called with param: %d", b);
-    rtLogError("pxTextCanvas::setShadowBlur. NOT IMPLEMENTED. Call ignored.");
-    mShadowBlur = b;
-    return RT_OK;
-}
-
-rtError pxTextCanvas::shadowOffsetX(float& o) const
-{
-    o = mShadowOffsetX;
-    return RT_OK;
-}
-
-rtError pxTextCanvas::setShadowOffsetX(const float o)
-{
-    rtLogInfo("pxTextCanvas::setShadowOffsetX called with param: %f", o);
-    rtLogError("pxTextCanvas::setShadowOffsetX. NOT IMPLEMENTED. Call ignored.");
-    mShadowOffsetX = o;
-    return RT_OK;
-}
-
-rtError pxTextCanvas::shadowOffsetY(float& o) const
-{
-    o = mShadowOffsetY;
-    return RT_OK;
-}
-
-rtError pxTextCanvas::setShadowOffsetY(const float o)
-{
-    rtLogInfo("pxTextCanvas::setShadowOffsetY called with param: %f", o);
-    rtLogError("pxTextCanvas::setShadowOffsetY. NOT IMPLEMENTED. Call ignored.");
-    mShadowOffsetY = o;
-    return RT_OK;
-}
 
 rtError pxTextCanvas::label(rtString &c) const
 {
@@ -210,6 +155,31 @@ rtError pxTextCanvas::setLabel(const rtString &c)
     mLabel = c;
     return RT_OK;
 }
+
+rtError pxTextCanvas::colorMode(rtString &c) const
+{
+    c = mColorMode;
+    return RT_OK;
+}
+rtError pxTextCanvas::setColorMode(const rtString &c)
+{
+    rtError res = RT_OK;
+
+    if (c != mColorMode)
+    {
+        if ((c == "ARGB") || (c == "RGBA"))
+        {
+            mColorMode = c;
+            rtLogDebug("Setting color mode: '%s;", c.cString());
+        } else {
+            rtLogError("Unknown color mode %s. Supported modes: 'ARGB', 'RGBA'", c.cString());
+            res = RT_ERROR;
+        }
+    }
+
+    return res;
+}
+
 float pxTextCanvas::getFBOWidth()
 {
     return pxText::getFBOWidth();
@@ -221,9 +191,8 @@ float pxTextCanvas::getFBOHeight()
 
 void pxTextCanvas::onInit()
 {
-    rtLogDebug("pxTextCanvas::onInit - begin.");
     pxText::onInit();
-    rtLogInfo("pxTextCanvas::onInit. mFontLoaded=%d\n",mFontLoaded);
+    rtLogDebug("pxTextCanvas::onInit. mFontLoaded=%d\n",mFontLoaded);
     mInitialized = true;
 
     // If this is using the default font, we would not get a callback
@@ -236,12 +205,10 @@ void pxTextCanvas::onInit()
             resourceReady("resolve");
         }
     }
-    rtLogDebug("pxTextCanvas::onInit - end.");
 }
 
 void pxTextCanvas::recalc()
 {
-    rtLogDebug("pxTextCanvas::recalc - begin.");
 
     if( mNeedsRecalc && mInitialized && mFontLoaded) {
         clearMeasurements();
@@ -259,7 +226,6 @@ void pxTextCanvas::recalc()
         renderText(true);
         mDirty = false;
     }
-    rtLogDebug("pxTextCanvas::recalc - end.");
 }
 
 void pxTextCanvas::clearMeasurements()
@@ -282,37 +248,29 @@ void pxTextCanvas::setNeedsRecalc(bool recalc)
 
 void pxTextCanvas::sendPromise()
 {
-    rtLogDebug("TextCanvas sendPromise - begin");
     rtLogDebug("pxTextCanvas::sendPromise mInitialized=%d mFontLoaded=%d mNeedsRecalc=%d\n",mInitialized,mFontLoaded,mNeedsRecalc);
     // TODO: hanlde mNeedsRecalc properly!
-    if(mInitialized && mFontLoaded /*&& !mNeedsRecalc*/ && !mDirty && !((rtPromise*)mReady.getPtr())->status())
-    {
+    if(mInitialized && mFontLoaded /*&& !mNeedsRecalc*/ && !mDirty && !((rtPromise*)mReady.getPtr())->status()) {
         rtLogDebug("pxTextCanvas SENDPROMISE\n");
-        mReady.send("resolve",this);
-
+        mReady.send("resolve", this);
     } else {
-        rtLogDebug("pxTextCanvas NOT sending promise");
+//        rtLogDebug("pxTextCanvas NOT sending promise");
     }
-    rtLogDebug("TextCanvas sendPromise - end");
 }
 
 void pxTextCanvas::renderText(bool render)
 {
-    rtLogDebug("pxTextCanvas::renderText - begin.");
     if (render && !mTextLines.empty()) {
         for (std::vector<pxTextLine>::iterator it = mTextLines.begin() ; it != mTextLines.end(); ++it)
             renderTextLine(*it);
     }
-    rtLogDebug("pxTextCanvas::renderText - end.");
 }
 
 void pxTextCanvas::renderTextLine(const pxTextLine& textLine)
 {
-    rtLogDebug("pxTextCanvas::renderTextLine - begin");
-
     const char* cStr = textLine.text.cString();
-    float xPos = textLine.x;
-    float yPos = textLine.y;
+    float xPos = textLine.x + mTranslateX;
+    float yPos = textLine.y + mTranslateY;
 
     // TODO ignoring sx and sy now.
     float sx = 1.0;
@@ -320,7 +278,16 @@ void pxTextCanvas::renderTextLine(const pxTextLine& textLine)
 
     float charW = 0, charH = 0;
     uint32_t size = textLine.pixelSize;
-    setFont(textLine.font);
+    if (mFont != textLine.font)
+    {
+        setFont(textLine.font);
+    }
+//    rtLogInfo("pxTextCanvas::renderTextLine; textline: '%s', current canvas: '%s' (w x h): %04.0f x %04.0f"
+//            , cStr
+//            , mLabel.cString()
+//            , mw
+//            , mh
+//            );
 
     // TODO: calc alignment
     if (getFontResource() != nullptr)
@@ -328,8 +295,10 @@ void pxTextCanvas::renderTextLine(const pxTextLine& textLine)
         getFontResource()->measureTextInternal(cStr, size, sx, sy, charW, charH);
         //TODO: add clipping support here
         mw = charW > mw ? charW : mw;
-        mh = charH > mh ? charH : mh;
     }
+
+    mh  += charH;   // TODO: hack, remove. For some reason canvas size calculated in js is smaller than expected
+                    // this allows to account for height changes when drawing multiple lines
 
     // Now, render the text
     if( getFontResource() != nullptr)
@@ -344,12 +313,10 @@ void pxTextCanvas::renderTextLine(const pxTextLine& textLine)
         rtLogError("pxTextCanvas::drawing without FONT ATLAS is not supported yet.");
 #endif
     }
-    rtLogDebug("pxTextCanvas::renderTextLine - end");
 }
 
 void pxTextCanvas::draw()
 {
-    rtLogDebug("pxTextCanvas::draw - begin.");
 #ifdef PXSCENE_FONT_ATLAS
     if (mDirty)
     {
@@ -363,7 +330,6 @@ void pxTextCanvas::draw()
 #else
     rtLogError("pxTextCanvas::drawing without FONT ATLAS is not supported yet.");
 #endif
-    rtLogDebug("pxTextCanvas::draw - end.");
 }
 
 float pxTextCanvas::getOnscreenWidth()
@@ -380,19 +346,15 @@ float pxTextCanvas::getOnscreenHeight()
 
 void pxTextCanvas::update(double t, bool updateChildren)
 {
-    rtLogDebug("pxTextCanvas::update - begin.");
     if( mNeedsRecalc ) {
         recalc();
         markDirty();
     }
     pxText::update(t, updateChildren);
-    rtLogDebug("pxTextCanvas::update - end.");
 }
 
 rtError pxTextCanvas::measureText(rtString text, rtObjectRef& o)
 {
-    rtLogDebug("pxTextCanvas::measureText - begin.");
-    rtLogInfo("pxTextCanvas::measureText() mNeedsRecalc is %d text: %s", mNeedsRecalc, text.cString());
     rtObjectRef tcm = new pxTextCanvasMeasurements(); // TODO: aren't we leaking here with 'new'? Is it efficient?
     o = tcm;
     if(getFontResource() != nullptr) {
@@ -400,42 +362,44 @@ rtError pxTextCanvas::measureText(rtString text, rtObjectRef& o)
         getFontResource()->measureText(mPixelSize, text, sm);
         ((pxTextCanvasMeasurements*)tcm.getPtr())->fromSimpleMeasurements(sm);
 
-        rtLogInfo("pxTextCanvas::measureText(). Got measurements; width: %d, height: %d "
+        rtLogDebug("pxTextCanvas::measureText(). Got measurements; width: %d, height: %d "
                 , ((pxTextCanvasMeasurements*)tcm.getPtr())->width()
                 , ((pxTextCanvasMeasurements*)tcm.getPtr())->h()
                 );
-
     } else {
         rtLogWarn("measureText called TOO EARLY -- not initialized or font not loaded!\n");
         //return RT_OK; // !CLF: TO DO - COULD RETURN RT_ERROR HERE TO CATCH NOT WAITING ON PROMISE
     }
-    rtLogDebug("pxTextCanvas::measureText - end.");
     return RT_OK;
 }
 
 rtError pxTextCanvas::fillText(rtString text, uint32_t x, uint32_t y)
 {
-    rtLogDebug("pxTextCanvas::fillText - begin.");
-    rtLogInfo("pxTextCanvas::fillText called with params: text: %s, x %d, y %d", text.cString(), x, y);
+    rtLogDebug("pxTextCanvas::fillText called with params: text: '%s', x %d, y %d. Canvas: '%s' (w x h): %04.0f x %04.0f"
+            , text.cString()
+            , x
+            , y
+            , mLabel.cString()
+            , mw
+            , mh
+            );
     pxTextLine textLine(text, x, y);
-    uint32_t color;
-    textColorInternal(color);
-    textLine.setStyle(mFont, mPixelSize, color);
+    rtValue color;
+    textColor(color);
+    textLine.setStyle(mFont, mPixelSize, color.toInt32());
     mTextLines.push_back(textLine);
     setNeedsRecalc(true);
-    rtLogDebug("pxTextCanvas::fillText - end.");
     return RT_OK;
 }
 
 rtError pxTextCanvas::clear()
 {
-    rtLogDebug("pxTextCanvas::clear - begin.");
     mTextLines.clear();
     mw = 0;
     mh = 0;
+    mTranslateX = 0;
+    mTranslateY = 0;
     setNeedsRecalc(true);
-    rtLogDebug("pxTextCanvas::clear - end.");
-
     return RT_OK;
 }
 
@@ -452,10 +416,10 @@ rtError pxTextCanvas::fillRect(uint32_t x, uint32_t y, uint32_t width, uint32_t 
 
 rtError pxTextCanvas::translate(uint32_t x, uint32_t y)
 {
-    UNUSED_PARAM(x);
-    UNUSED_PARAM(y);
-    rtLogInfo("pxTextCanvas::translate called with params: x %d, y %d", x, y);
-    rtLogError("pxTextCanvas::translate. NOT IMPLEMENTED. Call ignored.");
+    mTranslateX += x;
+    mTranslateY += y;
+
+    rtLogInfo("pxTextCanvas::translate applied translation params: x: %d, y: %d, current translation (x, y): %d, %d", x, y, mTranslateX, mTranslateY);
     return RT_OK;
 }
 
@@ -463,7 +427,6 @@ uint32_t pxTextCanvas::argb2rgba(uint32_t val)
 {
     return val << 8 | val >> 24;
 }
-
 
 // pxTextCanvasMeasurements
 rtDefineObject(pxTextCanvasMeasurements, rtObject);
@@ -475,11 +438,10 @@ rtDefineProperty(pxTextCanvas, alignHorizontal);
 rtDefineProperty(pxTextCanvas, fillStyle);
 rtDefineProperty(pxTextCanvas, textBaseline);
 rtDefineProperty(pxTextCanvas, globalAlpha);
-rtDefineProperty(pxTextCanvas, shadowColor);
-rtDefineProperty(pxTextCanvas, shadowBlur);
-rtDefineProperty(pxTextCanvas, shadowOffsetX);
-rtDefineProperty(pxTextCanvas, shadowOffsetY);
 rtDefineProperty(pxTextCanvas, label);
+rtDefineProperty(pxTextCanvas, colorMode);
+rtDefineProperty(pxTextCanvas, width);
+rtDefineProperty(pxTextCanvas, height);
 
 rtDefineMethod(pxTextCanvas, measureText);
 rtDefineMethod(pxTextCanvas, fillText);

--- a/examples/pxScene2d/src/pxTextCanvas.cpp
+++ b/examples/pxScene2d/src/pxTextCanvas.cpp
@@ -1,0 +1,328 @@
+#include "pxConstants.h"
+#include "pxText.h"
+#include "pxTextCanvas.h"
+#include "pxContext.h"
+
+extern pxContext context;
+
+pxTextCanvas::pxTextCanvas(pxScene2d* s): pxText(s)
+        , mInitialized(false)
+        , mNeedsRecalc(false)
+        , mAlignHorizontal(pxConstantsAlignHorizontal::LEFT)
+        , mGlobalAlpha(0.0)
+        , mShadowColor(0X00000000) /*fully transparent black*/
+        , mShadowBlur(0)
+        , mShadowOffsetX(0.0)
+        , mShadowOffsetY(0.0)
+
+{
+    rtLogDebug("pxTextCanvas::ctor - begin");
+    measurements = new pxTextCanvasMeasurements;
+    mFontLoaded = false;
+    mFontFailed = false;
+    mTextBaseline = "alphabetic"; //TODO: make a const class from it?
+    rtLogDebug("pxTextCanvas::ctor - end");
+}
+/** This signals that the font file loaded successfully; now we need to
+ * send the ready promise once we have the text, too
+ */
+void pxTextCanvas::resourceReady(rtString readyResolution)
+{
+    rtLogDebug("pxTextCanvas::resourceReady - begin");
+    if( !readyResolution.compare("resolve"))
+    {
+        mFontLoaded = true;
+        if( mInitialized) {
+            setNeedsRecalc(true);
+            pxObject::onTextureReady();
+            if( !mParent)
+            {
+                // Send the promise here because the canvas will not get an
+                // update call until it has parent
+                recalc();
+                sendPromise();
+            }
+        }
+    }
+    else
+    {
+        mFontFailed = true;
+        pxObject::onTextureReady();
+        mReady.send("reject",this);
+    }
+    rtLogDebug("pxTextCanvas::resourceReady - end");
+}
+
+float pxTextCanvas::getFBOWidth()
+{
+    rtLogDebug("pxTextCanvas::getFBOWidth - begin.");
+    rtLogDebug("pxTextCanvas::getFBOWidth - end.");
+    return pxText::getFBOWidth();
+}
+float pxTextCanvas::getFBOHeight()
+{
+    rtLogDebug("pxTextCanvas::getFBOHeight - begin.");
+    rtLogDebug("pxTextCanvas::getFBOHeight - end.");
+    return pxText::getFBOHeight();
+}
+
+void pxTextCanvas::onInit()
+{
+    rtLogDebug("pxTextCanvas::onInit - begin.");
+    pxText::onInit();
+    rtLogInfo("pxTextCanvas::onInit. mFontLoaded=%d\n",mFontLoaded);
+    mInitialized = true;
+
+    // If this is using the default font, we would not get a callback
+    if(mFontLoaded || (getFontResource() != nullptr && getFontResource()->isFontLoaded()))
+    {
+        mFontLoaded = true;
+        setNeedsRecalc(true);
+        if (!mParent)
+        {
+            resourceReady("resolve");
+        }
+    }
+    rtLogDebug("pxTextCanvas::onInit - end.");
+}
+
+void pxTextCanvas::recalc()
+{
+    rtLogDebug("pxTextCanvas::recalc - begin.");
+
+    if( mNeedsRecalc && mInitialized && mFontLoaded) {
+        clearMeasurements();
+#ifdef PXSCENE_FONT_ATLAS
+        mQuadsVector.clear();
+#endif
+        renderText(false);
+        setNeedsRecalc(false);
+        if(clip()) {
+            pxObject::onTextureReady();
+        }
+#ifdef PXSCENE_FONT_ATLAS
+        mQuadsVector.clear();
+#endif
+        renderText(true);
+        mDirty = false;
+    }
+    rtLogDebug("pxTextCanvas::recalc - end.");
+}
+
+void pxTextCanvas::clearMeasurements()
+{
+    getMeasurements()->clear();
+}
+
+void pxTextCanvas::setNeedsRecalc(bool recalc)
+{
+    rtLogDebug("Setting mNeedsRecalc=%d\n",recalc);
+    mNeedsRecalc = recalc;
+
+    if(recalc)
+    {
+        rtLogDebug("TextCanvas CREATE NEW PROMISE\n");
+        createNewPromise();
+//        mDirty = true;
+    }
+}
+
+void pxTextCanvas::sendPromise()
+{
+    rtLogDebug("TextCanvas sendPromise - begin");
+    rtLogDebug("pxTextCanvas::sendPromise mInitialized=%d mFontLoaded=%d mNeedsRecalc=%d\n",mInitialized,mFontLoaded,mNeedsRecalc);
+    // TODO: hanlde mNeedsRecalc properly!
+    if(mInitialized && mFontLoaded /*&& !mNeedsRecalc*/ && !mDirty && !((rtPromise*)mReady.getPtr())->status())
+    {
+        rtLogDebug("pxTextCanvas SENDPROMISE\n");
+        mReady.send("resolve",this);
+
+    } else {
+        rtLogDebug("pxTextCanvas NOT sending promise");
+    }
+    rtLogDebug("TextCanvas sendPromise - end");
+}
+
+void pxTextCanvas::renderText(bool render)
+{
+    rtLogDebug("pxTextCanvas::renderText - begin.");
+    if (render && !mTextLines.empty()) {
+        for (std::vector<pxTextLine>::iterator it = mTextLines.begin() ; it != mTextLines.end(); ++it)
+            renderTextLine(*it);
+    }
+    rtLogDebug("pxTextCanvas::renderText - end.");
+}
+
+void pxTextCanvas::renderTextLine(const pxTextLine& textLine)
+{
+    rtLogDebug("pxTextCanvas::renderTextLine - begin");
+
+    const char* cStr = textLine.text.cString();
+    float xPos = textLine.x;
+    float yPos = textLine.y;
+
+    // TODO ignoring sx and sy now.
+    float sx = 1.0;
+    float sy = 1.0;
+
+    float charW = 0, charH = 0;
+    uint32_t size = textLine.pixelSize;
+    setFont(textLine.font);
+
+    // TODO: calc alignment
+    if (getFontResource() != nullptr)
+    {
+        getFontResource()->measureTextInternal(cStr, size, sx, sy, charW, charH);
+        //TODO: add clipping support here
+        mw = charW > mw ? charW : mw;
+        mh = charH > mh ? charH : mh;
+    }
+
+    // Now, render the text
+    if( getFontResource() != nullptr)
+    {
+#ifdef PXSCENE_FONT_ATLAS
+        pxTexturedQuads quads;
+        getFontResource()->renderTextToQuads(cStr, size, sx, sy, quads, roundf(xPos), roundf(yPos));
+        quads.setColor(textLine.color);
+        mQuadsVector.push_back(quads);
+#else
+        //getFontResource()->renderText(cStr, size, xPos, tempY, sx, sy, mTextColor,lineWidth);
+        rtLogError("pxTextCanvas::drawing without FONT ATLAS is not supported yet.");
+#endif
+    }
+    rtLogDebug("pxTextCanvas::renderTextLine - end");
+}
+
+void pxTextCanvas::draw()
+{
+    rtLogDebug("pxTextCanvas::draw - begin.");
+#ifdef PXSCENE_FONT_ATLAS
+    if (mDirty)
+    {
+        mQuadsVector.clear();
+        renderText(true);
+        mDirty = false;
+    }
+    float x = 0, y = 0;
+    for (std::vector<pxTexturedQuads>::iterator it = mQuadsVector.begin() ; it != mQuadsVector.end(); ++it)
+        (*it).draw(x, y);
+#else
+    rtLogError("pxTextCanvas::drawing without FONT ATLAS is not supported yet.");
+#endif
+    rtLogDebug("pxTextCanvas::draw - end.");
+}
+
+float pxTextCanvas::getOnscreenWidth()
+{
+    // TODO review max texture handling
+    return this->w();
+}
+
+float pxTextCanvas::getOnscreenHeight()
+{
+    // TODO review max texture handling
+    return this->h();
+}
+
+void pxTextCanvas::update(double t, bool updateChildren)
+{
+    rtLogDebug("pxTextCanvas::update - begin.");
+    if( mNeedsRecalc ) {
+        recalc();
+        markDirty();
+    }
+    pxText::update(t, updateChildren);
+    rtLogDebug("pxTextCanvas::update - end.");
+}
+
+rtError pxTextCanvas::measureText(rtString text, rtObjectRef& o)
+{
+    rtLogDebug("pxTextCanvas::measureText - begin.");
+    rtLogInfo("pxTextCanvas::measureText() mNeedsRecalc is %d text: %s", mNeedsRecalc, text.cString());
+    rtObjectRef tcm = new pxTextCanvasMeasurements(); // TODO: aren't we leaking here with 'new'? Is it efficient?
+    o = tcm;
+    if(getFontResource() != nullptr) {
+        rtObjectRef sm; // pxTextSimpleMeasurements
+        getFontResource()->measureText(mPixelSize, text, sm);
+        ((pxTextCanvasMeasurements*)tcm.getPtr())->fromSimpleMeasurements(sm);
+
+        rtLogInfo("pxTextCanvas::measureText(). Got measurements; width: %d, height: %d "
+                , ((pxTextCanvasMeasurements*)tcm.getPtr())->width()
+                , ((pxTextCanvasMeasurements*)tcm.getPtr())->h()
+                );
+
+    } else {
+        rtLogWarn("measureText called TOO EARLY -- not initialized or font not loaded!\n");
+        //return RT_OK; // !CLF: TO DO - COULD RETURN RT_ERROR HERE TO CATCH NOT WAITING ON PROMISE
+    }
+    rtLogDebug("pxTextCanvas::measureText - end.");
+    return RT_OK;
+}
+
+rtError pxTextCanvas::fillText(rtString text, uint32_t x, uint32_t y)
+{
+    rtLogDebug("pxTextCanvas::fillText - begin.");
+    rtLogInfo("pxTextCanvas::fillText called with params: text: %s, x %d, y %d", text.cString(), x, y);
+    pxTextLine textLine(text, x, y);
+    uint32_t color;
+    textColorInternal(color);
+    textLine.setStyle(mFont, mPixelSize, color);
+    mTextLines.push_back(textLine);
+    setNeedsRecalc(true);
+    rtLogDebug("pxTextCanvas::fillText - end.");
+    return RT_OK;
+}
+
+rtError pxTextCanvas::clear()
+{
+    rtLogDebug("pxTextCanvas::clear - begin.");
+    mTextLines.clear();
+    mw = 0;
+    mh = 0;
+    setNeedsRecalc(true);
+    rtLogDebug("pxTextCanvas::clear - end.");
+
+    return RT_OK;
+}
+
+rtError pxTextCanvas::fillRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height)
+{
+    UNUSED_PARAM(x);
+    UNUSED_PARAM(y);
+    UNUSED_PARAM(width);
+    UNUSED_PARAM(height);
+    rtLogInfo("pxTextCanvas::fillRect called with params: x %d, y %d, width %d, height %d", x, y, width, height);
+    rtLogError("pxTextCanvas::fillRect. NOT IMPLEMENTED. Call ignored.");
+    return RT_OK;
+}
+
+rtError pxTextCanvas::translate(uint32_t x, uint32_t y)
+{
+    UNUSED_PARAM(x);
+    UNUSED_PARAM(y);
+    rtLogInfo("pxTextCanvas::translate called with params: x %d, y %d", x, y);
+    rtLogError("pxTextCanvas::translate. NOT IMPLEMENTED. Call ignored.");
+    return RT_OK;
+}
+
+// pxTextCanvasMeasurements
+rtDefineObject(pxTextCanvasMeasurements, rtObject);
+rtDefineProperty(pxTextCanvasMeasurements, width);
+
+// pxTextCanvas
+rtDefineObject(pxTextCanvas, pxText);
+rtDefineProperty(pxTextCanvas, alignHorizontal);
+rtDefineProperty(pxTextCanvas, fillStyle);
+rtDefineProperty(pxTextCanvas, textBaseline);
+rtDefineProperty(pxTextCanvas, globalAlpha);
+rtDefineProperty(pxTextCanvas, shadowColor);
+rtDefineProperty(pxTextCanvas, shadowBlur);
+rtDefineProperty(pxTextCanvas, shadowOffsetX);
+rtDefineProperty(pxTextCanvas, shadowOffsetY);
+
+rtDefineMethod(pxTextCanvas, measureText);
+rtDefineMethod(pxTextCanvas, fillText);
+rtDefineMethod(pxTextCanvas, clear);
+rtDefineMethod(pxTextCanvas, fillRect);
+rtDefineMethod(pxTextCanvas, translate);

--- a/examples/pxScene2d/src/pxTextCanvas.cpp
+++ b/examples/pxScene2d/src/pxTextCanvas.cpp
@@ -110,7 +110,9 @@ rtError pxTextCanvas::fillStyle(rtValue &c) const
 rtError pxTextCanvas::setFillStyle(rtValue c)
 {
     rtLogInfo("pxTextCanvas::setFillStyle. Called with param: %#08x", c.toUInt32());
-    setTextColor(c);
+    rtValue clr(argb2rgba(c.toUInt32()));
+    rtLogInfo("pxTextCanvas::setFillStyle. Converted to: %#08x", clr.toUInt32());
+    setTextColor(clr);
     return RT_OK;
 }
 rtError pxTextCanvas::textBaseline(rtString &b) const
@@ -155,13 +157,13 @@ rtError pxTextCanvas::setShadowColor(const uint32_t c)
     return RT_OK;
 }
 
-rtError pxTextCanvas::shadowBlur(uint8_t& b) const
+rtError pxTextCanvas::shadowBlur(uint32_t& b) const
 {
-    b = mShadowColor;
+    b = mShadowBlur;
     return RT_OK;
 }
 
-rtError pxTextCanvas::setShadowBlur(const uint8_t b)
+rtError pxTextCanvas::setShadowBlur(const uint32_t b)
 {
     rtLogInfo("pxTextCanvas::setShadowBlur. Called with param: %d", b);
     rtLogError("pxTextCanvas::setShadowBlur. NOT IMPLEMENTED. Call ignored.");
@@ -445,6 +447,12 @@ rtError pxTextCanvas::translate(uint32_t x, uint32_t y)
     rtLogError("pxTextCanvas::translate. NOT IMPLEMENTED. Call ignored.");
     return RT_OK;
 }
+
+uint32_t pxTextCanvas::argb2rgba(uint32_t val)
+{
+    return val << 8 | val >> 24;
+}
+
 
 // pxTextCanvasMeasurements
 rtDefineObject(pxTextCanvasMeasurements, rtObject);

--- a/examples/pxScene2d/src/pxTextCanvas.cpp
+++ b/examples/pxScene2d/src/pxTextCanvas.cpp
@@ -52,6 +52,7 @@ pxTextCanvas::pxTextCanvas(pxScene2d* s): pxText(s)
     mFontLoaded = false;
     mFontFailed = false;
     mTextBaseline = "alphabetic"; //TODO: make a const class from it?
+	mLabel = "";
     rtLogDebug("pxTextCanvas::ctor - end");
 }
 /** This signals that the font file loaded successfully; now we need to
@@ -199,6 +200,16 @@ rtError pxTextCanvas::setShadowOffsetY(const float o)
     return RT_OK;
 }
 
+rtError pxTextCanvas::label(rtString &c) const
+{
+    c = mLabel;
+    return RT_OK;
+}
+rtError pxTextCanvas::setLabel(const rtString &c)
+{
+    mLabel = c;
+    return RT_OK;
+}
 float pxTextCanvas::getFBOWidth()
 {
     return pxText::getFBOWidth();
@@ -468,6 +479,7 @@ rtDefineProperty(pxTextCanvas, shadowColor);
 rtDefineProperty(pxTextCanvas, shadowBlur);
 rtDefineProperty(pxTextCanvas, shadowOffsetX);
 rtDefineProperty(pxTextCanvas, shadowOffsetY);
+rtDefineProperty(pxTextCanvas, label);
 
 rtDefineMethod(pxTextCanvas, measureText);
 rtDefineMethod(pxTextCanvas, fillText);

--- a/examples/pxScene2d/src/pxTextCanvas.h
+++ b/examples/pxScene2d/src/pxTextCanvas.h
@@ -87,7 +87,7 @@ public:
     rtProperty(textBaseline, textBaseline, setTextBaseline, rtString);
     rtProperty(globalAlpha, globalAlpha, setGlobalAlpha, float);
     rtProperty(shadowColor, shadowColor, setShadowColor, uint32_t);
-    rtProperty(shadowBlur, shadowBlur, setShadowBlur, uint8_t);
+    rtProperty(shadowBlur, shadowBlur, setShadowBlur, uint32_t);
     rtProperty(shadowOffsetX, shadowOffsetX, setShadowOffsetX, float);
     rtProperty(shadowOffsetY, shadowOffsetY, setShadowOffsetY, float);
 
@@ -102,8 +102,8 @@ public:
     rtError setGlobalAlpha(const float a);
     rtError shadowColor(uint32_t& c) const;
     rtError setShadowColor(const uint32_t c);
-    rtError shadowBlur(uint8_t& b) const;
-    rtError setShadowBlur(const uint8_t b);
+    rtError shadowBlur(uint32_t& b) const;
+    rtError setShadowBlur(const uint32_t b);
     rtError shadowOffsetX(float& o) const;
     rtError setShadowOffsetX(const float o);
     rtError shadowOffsetY(float& o) const;
@@ -149,6 +149,7 @@ protected:
     pxTextCanvasMeasurements* getMeasurements() { return (pxTextCanvasMeasurements*)measurements.getPtr();}
     void recalc();
     void clearMeasurements();
+    static uint32_t argb2rgba(uint32_t val);
 
     bool mInitialized;
     bool mNeedsRecalc;
@@ -156,7 +157,7 @@ protected:
     rtString mTextBaseline;
     float mGlobalAlpha;
     uint32_t mShadowColor;
-    uint8_t  mShadowBlur;
+    uint32_t  mShadowBlur;
     float mShadowOffsetX;
     float mShadowOffsetY;
 

--- a/examples/pxScene2d/src/pxTextCanvas.h
+++ b/examples/pxScene2d/src/pxTextCanvas.h
@@ -28,24 +28,8 @@ struct pxTextLine
             , pixelSize(10)
             , color(0xFFFFFFFF)
     {};
-
-    pxTextLine(const char* text, uint32_t x, uint32_t y)
-            : pixelSize(10)
-            , color(0xFFFFFFFF)
-    {
-        this->text = text;
-        this->x = x;
-        this->y = y;
-        this->styleSet = false;
-    };
-
-    void setStyle(const rtObjectRef& f, uint32_t ps, uint32_t c) {
-        // TODO: validate pxFont object
-        this->font = f;
-        this->pixelSize = ps;
-        this->color = c;
-        this->styleSet = true;
-    }
+    pxTextLine(const char* text, uint32_t x, uint32_t y);
+    void setStyle(const rtObjectRef& f, uint32_t ps, uint32_t c);
 
     bool styleSet;
     rtString text;
@@ -66,10 +50,7 @@ class pxTextCanvasMeasurements: public rtObject
 {
 public:
     pxTextCanvasMeasurements():mw(0), mh(0) {}
-    pxTextCanvasMeasurements(rtObjectRef sm)
-    {
-        fromSimpleMeasurements(sm);
-    }
+    pxTextCanvasMeasurements(rtObjectRef sm);
     virtual ~pxTextCanvasMeasurements() {}
 
     rtDeclareObject(pxTextCanvasMeasurements, rtObject);
@@ -77,19 +58,12 @@ public:
 
     int32_t width() const { return mw;  }
     rtError width(int32_t& v) const { v = mw;  return RT_OK; }
-
     int32_t w() const { return mw;  }
     int32_t h() const { return mh; }
-
     void setW(int32_t v) { mw = v;}
     void setH(int32_t v) { mh = v; }
-
     void clear() { mw = 0; mh = 0;}
-
-    void fromSimpleMeasurements(rtObjectRef sm) {
-        pxTextSimpleMeasurements* pSm = ((pxTextSimpleMeasurements*)sm.getPtr());
-        mw = pSm->w(); mh = pSm->h();
-    }
+    void fromSimpleMeasurements(rtObjectRef sm);
 
 protected:
     int32_t mw;
@@ -117,108 +91,27 @@ public:
     rtProperty(shadowOffsetX, shadowOffsetX, setShadowOffsetX, float);
     rtProperty(shadowOffsetY, shadowOffsetY, setShadowOffsetY, float);
 
-    uint32_t alignHorizontal()              const { return mAlignHorizontal;}
-    rtError alignHorizontal(uint32_t& v)    const { v = mAlignHorizontal; return RT_OK;}
-    rtError setAlignHorizontal(uint32_t v)        { mAlignHorizontal = v;  setNeedsRecalc(true); return RT_OK;}
-
-    rtError fillStyle(rtValue &c) const
-    {
-        return textColor(c);
-    }
-
-    rtError setFillStyle(rtValue c)
-    {
-        rtLogInfo("pxTextCanvas::setFillStyle. Called with param: %#08x", c.toUInt32());
-        setTextColor(c);
-        return RT_OK;
-    }
-    rtError textBaseline(rtString &b) const
-    {
-        b = mTextBaseline;
-        return RT_OK;
-    }
-
-    rtError setTextBaseline(const rtString& c)
-    {
-        rtLogInfo("pxTextCanvas::setTextBaseline called with param: %s", c.cString());
-        rtLogError("pxTextCanvas::setTextBaseline. NOT IMPLEMENTED. Call ignored.");
-        mTextBaseline = c;
-        return RT_OK;
-    }
-
-    rtError globalAlpha(float& a) const
-    {
-        a = mGlobalAlpha;
-        return RT_OK;
-    }
-
-    rtError setGlobalAlpha(const float a)
-    {
-        rtLogInfo("pxTextCanvas::setGlobalAlpha called with param: %f", a);
-        rtLogError("pxTextCanvas::setGlobalAlpha. NOT IMPLEMENTED. Call ignored.");
-        mGlobalAlpha = a;
-        return RT_OK;
-    }
-
-    rtError shadowColor(uint32_t& c) const
-    {
-        c = mShadowColor;
-        return RT_OK;
-    }
-
-    rtError setShadowColor(const uint32_t c)
-    {
-        rtLogInfo("pxTextCanvas::setShadowColor. Called with param: %#08x", c);
-        rtLogError("pxTextCanvas::setShadowColor. NOT IMPLEMENTED. Call ignored.");
-        mShadowColor = c;
-        return RT_OK;
-    }
-
-    rtError shadowBlur(uint8_t& b) const
-    {
-        b = mShadowColor;
-        return RT_OK;
-    }
-
-    rtError setShadowBlur(const uint8_t b)
-    {
-        rtLogInfo("pxTextCanvas::setShadowBlur. Called with param: %d", b);
-        rtLogError("pxTextCanvas::setShadowBlur. NOT IMPLEMENTED. Call ignored.");
-        mShadowBlur = b;
-        return RT_OK;
-    }
-
-    rtError shadowOffsetX(float& o) const
-    {
-        o = mShadowOffsetX;
-        return RT_OK;
-    }
-
-    rtError setShadowOffsetX(const float o)
-    {
-        rtLogInfo("pxTextCanvas::setShadowOffsetX called with param: %f", o);
-        rtLogError("pxTextCanvas::setShadowOffsetX. NOT IMPLEMENTED. Call ignored.");
-        mShadowOffsetX = o;
-        return RT_OK;
-    }
-
-    rtError shadowOffsetY(float& o) const
-    {
-        o = mShadowOffsetY;
-        return RT_OK;
-    }
-
-    rtError setShadowOffsetY(const float o)
-    {
-        rtLogInfo("pxTextCanvas::setShadowOffsetY called with param: %f", o);
-        rtLogError("pxTextCanvas::setShadowOffsetY. NOT IMPLEMENTED. Call ignored.");
-        mShadowOffsetY = o;
-        return RT_OK;
-    }
+    uint32_t alignHorizontal() const;
+    rtError alignHorizontal(uint32_t& v) const;
+    rtError setAlignHorizontal(uint32_t v);
+    rtError fillStyle(rtValue &c) const;
+    rtError setFillStyle(rtValue c);
+    rtError textBaseline(rtString &b) const;
+    rtError setTextBaseline(const rtString& c);
+    rtError globalAlpha(float& a) const;
+    rtError setGlobalAlpha(const float a);
+    rtError shadowColor(uint32_t& c) const;
+    rtError setShadowColor(const uint32_t c);
+    rtError shadowBlur(uint8_t& b) const;
+    rtError setShadowBlur(const uint8_t b);
+    rtError shadowOffsetX(float& o) const;
+    rtError setShadowOffsetX(const float o);
+    rtError shadowOffsetY(float& o) const;
+    rtError setShadowOffsetY(const float o);
 
     /* override virtuals from pxObject that must affect the readiness of pxTextCanvas due to text measurements */
-    rtError setW(float v) override      { rtLogInfo("pxTextCanvas::setW: %f", v); setNeedsRecalc(true); return pxObject::setW(v);}
-    rtError setH(float v) override      { rtLogInfo("pxTextCanvas::setH: %f", v); setNeedsRecalc(true); return pxObject::setH(v);}
+    rtError setW(float v) override      { setNeedsRecalc(true); return pxObject::setW(v);}
+    rtError setH(float v) override      { setNeedsRecalc(true); return pxObject::setH(v);}
     rtError setClip(bool v) override    { setNeedsRecalc(true); return pxObject::setClip(v);}
     rtError setSX(float v) override     { setNeedsRecalc(true); return pxObject::setSX(v);}
     rtError setSY(float v) override     { setNeedsRecalc(true); return pxObject::setSY(v);}

--- a/examples/pxScene2d/src/pxTextCanvas.h
+++ b/examples/pxScene2d/src/pxTextCanvas.h
@@ -1,0 +1,280 @@
+/*
+
+ pxCore Copyright 2005-2019 John Robinson
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+#ifndef PX_TEXTCANVAS_H
+#define PX_TEXTCANVAS_H
+
+#include "pxScene2d.h"
+#include "pxText.h"
+struct pxTextLine
+{
+    pxTextLine(): styleSet(false)
+            , x(0), y(0)
+            , pixelSize(10)
+            , color(0xFFFFFFFF)
+    {};
+
+    pxTextLine(const char* text, uint32_t x, uint32_t y)
+            : pixelSize(10)
+            , color(0xFFFFFFFF)
+    {
+        this->text = text;
+        this->x = x;
+        this->y = y;
+        this->styleSet = false;
+    };
+
+    void setStyle(const rtObjectRef& f, uint32_t ps, uint32_t c) {
+        // TODO: validate pxFont object
+        this->font = f;
+        this->pixelSize = ps;
+        this->color = c;
+        this->styleSet = true;
+    }
+
+    bool styleSet;
+    rtString text;
+    uint32_t x;
+    uint32_t y;
+    // current style settings
+    rtObjectRef font;
+    uint32_t pixelSize;
+    uint32_t color;
+};
+
+/**********************************************************************
+ *
+ * pxTextCanvasMeasurements (used in javascript measureText() call)
+ *
+ **********************************************************************/
+class pxTextCanvasMeasurements: public rtObject
+{
+public:
+    pxTextCanvasMeasurements():mw(0), mh(0) {}
+    pxTextCanvasMeasurements(rtObjectRef sm)
+    {
+        fromSimpleMeasurements(sm);
+    }
+    virtual ~pxTextCanvasMeasurements() {}
+
+    rtDeclareObject(pxTextCanvasMeasurements, rtObject);
+    rtReadOnlyProperty(width, width, int32_t);
+
+    int32_t width() const { return mw;  }
+    rtError width(int32_t& v) const { v = mw;  return RT_OK; }
+
+    int32_t w() const { return mw;  }
+    int32_t h() const { return mh; }
+
+    void setW(int32_t v) { mw = v;}
+    void setH(int32_t v) { mh = v; }
+
+    void clear() { mw = 0; mh = 0;}
+
+    void fromSimpleMeasurements(rtObjectRef sm) {
+        pxTextSimpleMeasurements* pSm = ((pxTextSimpleMeasurements*)sm.getPtr());
+        mw = pSm->w(); mh = pSm->h();
+    }
+
+protected:
+    int32_t mw;
+    int32_t mh;
+};
+
+/**********************************************************************
+ *
+ * pxTextCanvas
+ *
+ **********************************************************************/
+class pxTextCanvas : public pxText {
+public:
+    rtDeclareObject(pxTextCanvas, pxText);
+
+    pxTextCanvas(pxScene2d *s);
+    virtual ~pxTextCanvas() {}
+
+    rtProperty(alignHorizontal, alignHorizontal, setAlignHorizontal, uint32_t);
+    rtProperty(fillStyle, fillStyle, setFillStyle, rtValue);
+    rtProperty(textBaseline, textBaseline, setTextBaseline, rtString);
+    rtProperty(globalAlpha, globalAlpha, setGlobalAlpha, float);
+    rtProperty(shadowColor, shadowColor, setShadowColor, uint32_t);
+    rtProperty(shadowBlur, shadowBlur, setShadowBlur, uint8_t);
+    rtProperty(shadowOffsetX, shadowOffsetX, setShadowOffsetX, float);
+    rtProperty(shadowOffsetY, shadowOffsetY, setShadowOffsetY, float);
+
+    uint32_t alignHorizontal()              const { return mAlignHorizontal;}
+    rtError alignHorizontal(uint32_t& v)    const { v = mAlignHorizontal; return RT_OK;}
+    rtError setAlignHorizontal(uint32_t v)        { mAlignHorizontal = v;  setNeedsRecalc(true); return RT_OK;}
+
+    rtError fillStyle(rtValue &c) const
+    {
+        return textColor(c);
+    }
+
+    rtError setFillStyle(rtValue c)
+    {
+        rtLogInfo("pxTextCanvas::setFillStyle. Called with param: %#08x", c.toUInt32());
+        setTextColor(c);
+        return RT_OK;
+    }
+    rtError textBaseline(rtString &b) const
+    {
+        b = mTextBaseline;
+        return RT_OK;
+    }
+
+    rtError setTextBaseline(const rtString& c)
+    {
+        rtLogInfo("pxTextCanvas::setTextBaseline called with param: %s", c.cString());
+        rtLogError("pxTextCanvas::setTextBaseline. NOT IMPLEMENTED. Call ignored.");
+        mTextBaseline = c;
+        return RT_OK;
+    }
+
+    rtError globalAlpha(float& a) const
+    {
+        a = mGlobalAlpha;
+        return RT_OK;
+    }
+
+    rtError setGlobalAlpha(const float a)
+    {
+        rtLogInfo("pxTextCanvas::setGlobalAlpha called with param: %f", a);
+        rtLogError("pxTextCanvas::setGlobalAlpha. NOT IMPLEMENTED. Call ignored.");
+        mGlobalAlpha = a;
+        return RT_OK;
+    }
+
+    rtError shadowColor(uint32_t& c) const
+    {
+        c = mShadowColor;
+        return RT_OK;
+    }
+
+    rtError setShadowColor(const uint32_t c)
+    {
+        rtLogInfo("pxTextCanvas::setShadowColor. Called with param: %#08x", c);
+        rtLogError("pxTextCanvas::setShadowColor. NOT IMPLEMENTED. Call ignored.");
+        mShadowColor = c;
+        return RT_OK;
+    }
+
+    rtError shadowBlur(uint8_t& b) const
+    {
+        b = mShadowColor;
+        return RT_OK;
+    }
+
+    rtError setShadowBlur(const uint8_t b)
+    {
+        rtLogInfo("pxTextCanvas::setShadowBlur. Called with param: %d", b);
+        rtLogError("pxTextCanvas::setShadowBlur. NOT IMPLEMENTED. Call ignored.");
+        mShadowBlur = b;
+        return RT_OK;
+    }
+
+    rtError shadowOffsetX(float& o) const
+    {
+        o = mShadowOffsetX;
+        return RT_OK;
+    }
+
+    rtError setShadowOffsetX(const float o)
+    {
+        rtLogInfo("pxTextCanvas::setShadowOffsetX called with param: %f", o);
+        rtLogError("pxTextCanvas::setShadowOffsetX. NOT IMPLEMENTED. Call ignored.");
+        mShadowOffsetX = o;
+        return RT_OK;
+    }
+
+    rtError shadowOffsetY(float& o) const
+    {
+        o = mShadowOffsetY;
+        return RT_OK;
+    }
+
+    rtError setShadowOffsetY(const float o)
+    {
+        rtLogInfo("pxTextCanvas::setShadowOffsetY called with param: %f", o);
+        rtLogError("pxTextCanvas::setShadowOffsetY. NOT IMPLEMENTED. Call ignored.");
+        mShadowOffsetY = o;
+        return RT_OK;
+    }
+
+    /* override virtuals from pxObject that must affect the readiness of pxTextCanvas due to text measurements */
+    rtError setW(float v) override      { rtLogInfo("pxTextCanvas::setW: %f", v); setNeedsRecalc(true); return pxObject::setW(v);}
+    rtError setH(float v) override      { rtLogInfo("pxTextCanvas::setH: %f", v); setNeedsRecalc(true); return pxObject::setH(v);}
+    rtError setClip(bool v) override    { setNeedsRecalc(true); return pxObject::setClip(v);}
+    rtError setSX(float v) override     { setNeedsRecalc(true); return pxObject::setSX(v);}
+    rtError setSY(float v) override     { setNeedsRecalc(true); return pxObject::setSY(v);}
+
+    void renderText(bool render);
+    void setNeedsRecalc(bool recalc);
+    virtual float getFBOWidth();
+    virtual float getFBOHeight();
+
+    virtual void resourceReady(rtString readyResolution);
+    virtual void sendPromise();
+    virtual void draw();
+    virtual void onInit();
+    virtual void update(double t, bool updateChildren = true);
+
+    virtual float getOnscreenWidth();
+    virtual float getOnscreenHeight();
+
+    rtMethod1ArgAndReturn("measureText", measureText, rtString, rtObjectRef);
+    rtError measureText(rtString text, rtObjectRef &o);
+
+    rtMethod3ArgAndNoReturn("fillText", fillText, rtString, uint32_t, uint32_t);
+    rtError fillText(rtString text, uint32_t x, uint32_t y);
+
+    rtMethodNoArgAndNoReturn("clear", clear);
+    rtError clear();
+
+    rtMethod4ArgAndNoReturn("fillRect", fillRect, uint32_t, uint32_t, uint32_t, uint32_t);
+    rtError fillRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
+
+    rtMethod2ArgAndNoReturn("translate", translate, uint32_t, uint32_t);
+    rtError translate(uint32_t x, uint32_t y);
+
+protected:
+    pxTextCanvasMeasurements* getMeasurements() { return (pxTextCanvasMeasurements*)measurements.getPtr();}
+    void recalc();
+    void clearMeasurements();
+
+    bool mInitialized;
+    bool mNeedsRecalc;
+    uint32_t mAlignHorizontal;
+    rtString mTextBaseline;
+    float mGlobalAlpha;
+    uint32_t mShadowColor;
+    uint8_t  mShadowBlur;
+    float mShadowOffsetX;
+    float mShadowOffsetY;
+
+    std::vector<pxTextLine> mTextLines;
+
+#ifdef PXSCENE_FONT_ATLAS
+    std::vector<pxTexturedQuads> mQuadsVector;
+#endif
+    rtObjectRef measurements;
+
+    void renderTextLine(const pxTextLine& textLine);
+};
+
+#endif

--- a/examples/pxScene2d/src/pxTextCanvas.h
+++ b/examples/pxScene2d/src/pxTextCanvas.h
@@ -90,6 +90,7 @@ public:
     rtProperty(shadowBlur, shadowBlur, setShadowBlur, uint32_t);
     rtProperty(shadowOffsetX, shadowOffsetX, setShadowOffsetX, float);
     rtProperty(shadowOffsetY, shadowOffsetY, setShadowOffsetY, float);
+    rtProperty(label, label, setLabel, rtString);
 
     uint32_t alignHorizontal() const;
     rtError alignHorizontal(uint32_t& v) const;
@@ -108,6 +109,8 @@ public:
     rtError setShadowOffsetX(const float o);
     rtError shadowOffsetY(float& o) const;
     rtError setShadowOffsetY(const float o);
+    rtError label(rtString &c) const;
+    rtError setLabel(const rtString &c);
 
     /* override virtuals from pxObject that must affect the readiness of pxTextCanvas due to text measurements */
     rtError setW(float v) override      { setNeedsRecalc(true); return pxObject::setW(v);}
@@ -160,6 +163,7 @@ protected:
     uint32_t  mShadowBlur;
     float mShadowOffsetX;
     float mShadowOffsetY;
+    rtString mLabel;
 
     std::vector<pxTextLine> mTextLines;
 

--- a/examples/pxScene2d/src/pxTextCanvas.h
+++ b/examples/pxScene2d/src/pxTextCanvas.h
@@ -86,11 +86,13 @@ public:
     rtProperty(fillStyle, fillStyle, setFillStyle, rtValue);
     rtProperty(textBaseline, textBaseline, setTextBaseline, rtString);
     rtProperty(globalAlpha, globalAlpha, setGlobalAlpha, float);
-    rtProperty(shadowColor, shadowColor, setShadowColor, uint32_t);
-    rtProperty(shadowBlur, shadowBlur, setShadowBlur, uint32_t);
-    rtProperty(shadowOffsetX, shadowOffsetX, setShadowOffsetX, float);
-    rtProperty(shadowOffsetY, shadowOffsetY, setShadowOffsetY, float);
-    rtProperty(label, label, setLabel, rtString);
+    rtProperty(width, w, setW, float);
+    rtProperty(height, h, setH, float);
+    // specific to pxTextCanvas
+    rtProperty(label, label, setLabel, rtString);   // mainly for debug logging when multiple canvases are created (default behaviour)
+                                                    // Lightning++ assigns the timestamp, initially
+    rtProperty(colorMode, colorMode, setColorMode, rtString); // Lightning++ assigns 'ARGB' for color compatibility
+
 
     uint32_t alignHorizontal() const;
     rtError alignHorizontal(uint32_t& v) const;
@@ -101,20 +103,14 @@ public:
     rtError setTextBaseline(const rtString& c);
     rtError globalAlpha(float& a) const;
     rtError setGlobalAlpha(const float a);
-    rtError shadowColor(uint32_t& c) const;
-    rtError setShadowColor(const uint32_t c);
-    rtError shadowBlur(uint32_t& b) const;
-    rtError setShadowBlur(const uint32_t b);
-    rtError shadowOffsetX(float& o) const;
-    rtError setShadowOffsetX(const float o);
-    rtError shadowOffsetY(float& o) const;
-    rtError setShadowOffsetY(const float o);
     rtError label(rtString &c) const;
     rtError setLabel(const rtString &c);
+    rtError colorMode(rtString &c) const;
+    rtError setColorMode(const rtString &c);
 
     /* override virtuals from pxObject that must affect the readiness of pxTextCanvas due to text measurements */
-    rtError setW(float v) override      { setNeedsRecalc(true); return pxObject::setW(v);}
-    rtError setH(float v) override      { setNeedsRecalc(true); return pxObject::setH(v);}
+    rtError setW(float v) override      { setNeedsRecalc(true); rtLogDebug("pxTextCanvas::width set to %4.0f ('%s')", v, mLabel.cString()); return pxObject::setW(v);}
+    rtError setH(float v) override      { setNeedsRecalc(true); rtLogDebug("pxTextCanvas::height set to %4.0f ('%s')", v, mLabel.cString());return pxObject::setH(v);}
     rtError setClip(bool v) override    { setNeedsRecalc(true); return pxObject::setClip(v);}
     rtError setSX(float v) override     { setNeedsRecalc(true); return pxObject::setSX(v);}
     rtError setSY(float v) override     { setNeedsRecalc(true); return pxObject::setSY(v);}
@@ -159,11 +155,10 @@ protected:
     uint32_t mAlignHorizontal;
     rtString mTextBaseline;
     float mGlobalAlpha;
-    uint32_t mShadowColor;
-    uint32_t  mShadowBlur;
-    float mShadowOffsetX;
-    float mShadowOffsetY;
     rtString mLabel;
+    rtString mColorMode;
+    uint32_t mTranslateX;
+    uint32_t mTranslateY;
 
     std::vector<pxTextLine> mTextLines;
 

--- a/tests/pxScene2d/test_pxTextCanvas.js
+++ b/tests/pxScene2d/test_pxTextCanvas.js
@@ -1,0 +1,364 @@
+/**
+ * Spark application
+ * author: sgladk001c
+ *
+ * This test will ensure that pxTextCanvas is behaving as expected
+ */
+
+"use strict";
+px.configImport({"px.local:": px.getPackageBaseFilePath()+"/"});
+
+px.import({
+    scene:  "px:scene.1.js"
+    , assert: "./test-run/assert.js"
+    , manual: "./test-run/tools_manualTests.js"
+}).then( function ready(imports) {
+
+    let sparkscene = imports.scene;
+    let assert = imports.assert.assert;
+    let manual = imports.manual;
+
+    let manualTest = manual.getManualTestValue();
+    let parent = sparkscene.root;
+    let promises = [];
+
+    // Can be replaced with the standard logger, consider including 'px:tools.../Logger.js'
+    let Logger = function(enabled = false) {
+        this.enabled = enabled;
+        this.enable = () => { this.enabled = true; };
+        this.diable = () => { this.enabled = false; };
+        this.message = function () {if (this.enabled) { console.log.apply(this, arguments); }};
+    };
+    let logger = new Logger(true);
+
+    //let fontUrlBase = "http://sparkui.org/examples/fonts/";
+    // local:
+    let fontUrlBase = "/Users/silver/developer/spark/simple-lightning-spark-apps/v0.simpleImage/static/fonts/";
+    let IndieFlower = "IndieFlower.ttf";
+    let DejaVu = "DejaVuSans.ttf";
+
+    let fontUrl = fontUrlBase + IndieFlower;
+    let fontUrl2 = fontUrlBase + DejaVu;
+    let fontResource = sparkscene.create({t:"fontResource", url: fontUrl});
+    let fontResource2 = sparkscene.create({t:"fontResource", url: fontUrl2});
+
+    let w = 300;
+    let h = 300;
+    // let x = 100;
+    // let y = 0;
+    let canvas;
+
+    promises.push(fontResource.ready);
+    promises.push(fontResource2.ready);
+
+    // beforeStart will verify that we have correct resolutions for the fontResources that were preloaded
+    // as well as for the canvas scene we're going to test
+    let beforeStart = function () {
+        return new Promise(function (resolve, reject) {
+            let results = [];
+            let message;
+            Promise.all(promises).then(function () {
+                message = 'promise resolved for the fonts';
+                results.push(assert(true, message));
+            }, function () {
+                message = 'Not expected rejection received for the fonts';
+                results.push(assert(false, message));
+                reject(results);
+            }).then(function () {
+                canvas = sparkscene.create({
+                    t: "textCanvas"
+                    , w: w
+                    , h: h
+                    , parent: parent
+                    , text: "Bitter sweet"
+                    , font: fontResource
+                });
+                return canvas.ready.then(
+                    () => {
+                        message = 'promise resolved for the textCanvas scene';
+                        results.push(assert(true, message));
+                    },
+                    () => {
+                        message = 'Not expected rejection received the textCanvas scene';
+                        results.push(assert(false, message));
+                        reject(results);
+                    });
+            }).then(function () {
+                resolve(results);
+            });
+        });
+    };
+
+    ///////////////////////
+    // Test functions begin
+
+    let fillStyle = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.fillStyle = 0xFF6600FF;
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let fillText = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.fillText('Hello, world', 0, 0);
+            //canvas.clear();
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let textBaseline = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.textBaseline = 'hanging';
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let globalAlpha = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.globalAlpha = 1.0;
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let shadowColor = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.shadowColor = 0xFF6600FF;
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let shadowBlur = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.shadowBlur = 5;
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let shadowOffsetX = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.shadowOffsetX = 1.5;
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let shadowOffsetY = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.shadowOffsetY = 1.6;
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let measureText = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            let text = 'I need to measure this';
+            let measure = canvas.measureText(text);
+            logger.message('Width of "' + text + '" is ' + measure.width);
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let clear = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            logger.message("Canvas", canvas);
+            canvas.fillStyle = 0xFFFFFFFF;
+            canvas.clear();
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let fillRect = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.fillRect(0, 0, 10, 10);
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    let translate = function(params) {
+        return new Promise(function(resolve, reject) {
+            var results = [];
+            logger.message("Executing", params.name, params.description);
+            canvas.translate(10, 10);
+            canvas.ready.then(function() {
+                results.push(assert(true, params.name + ": expected and received resolution"));
+                resolve(results);
+            }, function() {
+                results.push(assert(false, params.name + ": expected resolution but received rejection"));
+                reject(results);
+            }).then(function() {
+                resolve(results);
+            });
+        });
+    };
+
+    // Test functions end
+    //////////////////////////
+
+    // Function executor with timeout
+    let timeout = 1000; //msecs
+    let exec = function (params) {
+        return new Promise(function (resolve, reject) {
+            let results = [];
+            let message;
+
+            let timer = setTimeout(function () {
+                message = params.name + ' never got promise!';
+                logger.message('debug', message);
+                results.push(assert(false, message));
+                reject(results);
+            }, timeout);
+
+            params.func(params).then(function (res) {
+                results.push(res);
+                clearTimeout(timer);
+                resolve(results);
+            }, function () {
+                clearTimeout(timer);
+                reject(results);
+            });
+        }, function () {
+            logger.message('debug', 'exec() got a rejection promise');
+        });
+    };
+
+    // We execute the functions through exec() by supplying them as a params object
+    // params object: {name: 'function name', func: functionName, description: 'some optional text'};
+
+    let beforeStartEx = function() {
+        return exec({name: 'beforeStart', func: beforeStart});
+    };
+
+    let tests = {
+        0: () => {return exec({name: 'fillStyle', func: fillStyle, description: 'promise test'})}
+        , 1: () => {return exec({name: 'fillText', func: fillText, description: 'promise test'})}
+        , 2: () => {return exec({name: 'textBaseline', func: textBaseline, description: 'promise test'})}
+        , 3: () => {return exec({name: 'shadowColor', func: shadowColor, description: 'promise test'})}
+        , 4: () => {return exec({name: 'shadowBlur', func: shadowBlur, description: 'promise test'})}
+        , 5: () => {return exec({name: 'shadowOffsetX', func: shadowOffsetX, description: 'promise test'})}
+        , 6: () => {return exec({name: 'shadowOffsetY', func: shadowOffsetY, description: 'promise test'})}
+        , 7: () => {return exec({name: 'measureText', func: measureText, description: 'promise test'})}
+        , 8: () => {return exec({name: 'globalAlpha', func: globalAlpha, description: 'promise test'})}
+        , 9: () => {return exec({name: 'fillRect', func: fillRect, description: 'promise test'})}
+        , 10: () => {return exec({name: 'clear', func: clear, description: 'promise test'})}
+        , 11: () => {return exec({name: 'translate', func: translate, description: 'promise test'})}
+    };
+
+    if(manualTest === true) {
+        logger.message('Manual mode.');
+        manual.runTestsManually(tests, beforeStartEx);
+    }
+
+    logger.message('done.');
+}).catch(function importFailed(err) {
+    console.error("Import failed for test-textcanvas.js: " + err);
+});


### PR DESCRIPTION
Implemented properties:

fillStyle
width
height
label
colorMode

Implemented methods:
measureText
fillText
translate

Stubs for:

textBaseline
globalAlpha
fillRect

NOTE: this PR contains a code from another PR from Hugh with  
shadows/hightlight for pxText as it depends on it: https://github.com/pxscene/pxCore/pull/2002

Demo app: https://github.com/sergiygladkyy/sparkTextCanvas

```
git clone
npm i
npm run release-spark
cd dist/spark
npm i
Then run dist/spark/lightning-demo-spark.js
```

See also the following files in the src dir:
```
test-textcanvas.js - CI test
textcanvas-spark-min.js - minimal textCanvas invocation
textcanvas-spark.js - non-lightning textCanvas demo
```

Related repos with the updates for node modules:
wpe-lightning-sdk: https://github.com/sergiygladkyy/Lightning-SDK
wpe-lightning: https://github.com/sergiygladkyy/Lightning
wpe-lightning-spark: https://github.com/sergiygladkyy/Lightning-Spark