### PR TITLE
pxVideo player loop and player thread created in constructor

### DIFF
--- a/examples/pxScene2d/src/pxVideo.h
+++ b/examples/pxScene2d/src/pxVideo.h
@@ -131,8 +131,8 @@ private:
   void initPlayback();
   void deInitPlayback();
 
-  void InitPlayerLoop();
-  void TermPlayerLoop();
+  void initPlayerLoop();
+  void termPlayerLoop();
   static void* AAMPGstPlayer_StreamThread(void* arg);
   static void newAampFrame(void* context, void* data);
   void registerAampEventsListeners();


### PR DESCRIPTION
This change fixes pxVideo playback being terminated by glib after EndOfStream event is handled.