### PR TITLE
Moved playback init/deinit from constructor/destructor to play/stop

### DIFF
--- a/examples/pxScene2d/src/pxVideo.h
+++ b/examples/pxScene2d/src/pxVideo.h
@@ -122,6 +122,8 @@ public:
   void updateYUVFrame(uint8_t *yuvBuffer, int size, int pixel_w, int pixel_h);
 
 private:
+  void initPlayback();
+  void deInitPlayback();
 
   void InitPlayerLoop();
   void TermPlayerLoop();


### PR DESCRIPTION
To properly close the playback when Spark app is restarted the following code should be added
  scene.on("onClose", function(e) {
    videoObject.stop();
  });
