### PR TITLE
openssl issue on libnode 6.9

### DIFF
--- a/examples/pxScene2d/external/libnode-v6.9.0/node.gyp
+++ b/examples/pxScene2d/external/libnode-v6.9.0/node.gyp
@@ -133,6 +133,8 @@
         'src',
         'tools/msvs/genfiles',
         'deps/uv/src/ares',
+        'deps/openssl/include',
+        'deps/openssl/openssl/include',
         '<(SHARED_INTERMEDIATE_DIR)', # for node_natives.h
       ],
 


### PR DESCRIPTION
openssl include directories from 'deps' are
missed in node.gyp. This causes to pick openssl
headers from sysroot (which is openssl 1.1 headers)

Signed-off-by: Moorthy Baskar <moorthy.baskaravenkatraman-sambamoorthy@linaro.org>