### PR TITLE
pxSleepMS: handling timeval struct properly

### DIFF
--- a/src/essos/pxTimerNative.cpp
+++ b/src/essos/pxTimerNative.cpp
@@ -72,7 +72,7 @@ double  pxMicroseconds()
 void pxSleepMS(uint32_t msToSleep)
 {
     timeval tv;
-    tv.tv_sec = 0;
-    tv.tv_usec = 1000 * msToSleep;
+    tv.tv_sec = msToSleep / 1000;
+    tv.tv_usec = 1000 * (msToSleep % 1000);
     select(0, NULL, NULL, NULL, &tv);
 }

--- a/src/gles/pxTimerNative.cpp
+++ b/src/gles/pxTimerNative.cpp
@@ -72,7 +72,7 @@ double  pxMicroseconds()
 void pxSleepMS(uint32_t msToSleep)
 {
     timeval tv;
-    tv.tv_sec = 0;
-    tv.tv_usec = 1000 * msToSleep;
+    tv.tv_sec = msToSleep / 1000;
+    tv.tv_usec = 1000 * (msToSleep % 1000);
     select(0, NULL, NULL, NULL, &tv);
 }

--- a/src/glut/pxTimerNative.cpp
+++ b/src/glut/pxTimerNative.cpp
@@ -79,8 +79,8 @@ void pxSleepMS(uint32_t msToSleep)
 {
 #ifdef USE_SELECT_FOR_SLEEP
   timeval tv;
-  tv.tv_sec = 0;
-  tv.tv_usec = 1000 * msToSleep;
+  tv.tv_sec = msToSleep / 1000;
+  tv.tv_usec = 1000 * (msToSleep % 1000);
   select(0, NULL, NULL, NULL, &tv);
 #else
   useconds_t s = (useconds_t)msToSleep*1000;

--- a/src/wayland/pxTimerNative.cpp
+++ b/src/wayland/pxTimerNative.cpp
@@ -72,7 +72,7 @@ double  pxMicroseconds()
 void pxSleepMS(uint32_t msToSleep)
 {
     timeval tv;
-    tv.tv_sec = 0;
-    tv.tv_usec = 1000 * msToSleep;
+    tv.tv_sec = msToSleep / 1000;
+    tv.tv_usec = 1000 * (msToSleep % 1000);
     select(0, NULL, NULL, NULL, &tv);
 }

--- a/src/wayland_egl/pxTimerNative.cpp
+++ b/src/wayland_egl/pxTimerNative.cpp
@@ -72,7 +72,7 @@ double  pxMicroseconds()
 void pxSleepMS(uint32_t msToSleep)
 {
     timeval tv;
-    tv.tv_sec = 0;
-    tv.tv_usec = 1000 * msToSleep;
+    tv.tv_sec = msToSleep / 1000;
+    tv.tv_usec = 1000 * (msToSleep % 1000);
     select(0, NULL, NULL, NULL, &tv);
 }


### PR DESCRIPTION
milliseconds to be splitted in tv_sec and tv_usec(microsecond)
in struct timeval as 64bit linux kernel throws EINVAL error code
if value greater than 1sec (1000000L in terms of microsec) is
given to tv_usec whereas it works for any value in 32bit linux kernel.

glibc invokes kern_select()/select() kernel function in 32bit linux
kernel but it invokes do_pselect() kernel function for 64bit.
Ref. https://github.com/lattera/glibc/blob/master/sysdeps/unix/sysv/linux/select.c#L37
kern_select()/select() function splitted the value properly to
tv_sec and tv_usec fields in kernel level whereas do_pselect()
passes the value as same as copied from user space.
Ref. https://github.com/raspberrypi/linux/blob/rpi-4.19.y/fs/select.c#L673

To make uniformity on both 32bit and 64bit kernels, milliseconds value
is splitted properly to tv_sec and tv_usec in timeval struct.

Signed-off-by: Moorthy Baskar <moorthy.baskaravenkatraman-sambamoorthy@linaro.org>