### PR TITLE
pxTextCanvas: support for CutSx, CutSy, CutEx, CutEy, fontStyle in Lightning++

### DIFF
--- a/examples/pxScene2d/src/pxFont.cpp
+++ b/examples/pxScene2d/src/pxFont.cpp
@@ -83,12 +83,13 @@ uint32_t npot(uint32_t i)
 pxFontAtlas gFontAtlas;
 #endif
 
-pxFont::pxFont(rtString fontUrl, uint32_t id, rtString proxyUrl):pxResource(),mFace(NULL),mPixelSize(0), mFontData(0), mFontDataSize(0),
+pxFont::pxFont(rtString fontUrl, uint32_t id, rtString proxyUrl, rtString fontStyle):pxResource(),mFace(NULL),mPixelSize(0), mFontData(0), mFontDataSize(0),
              mFontMutex(), mFontDataMutex(), mFontDownloadedData(NULL), mFontDownloadedDataSize(0), mFontDataUrl()
 {  
   mFontId = id; 
   mUrl = fontUrl;
   mProxy = proxyUrl;
+  mFontStyle = fontStyle;
 }
 
 pxFont::~pxFont() 
@@ -259,9 +260,57 @@ rtError pxFont::init(const char* n)
 
   do {
     if (FT_New_Face(ft, n, 0, &mFace) == 0)
+    // Simulating italic or oblique font style if required and possible
     {
       loadFontStatus = RT_OK;
+      rtString loadedStyleName(mFace->style_name);
+      if (!loadedStyleName.isEmpty())loadedStyleName.toLowerAscii();
+      if (!mFontStyle.isEmpty()) mFontStyle.toLowerAscii();
+
+      if (loadedStyleName.beginsWith("italic"))
+      {
+        mFontStyle = loadedStyleName;
+        break;
+      }
+
+      if (mFontStyle.isEmpty() || !(mFontStyle.beginsWith("italic") || mFontStyle.beginsWith("oblique")))
+      {
+        break;
+      }
+
+      double k = 0;
+
+      if (mFontStyle.beginsWith("italic"))
+      {
+        k = 0.24;
+      }
+      else
+      {
+        int32_t pos = mFontStyle.find(0, " ");
+
+        if (pos < 0) break;
+
+        double angle = atof(mFontStyle.substring(pos, mFontStyle.length() - 3).cString());
+
+        k = tan(angle * M_PI / 180);
+      }
+
+      if (k <= 0) break;
+
+      FT_Matrix matrix;
+
+      matrix.xx = 0x10000L;
+      matrix.xy = k * 0x10000L;
+      matrix.yx = 0;
+      matrix.yy = 0x10000L;
+
+      FT_Set_Transform(mFace, &matrix, 0);
+
       break;
+    }
+
+    if (mFontStyle.isEmpty()) {
+      mFontStyle = mFace->style_name;
     }
 
     if (rtIsPathAbsolute(n))
@@ -743,6 +792,20 @@ rtError pxFont::measureText(uint32_t pixelSize, rtString stringToMeasure, rtObje
   return RT_OK; 
 }
 
+rtError pxFont::needsStyleCoercion(rtString fontStyle, bool& o)
+{
+    fontStyle.toLowerAscii();
+    bool aRegular = mFontStyle.beginsWith("regular") || mFontStyle.beginsWith("normal");
+    bool bOblique = fontStyle.beginsWith("italic") || fontStyle.beginsWith("oblique");
+
+    o = (aRegular && bOblique);
+    return RT_OK;
+}
+
+bool pxFont::coercible(const char *fontStyle) {
+    rtString style = fontStyle;
+    return (style.beginsWith("italic") || style.beginsWith("oblique"));
+}
 
 /**********************************************************************/
 /**                    pxFontManager                                  */
@@ -766,7 +829,7 @@ void pxFontManager::initFT()
   }
   
 }
-rtRef<pxFont> pxFontManager::getFont(const char* url, const char* proxy, const rtCORSRef& cors, rtObjectRef archive)
+rtRef<pxFont> pxFontManager::getFont(const char* url, const char* proxy, const rtCORSRef& cors, rtObjectRef archive, const char* fontStyle)
 {
   initFT();
 
@@ -777,6 +840,10 @@ rtRef<pxFont> pxFontManager::getFont(const char* url, const char* proxy, const r
     url = defaultFont;
 
   rtString key = url;
+  if (pxFont::coercible(fontStyle)) {
+     key = key + "+" + fontStyle;
+  }
+
   if (false == ((key.beginsWith("http:")) || (key.beginsWith("https:"))))
   {
     pxArchive* arc = (pxArchive*)archive.getPtr();
@@ -813,8 +880,8 @@ rtRef<pxFont> pxFontManager::getFont(const char* url, const char* proxy, const r
   }
   else 
   {
-    rtLogDebug("Create pxFont in map for %s\n",url);
-    pFont = new pxFont(url, fontId, proxy);
+    rtLogDebug("Create pxFont in map for %s\n",key.cString());
+    pFont = new pxFont(url, fontId, proxy, fontStyle);
     pFont->setCORS(cors);
     mFontMap.insert(make_pair(fontId, pFont));
     pFont->loadResource(archive);
@@ -856,8 +923,10 @@ rtDefineProperty(pxTextMetrics, baseline);
 
 // pxFont
 rtDefineObject(pxFont, pxResource);
+rtDefineProperty(pxFont, fontStyle);
 rtDefineMethod(pxFont, getFontMetrics);
 rtDefineMethod(pxFont, measureText);
+rtDefineMethod(pxFont, needsStyleCoercion);
 
 rtDefineObject(pxTextSimpleMeasurements, rtObject);
 rtDefineProperty(pxTextSimpleMeasurements, w);

--- a/examples/pxScene2d/src/pxFont.h
+++ b/examples/pxScene2d/src/pxFont.h
@@ -28,6 +28,7 @@
 // TODO it would be nice to push this back into implemention
 #include <ft2build.h>
 #include FT_FREETYPE_H
+#include FT_GLYPH_H
 
 #include "pxScene2d.h"
 #include <map>
@@ -252,17 +253,25 @@ protected:
 class pxFont: public pxResource {
 
 public:
-	pxFont(rtString fontUrl, uint32_t id, rtString proxyUrl);
+	pxFont(rtString fontUrl, uint32_t id, rtString proxyUrl, rtString fontStyle);
 	virtual ~pxFont() ;
 
 	rtDeclareObject(pxFont, pxResource);
   rtReadOnlyProperty(ready, ready, rtObjectRef);
+  rtReadOnlyProperty(fontStyle, fontStyle, rtString);
+
+  rtString fontStyle()             const { return mFontStyle; }
+  rtError fontStyle(rtString& v)   const { v = mFontStyle; return RT_OK; }
+  rtError setFontStyle(rtString v)       { mFontStyle = v; return RT_OK; }
   
   rtMethod1ArgAndReturn("getFontMetrics", getFontMetrics, uint32_t, rtObjectRef);
   rtError getFontMetrics(uint32_t pixelSize, rtObjectRef& o);
   rtMethod2ArgAndReturn("measureText", measureText, uint32_t, rtString, rtObjectRef);
-  rtError measureText(uint32_t, rtString, rtObjectRef& o);   
-    
+  rtError measureText(uint32_t, rtString, rtObjectRef& o);
+  rtMethod1ArgAndReturn("needsStyleCoercion", needsStyleCoercion, rtString, bool);
+  rtError needsStyleCoercion(rtString fontStyle, bool& o);
+  static bool coercible(const char* fontStyle);
+
   // FT Face related functions
   void setPixelSize(uint32_t s);  
   const GlyphCacheEntry* getGlyph(uint32_t codePoint);
@@ -316,7 +325,7 @@ private:
 	char* mFontDownloadedData;
 	size_t mFontDownloadedDataSize;
 	rtString mFontDataUrl;
-
+  rtString mFontStyle;
 };
 
 // Weak Map
@@ -327,7 +336,7 @@ class pxFontManager
   
   public: 
     
-    static rtRef<pxFont> getFont(const char* url, const char* proxy = NULL, const rtCORSRef& cors = NULL, rtObjectRef archive = NULL);
+    static rtRef<pxFont> getFont(const char* url, const char* proxy = NULL, const rtCORSRef& cors = NULL, rtObjectRef archive = NULL, const char* fontStyle = NULL);
     static void removeFont(uint32_t fontId);
     static void clearAllFonts();
     

--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -937,13 +937,16 @@ rtError pxScene2d::createFontResource(rtObjectRef p, rtObjectRef& o)
 {
   rtString url = p.get<rtString>("url");
   rtString proxy = p.get<rtString>("proxy");
+  rtString fontStyle = p.get<rtString>("fontStyle");
+
+  if (!fontStyle.isEmpty()) fontStyle.toLowerAscii();
 
 #ifdef ENABLE_PERMISSIONS_CHECK
   if (RT_OK != mPermissions->allows(url, rtPermissions::DEFAULT))
     return RT_ERROR_NOT_ALLOWED;
 #endif
 
-  o = pxFontManager::getFont(url, proxy, mCORS, mArchive);
+  o = pxFontManager::getFont(url, proxy, mCORS, mArchive, fontStyle);
   return RT_OK;
 }
 

--- a/examples/pxScene2d/src/pxText.cpp
+++ b/examples/pxScene2d/src/pxText.cpp
@@ -34,7 +34,7 @@ pxText::pxText(pxScene2d* scene):pxObject(scene), mFontLoaded(false), mFontFaile
   float c[4] = {1, 1, 1, 1};
   memcpy(mTextColor, c, sizeof(mTextColor));
   // Default to use default font
-  mFont = pxFontManager::getFont(defaultFont, NULL, NULL, scene->getArchive());
+  mFont = pxFontManager::getFont(defaultFont, NULL, NULL, scene->getArchive(), NULL);
   mPixelSize = defaultPixelSize;
 }
 
@@ -192,7 +192,7 @@ rtError pxText::setFontUrl(const char* s)
   createNewPromise();
 
   removeResourceListener();
-  mFont = pxFontManager::getFont(s, NULL, NULL, mScene->getArchive());
+  mFont = pxFontManager::getFont(s, NULL, NULL, mScene->getArchive(), NULL);
   mListenerAdded = true;
   if (getFontResource() != NULL)
   {

--- a/examples/pxScene2d/src/pxTextCanvas.cpp
+++ b/examples/pxScene2d/src/pxTextCanvas.cpp
@@ -21,6 +21,7 @@
 #include "pxTextCanvas.h"
 #include "pxContext.h"
 
+#define CLAMP(_x, _min, _max) ( (_x) < (_min) ? (_min) : (_x) > (_max) ? (_max) : (_x) )
 extern pxContext context;
 
 //pxTextLine
@@ -71,8 +72,10 @@ pxTextCanvas::pxTextCanvas(pxScene2d* s): pxText(s)
     mFontFailed = false;
     mTextBaseline = pxConstantsTextBaseline::ALPHABETIC;
     mColorMode = "RGBA"; //TODO: make a const class from it?
-	mLabel = "";
-	setClip(true);
+    mLabel = "";
+    setW(pxTextCanvas::DEFAULT_WIDTH);
+    setH(pxTextCanvas::DEFAULT_HEIGHT);
+    setClip(true);
 }
 /** This signals that the font file loaded successfully; now we need to
  * send the ready promise once we have the text, too
@@ -223,7 +226,7 @@ rtError pxTextCanvas::globalAlpha(float& a) const
 rtError pxTextCanvas::setGlobalAlpha(const float a)
 {
     rtLogDebug("pxTextCanvas::setGlobalAlpha called with param: %f", a);
-    mGlobalAlpha = pxCalc::clamp(a, 0.0f, 1.0f);
+    mGlobalAlpha = CLAMP(a, 0.0f, 1.0f);
     setA(mGlobalAlpha); // temporary solution. Actually alpha must be applied to the rendered objects, not the canvas itself.
     return RT_OK;
 }
@@ -416,8 +419,8 @@ void pxTextCanvas::renderText(bool render)
 void pxTextCanvas::renderTextLine(const pxTextLine& textLine)
 {
     const char* cStr = textLine.text.cString();
-    float xPos = (float)(textLine.x + mTranslateX);
-    float yPos = (float)(textLine.y + mTranslateY);
+    float xPos = (float)(textLine.x + textLine.translateX);
+    float yPos = (float)(textLine.y + textLine.translateY);
     // TODO ignoring sx and sy now.
     float sx = 1.0;
     float sy = 1.0;
@@ -446,7 +449,7 @@ void pxTextCanvas::renderTextLine(const pxTextLine& textLine)
         switch (alignH)
         {
             case pxConstantsAlignHorizontal::CENTER:
-                xPos -= textW / 2;
+                xPos -= float(textW / 2);
                 break;
 
             case pxConstantsAlignHorizontal::RIGHT:
@@ -457,23 +460,23 @@ void pxTextCanvas::renderTextLine(const pxTextLine& textLine)
         switch (baseline)
         {
             case pxConstantsTextBaseline::ALPHABETIC:
-                yPos -= size;
+                yPos -= float(size);
                 break;
 
             case pxConstantsTextBaseline::TOP:
-                yPos -= 0.2 * textH;
+                yPos -= float(0.2 * textH);
                 break;
 
             case pxConstantsTextBaseline::HANGING:
-                yPos -= 0.325 * textH;
+                yPos -= float(0.325 * textH);
                 break;
 
             case pxConstantsTextBaseline::MIDDLE:
-                yPos -= 0.575 * textH;
+                yPos -= float(0.575 * textH);
                 break;
 
             case pxConstantsTextBaseline::IDEOGRAPHIC:
-                yPos -= 1.1 * size;
+                yPos -= float(1.1 * size);
                 break;
 
             case pxConstantsTextBaseline::BOTTOM:
@@ -571,6 +574,8 @@ rtError pxTextCanvas::fillText(rtString text, int32_t x, int32_t y)
     textLine.setStyle(mFont, mPixelSize, color.toInt32());
     textLine.alignHorizontal = mAlignHorizontal;
     textLine.textBaseline = mTextBaseline;
+    textLine.translateX = mTranslateX;
+    textLine.translateY = mTranslateY;
     mTextLines.push_back(textLine);
     setNeedsRecalc(true);
     return RT_OK;

--- a/examples/pxScene2d/src/pxTextCanvas.h
+++ b/examples/pxScene2d/src/pxTextCanvas.h
@@ -22,23 +22,14 @@
 #include "pxScene2d.h"
 #include "pxText.h"
 
-namespace pxCalc {
-    template<typename T>
-    inline T min(T x, T y) { return (x < y ? x : y); }
-
-    template<typename T>
-    inline T max(T x, T y) { return (x > y ? x : y); }
-
-    template<typename T>
-    inline T clamp(T x, T lo, T hi) { return max(min(x, hi), lo); }
-}
-
 struct pxTextLine
 {
     pxTextLine(): styleSet(false)
             , x(0), y(0)
             , pixelSize(10)
             , color(0xFFFFFFFF)
+            , translateX(0)
+            , translateY(0)
     {};
     pxTextLine(const char* text, uint32_t x, uint32_t y);
     void setStyle(const rtObjectRef& f, uint32_t ps, uint32_t c);
@@ -53,6 +44,8 @@ struct pxTextLine
     uint32_t color;
     uint32_t alignHorizontal;
     uint32_t textBaseline;
+    int32_t translateX;
+    int32_t translateY;
 };
 
 /**********************************************************************
@@ -91,6 +84,9 @@ protected:
  **********************************************************************/
 class pxTextCanvas : public pxText {
 public:
+    static constexpr float DEFAULT_WIDTH  = 300;
+    static constexpr float DEFAULT_HEIGHT = 150;
+
     rtDeclareObject(pxTextCanvas, pxText);
 
     pxTextCanvas(pxScene2d *s);
@@ -136,8 +132,8 @@ public:
     rtError setColorMode(const rtString &c);
 
     /* override virtuals from pxObject that must affect the readiness of pxTextCanvas due to text measurements */
-    rtError setW(float v) override      { setNeedsRecalc(true); return pxObject::setW(v);}
-    rtError setH(float v) override      { setNeedsRecalc(true); return pxObject::setH(v);}
+    rtError setW(float v) override      { if (v < 0) { clear(); return pxObject::setW(DEFAULT_WIDTH);  } setNeedsRecalc(true); return pxObject::setW(v); }
+    rtError setH(float v) override      { if (v < 0) { clear(); return pxObject::setH(DEFAULT_HEIGHT); } setNeedsRecalc(true); return pxObject::setH(v); }
     rtError setClip(bool v) override    { setNeedsRecalc(true); return pxObject::setClip(v);}
     rtError setSX(float v) override     { setNeedsRecalc(true); return pxObject::setSX(v);}
     rtError setSY(float v) override     { setNeedsRecalc(true); return pxObject::setSY(v);}


### PR DESCRIPTION
Reverts pxscene/pxCore#2057