### PR TITLE
turn off permissive

### DIFF
--- a/examples/pxScene2d/src/CMakeLists.txt
+++ b/examples/pxScene2d/src/CMakeLists.txt
@@ -152,8 +152,8 @@ if (APPLE)
 
 elseif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
 
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -fpermissive -g -Wall -Wno-attributes -Wall -Wextra")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fpermissive -g -Wall -Wno-attributes -Wall -Wextra")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -g -Wall -Wno-attributes -Wall -Wextra")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -g -Wall -Wno-attributes -Wall -Wextra")
     execute_process(COMMAND "hostname" OUTPUT_VARIABLE HOSTNAME)
     string(STRIP ${HOSTNAME} HOSTNAME)
     set(PXSCENE_DEFINITIONS ${PXSCENE_DEFINITIONS} -DRT_PLATFORM_LINUX)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,7 +202,7 @@ else ()
 endif (APPLE)
 
 if (NOT PXCORE_DFB)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif (NOT PXCORE_DFB)
 
 if (PXCORE_COMPILE_WARNINGS_AS_ERRORS)


### PR DESCRIPTION
-fpermissive is not accepted by latest version of Coverity.  Removing it for linux.